### PR TITLE
Issue202: Add contributor to the DMP downloaded files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### Added
+
+- Added contributors to plan's cover page (if there is any) [#202](https://github.com/portagenetwork/roadmap/issues/202)
+- Added plan title to csv exported file
+
 ## [3.0.4+portage-3.0.12] - 2022-05-12
 
 ### Added

--- a/app/controllers/plan_exports_controller.rb
+++ b/app/controllers/plan_exports_controller.rb
@@ -33,11 +33,11 @@ class PlanExportsController < ApplicationController
 
     @hash           = @plan.as_pdf(current_user, @show_coversheet)
     @formatting     = export_params[:formatting] || @plan.settings(:export).formatting
-    
-    if params.key?(:phase_id) && params[:phase_id].length > 0
+
+    if params.key?(:phase_id) && params[:phase_id].length.positive?
       # order phases by phase number asc
-      @hash[:phases] = @hash[:phases].sort_by{|phase| phase[:number]}
-      if (params[:phase_id] == "All")
+      @hash[:phases] = @hash[:phases].sort_by { |phase| phase[:number] }
+      if params[:phase_id] == "All"
         @hash[:all_phases] = true
       else
         @selected_phase = @plan.phases.find(params[:phase_id])
@@ -47,15 +47,13 @@ class PlanExportsController < ApplicationController
                              .detect { |p| p.visibility_allowed?(@plan) }
     end
 
-    # Added contributors to coverage of plans. 
+    # Added contributors to coverage of plans.
     # Users will see both roles and contributor names if the role is filled
-    @hash.merge(
-      {:data_curation: Contributor.where(:plan_id => @plan.id).data_curation},
-      {:investigation: = Contributor.where(:plan_id => @plan.id).investigation},
-      {:pa: Contributor.where(:plan_id => @plan.id).project_administration},
-      {:other: Contributor.where(:plan_id => @plan.id).other}
-    )
-    
+    @hash[:data_curation] = Contributor.where(plan_id: @plan.id).data_curation
+    @hash[:investigation] = Contributor.where(plan_id: @plan.id).investigation
+    @hash[:pa] =  Contributor.where(plan_id: @plan.id).project_administration
+    @hash[:other] = Contributor.where(plan_id: @plan.id).other
+
     respond_to do |format|
       format.html { show_html }
       format.csv  { show_csv }
@@ -103,8 +101,8 @@ class PlanExportsController < ApplicationController
                date: l(@plan.updated_at.to_date, format: :readable)
              },
              font_size: 8,
-             spacing:   (Integer(@formatting[:margin][:bottom]) / 2) - 4,
-             right:     _("[page] of [topage]"),
+             spacing: (Integer(@formatting[:margin][:bottom]) / 2) - 4,
+             right: _("[page] of [topage]"),
              encoding: "UTF-8"
            }
   end

--- a/app/controllers/plan_exports_controller.rb
+++ b/app/controllers/plan_exports_controller.rb
@@ -46,6 +46,13 @@ class PlanExportsController < ApplicationController
       @selected_phase = @plan.phases.order("phases.updated_at DESC")
                              .detect { |p| p.visibility_allowed?(@plan) }
     end
+
+    #ISSUE205: add contributor to coverpage (note role number is required)
+    @hash[:data_curation] = Contributor.where(:plan_id => @plan.id, :roles=>1)
+    @hash[:investigation] = Contributor.where(:plan_id => @plan.id, :roles=>2)
+    @hash[:pa] = Contributor.where(:plan_id => @plan.id, :roles=>3)
+    @hash[:other] = Contributor.where(:plan_id => @plan.id, :roles=>4)
+
     respond_to do |format|
       format.html { show_html }
       format.csv  { show_csv }

--- a/app/controllers/plan_exports_controller.rb
+++ b/app/controllers/plan_exports_controller.rb
@@ -47,12 +47,15 @@ class PlanExportsController < ApplicationController
                              .detect { |p| p.visibility_allowed?(@plan) }
     end
 
