### PR TITLE
Issue70

### DIFF
--- a/.env
+++ b/.env
@@ -8,4 +8,4 @@ MYSQL_PASSWORD=roadmap_password
 MYSQL_ROOT_PASSWORD=secret_password
 DEVISE_PEPPER="change_me"
 TRANSLATION_IO_API_KEY='change_me'
-WICKED_PDF_PATH="change_me"
+WICKED_PDF_PATH="/usr/local/bin/wkhtmltopdf"

--- a/app/controllers/plan_exports_controller.rb
+++ b/app/controllers/plan_exports_controller.rb
@@ -35,6 +35,8 @@ class PlanExportsController < ApplicationController
     @formatting     = export_params[:formatting] || @plan.settings(:export).formatting
     
     if params.key?(:phase_id)
+      # order phases by phase number asc
+      @hash[:phases] = @hash[:phases].sort_by{|phase| phase[:number]}
       if (params[:phase_id] == "All")
         @hash[:all_phases] = true
       else

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -374,7 +374,7 @@ class PlansController < ApplicationController
     authorize @plan
     @phase_options = @plan.phases.order(:number).pluck(:title, :id)
     if @phase_options.length > 1
-      @phase_options.push(["All phases", "All"])
+      @phase_options.insert(0,["All phases", "All"])
     end
     @export_settings = @plan.settings(:export)
     render "download"

--- a/app/javascript/src/plans/download.js
+++ b/app/javascript/src/plans/download.js
@@ -22,13 +22,21 @@ $(() => {
       $('#download-settings').show();
     }
 
-    // muti-phase download not allowed for csv. trigger in both onload and change event
+    /*
+     Issue 70: first option 'All Phases' should be selected in default for pdf, html, docx and text.
+     Skip json for now since no phase has been set up yet for this format
+     For csv:
+     - Muti-phase download not allowed for csv
+     - the second phase will be automatically selected and 'All Phases' option will be hidden
+     */
     if (frmt === 'csv') {
       $('#phase_id').find('option[value="All"').hide();
-      $('#phase_id option:first').attr('selected', 'selected');
-      $('#phase_id').val($('#phase_id option:first').val()); // for different browsers
-    } else {
+      $('#phase_id option:eq(1)').attr('selected', 'selected');
+      $('#phase_id').val($('#phase_id option:eq(1)').val());
+    } else if (frmt === 'pdf' || frmt === 'html' || frmt === 'docx' || frmt === 'text') {
       $('#phase_id').find('option[value="All"').show();
+      $('#phase_id').val($('#phase_id option:first').val());
+      $('#phase_id option:first').attr('selected', 'selected');
     }
   }).trigger('change');
 });

--- a/app/views/shared/export/_plan.erb
+++ b/app/views/shared/export/_plan.erb
@@ -19,7 +19,7 @@
     <% end %>
 
     <% @hash[:phases].each do |phase| %>
-      <% if @hash[:all_phases] || phase[:title] == @selected_phase.title %>
+      <% if @hash[:all_phases] || (@selected_phase.present? && phase[:title] == @selected_phase.title) %>
         <%# Page break before each phase %>
         <div style="page-break-before:always;"></div>
         <h1><%= download_plan_page_title(@plan, phase, @hash) %></h1>

--- a/app/views/shared/export/_plan_txt.erb
+++ b/app/views/shared/export/_plan_txt.erb
@@ -22,7 +22,7 @@
 <% end %>
 
 <% @hash[:phases].each do |phase| %>
-<% if @hash[:all_phases] || phase[:title] == @selected_phase.title %>
+<% if @hash[:all_phases] || (@selected_phase.present? && phase[:title] == @selected_phase.title) %>
 <%= (@hash[:phases].many? ? "#{phase[:title]}" : "") %>
   <% phase[:sections].each do |section| %>
     <% if display_section?(@hash[:customization], section, @show_custom_sections) && num_section_questions(@plan, section, phase) > 0 %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,6 +2,10 @@ defaults: &defaults
   adapter: mysql2
   encoding: utf8mb4
   pool: 16
+  database: <%= ENV["MYSQL_DATABASE"] %>
+  username: <%= ENV["MYSQL_USER"] %>
+  password: <%= ENV["MYSQL_PASSWORD"] %>
+  host: <%= ENV["DATABASE_URL"] || '127.0.0.1' %>
 
 development:
   <<: *defaults

