### PR TITLE
change id to identifier in plan detail and add it to cover page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
   ### Fixed
    - Usage statistics page now shows correct data [#164](https://github.com/portagenetwork/roadmap/issues/164)
+   - Change plan identifier field and add it to export [#158](https://github.com/portagenetwork/roadmap/issues/158)
 
 ## [3.0.4+portage-3.0.5] - 2022-03-07
   

--- a/app/controllers/plan_exports_controller.rb
+++ b/app/controllers/plan_exports_controller.rb
@@ -46,7 +46,6 @@ class PlanExportsController < ApplicationController
       @selected_phase = @plan.phases.order("phases.updated_at DESC")
                              .detect { |p| p.visibility_allowed?(@plan) }
     end
- 
     respond_to do |format|
       format.html { show_html }
       format.csv  { show_csv }

--- a/app/views/plans/_project_details.html.erb
+++ b/app/views/plans/_project_details.html.erb
@@ -90,7 +90,7 @@ ethics_report_tooltip = _("Link to a protocol from a meeting with an ethics comm
 <% else %>
   <div class="form-group">
     <div class="col-md-12">
-      <%= form.label :id, _("ID"), class: "control-label" %>
+      <%= form.label :identifier, _("Identifier"), class: "control-label" %>
     </div>
     <div class="col-md-8">
       <em class="sr-only"><%= id_tooltip %></em>

--- a/app/views/shared/export/_plan_coversheet.erb
+++ b/app/views/shared/export/_plan_coversheet.erb
@@ -31,6 +31,10 @@
     <p><b><%= _("ID: ") %></b><%= @plan.id %></p> <br>
   <% end %>
 
+  <% if @plan.identifier.present? %>
+    <p><b><%= _("Identifier: ") %></b><%= @plan.identifier %></p> <br>
+  <% end %>
+
   <% if @plan.start_date.present? %>
     <p><b><%= _("Start date: ") %></b><%=  l(@plan.start_date.to_date, formats: :short) %></p> <br>
   <% end %>

--- a/app/views/shared/export/_plan_coversheet.erb
+++ b/app/views/shared/export/_plan_coversheet.erb
@@ -27,10 +27,6 @@
     <div style="margin-left: 15px;"><%= sanitize(@plan.description) %></div><br>
   <% end %>
 
-  <% if @plan.id.present? %>
-    <p><b><%= _("ID: ") %></b><%= @plan.id %></p> <br>
-  <% end %>
-
   <% if @plan.identifier.present? %>
     <p><b><%= _("Identifier: ") %></b><%= @plan.identifier %></p> <br>
   <% end %>


### PR DESCRIPTION
Fixes #issue158 .

Changes proposed in this PR:
- Change `ID` in plan detail to `identifier` since it is the field for identifier in the backend (identifier could be anything user-defined)
- Add the `Identifier` field to the cover page for plan export