-    #ISSUE205: add contributor to cover page
-    @hash[:data_curation] = Contributor.where(:plan_id => @plan.id).data_curation
-    @hash[:investigation] = Contributor.where(:plan_id => @plan.id).investigation
-    @hash[:pa] = Contributor.where(:plan_id => @plan.id).project_administration
-    @hash[:other] = Contributor.where(:plan_id => @plan.id).other
-
+    # Added contributors to coverage of plans. 
+    # Users will see both roles and contributor names if the role is filled
+    @hash.merge(
+      {:data_curation: Contributor.where(:plan_id => @plan.id).data_curation},
+      {:investigation: = Contributor.where(:plan_id => @plan.id).investigation},
+      {:pa: Contributor.where(:plan_id => @plan.id).project_administration},
+      {:other: Contributor.where(:plan_id => @plan.id).other}
+    )
+    
     respond_to do |format|
       format.html { show_html }
       format.csv  { show_csv }

--- a/app/controllers/plan_exports_controller.rb
+++ b/app/controllers/plan_exports_controller.rb
@@ -47,11 +47,11 @@ class PlanExportsController < ApplicationController
                              .detect { |p| p.visibility_allowed?(@plan) }
     end
 
-    #ISSUE205: add contributor to coverpage (note role number is required)
-    @hash[:data_curation] = Contributor.where(:plan_id => @plan.id, :roles=>1)
-    @hash[:investigation] = Contributor.where(:plan_id => @plan.id, :roles=>2)
-    @hash[:pa] = Contributor.where(:plan_id => @plan.id, :roles=>3)
-    @hash[:other] = Contributor.where(:plan_id => @plan.id, :roles=>4)
+    #ISSUE205: add contributor to cover page
+    @hash[:data_curation] = Contributor.where(:plan_id => @plan.id).data_curation
+    @hash[:investigation] = Contributor.where(:plan_id => @plan.id).investigation
+    @hash[:pa] = Contributor.where(:plan_id => @plan.id).project_administration
+    @hash[:other] = Contributor.where(:plan_id => @plan.id).other
 
     respond_to do |format|
       format.html { show_html }

--- a/app/models/concerns/exportable_plan.rb
+++ b/app/models/concerns/exportable_plan.rb
@@ -132,6 +132,7 @@ module ExportablePlan
 
   # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def prepare_coversheet_for_csv(csv, _headings, hash)
+    csv << [_("Title: "), _("%{title}") % { title: title }]
     csv << [if hash[:attribution].many?
               _("Creators: ")
             else

--- a/app/models/concerns/exportable_plan.rb
+++ b/app/models/concerns/exportable_plan.rb
@@ -101,15 +101,13 @@ module ExportablePlan
       attribution << role.user.name(false)
     end
     hash[:attribution] = attribution
-    
-    # Added contributors to coverage of plans. 
+
+    # Added contributors to coverage of plans.
     # Users will see both roles and contributor names if the role is filled
-    @hash.merge(
-      {:data_curation: Contributor.where(:plan_id => @plan.id).data_curation},
-      {:investigation: = Contributor.where(:plan_id => @plan.id).investigation},
-      {:pa: Contributor.where(:plan_id => @plan.id).project_administration},
-      {:other: Contributor.where(:plan_id => @plan.id).other}
-    )
+    hash[:data_curation] = Contributor.where(plan_id: id).data_curation
+    hash[:investigation] = Contributor.where(plan_id: id).investigation
+    hash[:pa] =  Contributor.where(plan_id: id).project_administration
+    hash[:other] = Contributor.where(plan_id: id).other
 
     # Org name of plan owner's org
     hash[:affiliation] = owner.present? ? owner.org.name : ""
@@ -142,17 +140,19 @@ module ExportablePlan
             else
               _("Creator:")
             end, _("%{authors}") % { authors: hash[:attribution].join(", ") }]
