### PR TITLE
3.1.0 formal release minor fixes for Github Action and Rubocop

### DIFF
--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -16,6 +16,9 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 1
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16
 
     - name: 'Install MySQL Packages'
       run: |

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -32,6 +32,9 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 1
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16
 
     - name: 'Install Postgresql Packages'
       run: |

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -106,7 +106,9 @@ Lint/UnmodifiedReduceAccumulator: # new in 1.1
   Enabled: true
 Lint/Debugger: # new in 1.45.0
   Description: 'Check for debugger calls.'
-  Enabled: false
+  Enabled: true
+  Exclude:
+    - 'lib/tasks/**/*'
 
 # -----------
 # - METRICS -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,9 @@
 
 - Fixed some potential PDF downloading problems
 
+- Updated Github Actions to use specified node version [#319](https://github.com/portagenetwork/roadmap/issues/319)
+
+
 ## [3.0.4+portage-3.0.16] - 2022-12-14
 
 ### Changed

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -20,7 +20,6 @@ class ApplicationRecord < ActiveRecord::Base
 
     # Generates the appropriate where clause for a JSON field based on the DB type
     def safe_json_where_clause(column:, hash_key:)
-      p mysql_db?
       return "(#{column}->>'#{hash_key}' LIKE ?)" if postgres_db?
 
       # return "#{column} LIKE ?)" if maria_db?


### PR DESCRIPTION
Fixes #319, #316

Changes proposed in this PR:
- Update `.rubocop.yml` based on the main codebase suggestion to only exclude lib files from the debugger
- Added `setup-node` action to Postgres Test and MySQL Test so that the node version is 16 only