--- a/spec/features/plans/exports_spec.rb
+++ b/spec/features/plans/exports_spec.rb
@@ -79,15 +79,35 @@ RSpec.describe "PlansExports", type: :feature, js: true do
     expect(page).not_to have_text(new_plan.title)
   end
 
+  # Seperate code to test all-phase-download for html since it requires operation in new window
   scenario "User downloads their plan as HTML" do
     within("#plan_#{plan.id}") do
       click_button("Actions")
       click_link "Download"
     end
     select("html")
-    new_window = window_opened_by { click_button "Download Plan" }
-    within_window new_window do
-      expect(page.source).to have_text(plan.title)
+    if plan.phases.present?
+      new_window = window_opened_by do
+        _select_option("phase_id", "All")
+        click_button "Download Plan"
+      end
+      within_window new_window do
+        expect(page.source).to have_text(plan.title)
+        plan.phases.each do |phase|
+          expect(page.source).to have_text(phase.title)
+        end
+      end
+      new_window = window_opened_by do
+        _select_option("phase_id", plan.phases[1].id)
+        click_button "Download Plan"
+      end
+      within_window new_window do
+        expect(page.source).to have_text(plan.title)
+        expect(page.source).to have_text(plan.phases[1].title)
+        expect(page.source).not_to have_text(plan.phases[2].title) if plan.phases.length > 2
+      end
+    else
+      _regular_download("html")
     end
   end
 
@@ -97,8 +117,12 @@ RSpec.describe "PlansExports", type: :feature, js: true do
       click_link "Download"
     end
     select("pdf")
-    click_button "Download Plan"
-    expect(page.source).to have_text(plan.title)
+    if plan.phases.present?
+      _all_phase_download
+      _single_phase_download
+    else
+      _regular_download("pdf")
+    end
   end
 
   scenario "User downloads their plan as CSV" do
@@ -107,8 +131,7 @@ RSpec.describe "PlansExports", type: :feature, js: true do
       click_link "Download"
     end
     select("csv")
-    click_button "Download Plan"
-    expect(page.source).to have_text(plan.title)
+    _regular_download("csv")
   end
 
   scenario "User downloads their plan as text" do
@@ -117,8 +140,12 @@ RSpec.describe "PlansExports", type: :feature, js: true do
       click_link "Download"
     end
     select("text")
-    click_button "Download Plan"
-    expect(page.source).to have_text(plan.title)
+    if plan.phases.present?
+      _all_phase_download
+      _single_phase_download
+    else
+      _regular_download("text")
+    end
   end
 
   scenario "User downloads their plan as docx" do
@@ -127,7 +154,51 @@ RSpec.describe "PlansExports", type: :feature, js: true do
       click_link "Download"
     end
     select("docx")
+    if plan.phases.present?
+      _all_phase_download
+      _single_phase_download
+    else
+      _regular_download("docx")
+    end
+  end
+
+  # ===========================
+  # = Helper methods =
+  # ===========================
+
+  def _regular_download(format)
+    if format == "html"
+      new_window = window_opened_by do
+        click_button "Download Plan"
+      end
+      within_window new_window do
+        expect(page.source).to have_text(plan.title)
+      end
+    else
+      click_button "Download Plan"
+      expect(page.source).to have_text(plan.title)
+    end
+  end
+
+  def _all_phase_download
+    _select_option("phase_id", "All")
     click_button "Download Plan"
     expect(page.source).to have_text(plan.title)
+    plan.phases.each do |phase| # All phase titles should be included in output
+      expect(page.source).to have_text(phase.title)
+    end
   end
+
+  def _single_phase_download
+    _select_option("phase_id", plan.phases[1].id)
+    click_button "Download Plan"
+    expect(page.source).to have_text(plan.title)
+    expect(page.source).to have_text(plan.phases[1].title)
+    expect(page.source).not_to have_text(plan.phases[2].title) if plan.phases.length > 2
+  end
+
+  def _select_option(select_id, option_value)
+    find(:id, select_id).find("option[value='#{option_value}']").select_option
+  end
+
 end


### PR DESCRIPTION
Fixes #70  .

Nothing change for JSON & CSV as we discussed in ticket

Changes proposed in this PR:
1. html, pdf, text and docx have a extra 'All Phases' option in the phase download dropbox
2. once user select this option and click 'download', corresponding file (i.e. html, pdf and docx) will have multiple phase in one file
3. phases will be ordered as phase1 -> phase2 -> phase3 -> phase4 regardless update_time for user to navigate

*Please let me know if I should ignore database.yml and .env file, I had to set up as you see to make things work*
