### PR TITLE
update Danger to V9.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,7 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.8.1)
+    addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     annotate (3.2.0)
       activerecord (>= 3.2, < 8.0)
@@ -123,18 +123,18 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    danger (9.2.0)
+    danger (9.3.1)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)
       cork (~> 0.1)
       faraday (>= 0.9.0, < 3.0)
       faraday-http-cache (~> 2.0)
-      git (~> 1.7)
+      git (~> 1.13)
       kramdown (~> 2.3)
       kramdown-parser-gfm (~> 1.0)
       no_proxy_fix
-      octokit (~> 5.0)
+      octokit (~> 6.0)
       terminal-table (>= 1, < 4)
     database_cleaner (2.0.1)
       database_cleaner-active_record (~> 2.0.0)
@@ -177,10 +177,10 @@ GEM
       railties (>= 5.0.0)
     faker (3.1.1)
       i18n (>= 1.8.11, < 2)
-    faraday (2.7.4)
+    faraday (2.7.10)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
-    faraday-http-cache (2.4.1)
+    faraday-http-cache (2.5.0)
       faraday (>= 0.8)
     faraday-net_http (3.0.2)
     ffi (1.15.5)
@@ -212,7 +212,7 @@ GEM
       locale (>= 2.0.5)
       prime
       text (>= 1.3.0)
-    git (1.13.2)
+    git (1.18.0)
       addressable (~> 2.8)
       rchardet (~> 1.8)
     globalid (1.1.0)
@@ -331,7 +331,7 @@ GEM
       rack (>= 1.2, < 4)
       snaky_hash (~> 2.0)
       version_gem (~> 1.1)
-    octokit (5.6.1)
+    octokit (6.1.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     omniauth (2.1.1)
@@ -365,7 +365,7 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    public_suffix (5.0.1)
+    public_suffix (5.0.3)
     puma (6.1.0)
       nio4r (~> 2.0)
     pundit (2.3.0)
@@ -671,4 +671,4 @@ RUBY VERSION
    ruby 2.7.6p219
 
 BUNDLED WITH
-   2.3.25
+   2.4.15


### PR DESCRIPTION
Updated Danger by running `bundle update danger`

Fixes https://github.com/portagenetwork/roadmap/issues/359

Changes proposed in this PR:
- Update Danger to V9.3.1
  - Perform additional updates to Gemfile.lock resulting from running `bundle update danger` (see changed file)