-    if hash[:investigation].present? 
-      csv <<  [_("Principal Investigator: "), _("%{investigation}") % { investigation: hash[:investigation].map(&:name).join(', ') }] 
+    if hash[:investigation].present?
+      csv << [_("Principal Investigator: "),
+              _("%{investigation}") % { investigation: hash[:investigation].map(&:name).join(", ") }]
     end
-    if hash[:data_curation].present? 
-      csv << [_("Date Manager: "), _("%{data_curation}") % { data_curation: hash[:data_curation].map(&:name).join(', ') }] 
+    if hash[:data_curation].present?
+      csv << [_("Date Manager: "),
+              _("%{data_curation}") % { data_curation: hash[:data_curation].map(&:name).join(", ") }]
     end
-    if hash[:pa].present? 
-      csv << [_("Project Administrator: "), _("%{pa}") % { pa: hash[:pa].map(&:name).join(', ') }] 
+    if hash[:pa].present?
+      csv << [_("Project Administrator: "), _("%{pa}") % { pa: hash[:pa].map(&:name).join(", ") }]
     end
-    if hash[:other].present? 
-      csv << [_("Contributor: "), _("%{other}") % { other: hash[:other].map(&:name).join(', ') }] 
+    if hash[:other].present?
+      csv << [_("Contributor: "), _("%{other}") % { other: hash[:other].map(&:name).join(", ") }]
     end
     csv << [_("Affiliation: "), _("%{affiliation}") % { affiliation: hash[:affiliation] }]
     csv << if hash[:funder].present?

--- a/app/models/concerns/exportable_plan.rb
+++ b/app/models/concerns/exportable_plan.rb
@@ -101,11 +101,15 @@ module ExportablePlan
       attribution << role.user.name(false)
     end
     hash[:attribution] = attribution
-    #ISSUE205: add contributor to cover page
-    hash[:data_curation] = Contributor.where(:plan_id => id).data_curation
-    hash[:investigation] = Contributor.where(:plan_id => id).investigation
-    hash[:pa] = Contributor.where(:plan_id => id).project_administration
-    hash[:other] = Contributor.where(:plan_id => id).other
+    
+    # Added contributors to coverage of plans. 
+    # Users will see both roles and contributor names if the role is filled
+    @hash.merge(
+      {:data_curation: Contributor.where(:plan_id => @plan.id).data_curation},
+      {:investigation: = Contributor.where(:plan_id => @plan.id).investigation},
+      {:pa: Contributor.where(:plan_id => @plan.id).project_administration},
+      {:other: Contributor.where(:plan_id => @plan.id).other}
+    )
 
     # Org name of plan owner's org
     hash[:affiliation] = owner.present? ? owner.org.name : ""

--- a/app/models/concerns/exportable_plan.rb
+++ b/app/models/concerns/exportable_plan.rb
@@ -101,6 +101,11 @@ module ExportablePlan
       attribution << role.user.name(false)
     end
     hash[:attribution] = attribution
+    #ISSUE205: add contributor to cover page
+    hash[:data_curation] = Contributor.where(:plan_id => id).data_curation
+    hash[:investigation] = Contributor.where(:plan_id => id).investigation
+    hash[:pa] = Contributor.where(:plan_id => id).project_administration
+    hash[:other] = Contributor.where(:plan_id => id).other
 
     # Org name of plan owner's org
     hash[:affiliation] = owner.present? ? owner.org.name : ""
@@ -132,7 +137,19 @@ module ExportablePlan
             else
               _("Creator:")
             end, _("%{authors}") % { authors: hash[:attribution].join(", ") }]
