### PR TITLE
3.1.1 - fix the missing logo by adding extra sql output and input to rake task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.1.0+portage-3.1.1] - 2023-02-22
+
+### Fixed
+
+- Add extra `orgs` table retrieve data via SQL process to fix the logo_uid and logo_name
+
+- Confirm for sandbox 3.1.0 release
+
 ## [3.1.0+portage-3.1.0] - 2023-02-22
 
 ### Added

--- a/lib/tasks/mysql_to_postgres.rake
+++ b/lib/tasks/mysql_to_postgres.rake
@@ -977,5 +977,16 @@ namespace :mysql_to_postgres do
     file_name = 'db/seeds/staging/temp/schema_migrations.rb'
     FileUtils.rm_f(file_name)
     File.write(file_name, JSON.dump(schema_migrations))
+     # orgs
+     orgs = []
+     puts 'loading orgs'
+     sql = 'SELECT logo_uid, logo_name, id FROM orgs'
+     ActiveRecord::Base.connection.exec_query(sql).map do |org|
+       org = org.with_indifferent_access
+       orgs << org
+     end
+     file_name = 'db/seeds/staging/temp/orgs.rb'
+     FileUtils.rm_f(file_name)
+     File.write(file_name, JSON.dump(orgs))
   end
 end

--- a/lib/tasks/mysql_to_postgres.rake
+++ b/lib/tasks/mysql_to_postgres.rake
@@ -977,16 +977,16 @@ namespace :mysql_to_postgres do
     file_name = 'db/seeds/staging/temp/schema_migrations.rb'
     FileUtils.rm_f(file_name)
     File.write(file_name, JSON.dump(schema_migrations))
-     # orgs
-     orgs = []
-     puts 'loading orgs'
-     sql = 'SELECT logo_uid, logo_name, id FROM orgs'
-     ActiveRecord::Base.connection.exec_query(sql).map do |org|
-       org = org.with_indifferent_access
-       orgs << org
-     end
-     file_name = 'db/seeds/staging/temp/orgs.rb'
-     FileUtils.rm_f(file_name)
-     File.write(file_name, JSON.dump(orgs))
+    # orgs
+    orgs = []
+    puts 'loading orgs'
+    sql = 'SELECT logo_uid, logo_name, id FROM orgs'
+    ActiveRecord::Base.connection.exec_query(sql).map do |org|
+      org = org.with_indifferent_access
+      orgs << org
+    end
+    file_name = 'db/seeds/staging/temp/orgs.rb'
+    FileUtils.rm_f(file_name)
+    File.write(file_name, JSON.dump(orgs))
   end
 end

--- a/lib/tasks/rewrite_postgres.rake
+++ b/lib/tasks/rewrite_postgres.rake
@@ -33,10 +33,21 @@ namespace :rewrite_postgres do
     Rake::Task['rewrite_postgres:projects_files'].execute
     Rake::Task['rewrite_postgres:settings_sessions_stats_stylesheets'].execute
     Rake::Task['rewrite_postgres:trackers_notes_prefs_dmptemplates_migrations'].execute
+    Rake::Task['rewrite_postgres:orgs'].execute
     Rake::Task['rewrite_postgres:reset_all_pk'].execute
+
     puts 'Now, please test user login THEN DELETE /db/seeds/staging/temp folder for security.'
   end
 
+  task orgs: :environment do
+    # orgs
+    orgs = JSON.parse(File.read('db/seeds/staging/temp/orgs.rb'))
+    orgs.each do |x|
+      query = ActiveRecord::Base.sanitize_sql(["Update orgs set logo_uid = ?,logo_name = ? where id = ?",
+        x['logo_uid'],x['logo_name'],x['id']])
+      ActiveRecord::Base.connection.exec_query(query)
+    end
+  end
   task users: :environment do
     users = JSON.parse(File.read('db/seeds/staging/temp/users.rb'))
     users.each do |x|

--- a/lib/tasks/rewrite_postgres.rake
+++ b/lib/tasks/rewrite_postgres.rake
@@ -43,8 +43,8 @@ namespace :rewrite_postgres do
     # orgs
     orgs = JSON.parse(File.read('db/seeds/staging/temp/orgs.rb'))
     orgs.each do |x|
-      query = ActiveRecord::Base.sanitize_sql(["Update orgs set logo_uid = ?,logo_name = ? where id = ?",
-        x['logo_uid'],x['logo_name'],x['id']])
+      query = ActiveRecord::Base.sanitize_sql(['Update orgs set logo_uid = ?,logo_name = ? where id = ?',
+                                               x['logo_uid'], x['logo_name'], x['id']])
       ActiveRecord::Base.connection.exec_query(query)
     end
   end


### PR DESCRIPTION
Fix the missing org after migration data to PostgreSQL.

The reason is that `Org.create` in seed_0.rb will *eliminate* logo_uid and logo_name, while banner_uid and banner_name will be there (and the rest of the data will be there), without any warning message. Thus the data is missing after using PostgreSQL db.

After adding the output of the org table specifically for logo_uid and logo_name, then updating Orgs for these two fields using raw SQL, this problem should be resolved.