### PR TITLE
Fix the 500 error when user try to download public templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.1.0+portage-3.1.1] - 2023-02-24
+
+### Fixed 
+
+- Fixed 500 error when admins try to downloading  [#328](https://github.com/portagenetwork/roadmap/issues/328)
+
 ## [3.1.0+portage-3.1.0] - 2023-02-22
 
 ### Added

--- a/app/controllers/plan_exports_controller.rb
+++ b/app/controllers/plan_exports_controller.rb
@@ -128,8 +128,8 @@ class PlanExportsController < ApplicationController
   end
 
   def publicly_authorized?
-    PublicPagePolicy.new(@plan, current_user).plan_organisationally_exportable? ||
-      PublicPagePolicy.new(@plan).plan_export?
+    PublicPagePolicy.new(current_user, @plan).plan_organisationally_exportable? ||
+      PublicPagePolicy.new(current_user, @plan).plan_export?
   end
 
   def privately_authorized?


### PR DESCRIPTION
Fixes #328  .

Changes proposed in this PR:
- Fixed the parameter name error after upgrading to 3.1.0