-    csv << ["Affiliation: ", _("%{affiliation}") % { affiliation: hash[:affiliation] }]
+    if hash[:investigation].present? 
+      csv <<  [_("Principal Investigator: "), _("%{investigation}") % { investigation: hash[:investigation].map(&:name).join(', ') }] 
+    end
+    if hash[:data_curation].present? 
+      csv << [_("Date Manager: "), _("%{data_curation}") % { data_curation: hash[:data_curation].map(&:name).join(', ') }] 
+    end
+    if hash[:pa].present? 
+      csv << [_("Project Administrator: "), _("%{pa}") % { pa: hash[:pa].map(&:name).join(', ') }] 
+    end
+    if hash[:other].present? 
+      csv << [_("Contributor: "), _("%{other}") % { other: hash[:other].map(&:name).join(', ') }] 
+    end
+    csv << [_("Affiliation: "), _("%{affiliation}") % { affiliation: hash[:affiliation] }]
     csv << if hash[:funder].present?
              [_("Template: "), _("%{funder}") % { funder: hash[:funder] }]
            else

--- a/app/views/shared/export/_plan_coversheet.erb
+++ b/app/views/shared/export/_plan_coversheet.erb
@@ -7,6 +7,29 @@
   <%# Allow raw html (==) for plan_attribution as it has <b> tags %>
   <p><%== plan_attribution(@hash[:attribution]) %></p><br>
 
+  <%# ISSUE205: print out contributors if exit %>
+  <%# Roles are ranked by PI -> DM -> PA -> Other (if any) %>
+  <% if @hash[:investigation].present? %>
+     <p><b><%= _("Principal Investigator: ") %></b>
+      <%= @hash[:investigation].map(&:name).join(', ') %>
+     </p><br>
+  <% end %>
+  <% if @hash[:data_curation].present? %>
+     <p><b><%= _("Data Manager: ") %></b>
+     <%= @hash[:data_curation].map(&:name).join(', ') %>
+     </p><br>
+  <% end %>
+  <% if @hash[:pa].present? %>
+     <p><b><%= _("Project Administrator: ") %></b>
+     <%= @hash[:pa].map(&:name).join(', ') %>
+     </p><br>
+  <% end %>
+  <% if @hash[:other].present? %>
+    <p><b><%= _("Contributor: ") %></b>
+    <%= @hash[:other].map(&:name).join(', ') %>
+    </p><br>
+  <% end %>
+
   <p><b><%= _("Affiliation: ") %></b><%= @hash[:affiliation] %></p><br>
 
   <% if @hash[:funder].present? %>

--- a/app/views/shared/export/_plan_coversheet.erb
+++ b/app/views/shared/export/_plan_coversheet.erb
@@ -7,7 +7,8 @@
   <%# Allow raw html (==) for plan_attribution as it has <b> tags %>
   <p><%== plan_attribution(@hash[:attribution]) %></p><br>
 
-  <%# ISSUE205: print out contributors if exit %>
+  <%# Added contributors to coverage of plans. 
+    # Users will see both roles and contributor names if the role is filled %>
   <%# Roles are ranked by PI -> DM -> PA -> Other (if any) %>
   <% if @hash[:investigation].present? %>
   <p><b><%= _("Principal Investigator: ") %></b><%= @hash[:investigation].map(&:name).join(', ') %></p><br>

--- a/app/views/shared/export/_plan_coversheet.erb
+++ b/app/views/shared/export/_plan_coversheet.erb
@@ -10,24 +10,16 @@
   <%# ISSUE205: print out contributors if exit %>
   <%# Roles are ranked by PI -> DM -> PA -> Other (if any) %>
   <% if @hash[:investigation].present? %>
-     <p><b><%= _("Principal Investigator: ") %></b>
-      <%= @hash[:investigation].map(&:name).join(', ') %>
-     </p><br>
+  <p><b><%= _("Principal Investigator: ") %></b><%= @hash[:investigation].map(&:name).join(', ') %></p><br>
   <% end %>
   <% if @hash[:data_curation].present? %>
-     <p><b><%= _("Data Manager: ") %></b>
-     <%= @hash[:data_curation].map(&:name).join(', ') %>
-     </p><br>
+  <p><b><%= _("Data Manager: ") %></b><%= @hash[:data_curation].map(&:name).join(', ') %></p><br>
   <% end %>
   <% if @hash[:pa].present? %>
