### PR TITLE
fix the org selector in the invitation link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Fixed
+
+- Fixed invalid org selection when new user accept invitation [#177](https://github.com/portagenetwork/roadmap/issues/177)
 ## [3.0.4+portage-3.0.7] - 2022-04-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [3.0.4+portage-3.0.8] - 2022-04-08
+
 ### Fixed
 
 - Fixed invalid org selection when new user accept invitation [#177](https://github.com/portagenetwork/roadmap/issues/177)

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -34,7 +34,7 @@
                      form: f,
                      default_org: nil,
                      required: true,
-                     orgs: @orgs
+                     orgs: @all_orgs
                    } %>
       </div>
       <%= f.button(_('Create account'), class: "btn btn-default", type: "submit") %>


### PR DESCRIPTION
Fixes #177  .

The invitation edit form, which needs to pass the `org` variable to `_local_only`, accepts `@orgs` instead of `@all_orgs`, but `@all_orgs` is the variable name that is used in `org_selectable` to generate all orgs. Other selectors haven't seen this issue so far because they all prepare their org list seperately.