### PR TITLE
Fix/create organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+ - Resolved problem when creating organisations [portagenetwork/roadmap#336](https://github.com/portagenetwork/roadmap/issues/336)
+
 ## [3.1.0+portage-3.1.2] - 2023-03-28
 
 ### Fixed 

--- a/app/views/orgs/_profile_form.html.erb
+++ b/app/views/orgs/_profile_form.html.erb
@@ -9,27 +9,19 @@
 <%= form_for(org, url: url, html: { multipart: true, method: method,
                                     id: "edit_org_profile_form" } ) do |f| %>
 
-  <% if org.new_record? %>
-    <%= render partial: "orgs/external_identifiers",
-               locals: {
-                 form: f,
-                 org: org,
-                 editable: current_user.can_super_admin?
-               } %>
-  <% else %>
-    <div class="row">
-      <div class="form-group col-xs-8">
-        <%= f.label :name, _('Organisation full name'), class: "control-label" %>
-        <%= f.text_field :name, id: "org_name", class: "form-control", "aria-required": true %>
-      </div>
+  <div class="row">
+    <div class="form-group col-xs-8">
+      <%= f.label :name, _('Organisation full name'), class: "control-label" %>
+      <%= f.text_field :name, id: "org_name", class: "form-control", "aria-required": true %>
     </div>
-    <div class="row">
-      <div class="form-group col-xs-8">
-        <%= f.label :abbreviation, _('Organisation abbreviated name'), class: "control-label" %>
-        <%= f.text_field :abbreviation, id: "org_abbreviation", class: "form-control" %>
-      </div>
+  </div>
+  <div class="row">
+    <div class="form-group col-xs-8">
+      <%= f.label :abbreviation, _('Organisation abbreviated name'), class: "control-label" %>
+      <%= f.text_field :abbreviation, id: "org_abbreviation", class: "form-control" %>
     </div>
-  <% end %>
+  </div>
+
 
   <% if current_user.can_super_admin? %>
     <div class="row">


### PR DESCRIPTION
## Context

The past behaviour tried to use external identifiers to auto-populate the organization name field. This is required by the main codebase as they are trying to have the correct names for all organizations. 

Querying an external resource for names takes a lot of time and the interface is less responsive. For now, we just want an open textfield to enter the organization name, the same as it was before.

The partial ``app/views/orgs/_profile_form.html.erb`` is used only in the super admin organization creation view, and in the admin edit view.

We can make this change without a lot of disruption to the rest of the code.

Fixes #336 

Changes proposed in this PR:
- Remove external identifiers from the organization creation view