-     <p><b><%= _("Project Administrator: ") %></b>
-     <%= @hash[:pa].map(&:name).join(', ') %>
-     </p><br>
+  <p><b><%= _("Project Administrator: ") %></b><%= @hash[:pa].map(&:name).join(', ') %></p><br>
   <% end %>
   <% if @hash[:other].present? %>
-    <p><b><%= _("Contributor: ") %></b>
-    <%= @hash[:other].map(&:name).join(', ') %>
-    </p><br>
+  <p><b><%= _("Contributor: ") %></b><%= @hash[:other].map(&:name).join(', ') %></p><br>
   <% end %>
 
   <p><b><%= _("Affiliation: ") %></b><%= @hash[:affiliation] %></p><br>

--- a/app/views/shared/export/_plan_txt.erb
+++ b/app/views/shared/export/_plan_txt.erb
@@ -1,7 +1,22 @@
 <%= "#{@plan.title}" %>
 <%= "----------------------------------------------------------\n" %>
 <% if @show_coversheet %>
+
 <%= @hash[:attribution].many? ? _("Creators: ") : _('Creator:') %> <%= @hash[:attribution].join(', ') %>
+<%# ISSUE205: print out contributors if exit %>
+<%# Roles are ranked by PI -> DM -> PA -> Other (if any) %>
+  <% if @hash[:investigation].present? %>
+<%= _("Principal Investigator: ") + @hash[:investigation].map(&:name).join(', ') %>
+  <% end %>
+  <% if @hash[:data_curation].present? %>
+<%= _("Data Manager: ") +  @hash[:data_curation].map(&:name).join(', ') %>
+  <% end %>
+  <% if @hash[:pa].present? %>
+<%= _("Project Administrator: ") + @hash[:pa].map(&:name).join(', ') %>
+  <% end %>
+  <% if @hash[:other].present? %>
+<%= _("Contributor: ") + @hash[:other].map(&:name).join(', ') %>
+  <% end %>
 <%= _("Affiliation: ") + @hash[:affiliation] %>
   <% if @hash[:funder].present? %>
 <%= _("Template: ") + @hash[:funder] %>

--- a/app/views/shared/export/_plan_txt.erb
+++ b/app/views/shared/export/_plan_txt.erb
@@ -3,7 +3,8 @@
 <% if @show_coversheet %>
 
 <%= @hash[:attribution].many? ? _("Creators: ") : _('Creator:') %> <%= @hash[:attribution].join(', ') %>
-<%# ISSUE205: print out contributors if exit %>
+<%# Added contributors to coverage of plans. 
+    # Users will see both roles and contributor names if the role is filled %>
 <%# Roles are ranked by PI -> DM -> PA -> Other (if any) %>
   <% if @hash[:investigation].present? %>
 <%= _("Principal Investigator: ") + @hash[:investigation].map(&:name).join(', ') %>


### PR DESCRIPTION
Fixes #202  .

Changes proposed in this PR:
- Added contributors to coverage of plans. Users will see both roles and contributor names if the role is filled ('Other' is replaced by 'Contributor' as the role name). A role can have many contributors and the same contributor can have more than one role:

![Screen Shot 2022-05-19 at 17 25 54](https://user-images.githubusercontent.com/92752107/169407300-22fde5bf-6715-4d65-9080-d4325a974306.png)

- For JSON export, it will show as part of JSON object with the whole contributor information:

`"contributor":[{"name":"Wendy Shan Both","mbox":"test@test.com","role":["http://credit.niso.org/contributor-roles//data-curation","http://credit.niso.org/contributor-roles//investigation"],"affiliation":{"name":"University of British Columbia","abbreviation":"UBC","region":null}},{"name":"Wendy Shan","mbox":"test@test.com","role":["http://credit.niso.org/contributor-roles//investigation","other"],"affiliation":{"name":"University of British Columbia","abbreviation":"UBC","region":null}}]`

- Added plan title to csv file
