### PR TITLE
Set Guidances/Comments to opened by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@
  
  - Bump puma from 6.1.0 to 6.3.0 [#396](https://github.com/portagenetwork/roadmap/pull/396)
 
+ - Set Guidances/Comments toggle to opened by default [#425](https://github.com/portagenetwork/roadmap/pull/425)
+
 ## [3.1.0+portage-3.1.3] - 2023-06-13
 
 ### Fixed

--- a/config/initializers/_dmproadmap.rb
+++ b/config/initializers/_dmproadmap.rb
@@ -128,7 +128,7 @@ module DMPRoadmap
 
     # Defines if Guidances/Comments in toggleable & if it's opened by default
     config.x.application.guidance_comments_toggleable = true
-    config.x.application.guidance_comments_opened_by_default = false
+    config.x.application.guidance_comments_opened_by_default = true
 
     # ------------------- #
     # SHIBBOLETH SETTINGS #


### PR DESCRIPTION
Default toggle position of guidances/comments is now open, rather than closed.
- Addresses Issue #424  