### PR TITLE
Fix WebDrivers For Chrome v116+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
  - Fixed broken "Help" link [#402](https://github.com/portagenetwork/roadmap/issues/412)
 
+ - Fixed compatibility issues between Webdrivers Gem and Google Chrome v116+ [#427](https://github.com/portagenetwork/roadmap/pull/427)
+
 ### Changed
 
  - Merged [v3.3.1](https://github.com/DMPRoadmap/roadmap/releases/tag/v3.3.1)

--- a/Gemfile
+++ b/Gemfile
@@ -276,7 +276,7 @@ group :development, :test, :sandbox do
   gem 'capybara'
   gem 'selenium-webdriver'
   # Easy installation and use of web drivers to run system tests with browsers
-  gem 'webdrivers', '~> 5.2'
+  gem 'webdrivers', '~> 5.3'
 
   # Automatically create snapshots when Cucumber steps fail with Capybara
   # and Rails (http://github.com/mattheworiordan/capybara-screenshot)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -549,10 +549,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
-    webdrivers (5.2.0)
+    webdrivers (5.3.1)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
+      selenium-webdriver (~> 4.0, < 4.11)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -661,7 +661,7 @@ DEPENDENCIES
   translation!
   turbolinks
   web-console
-  webdrivers (~> 5.2)
+  webdrivers (~> 5.3)
   webmock
   webpacker
   wicked_pdf

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -121,9 +121,10 @@ RSpec.configure do |config|
 
       # Allow Capybara to make localhost requests and also contact the
       # google api chromedriver store
+      # add googlechromelabs.github.io and edgedl.me.gvt1.com to work with Chrome v116+
       WebMock.disable_net_connect!(
         allow_localhost: true,
-        allow: %w[chromedriver.storage.googleapis.com]
+        allow: %w[chromedriver.storage.googleapis.com googlechromelabs.github.io edgedl.me.gvt1.com]
       )
     end
 

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -6,8 +6,6 @@ require_relative 'helpers/sessions_helper'
 require_relative 'helpers/tiny_mce_helper'
 require_relative 'helpers/autocomplete_helper'
 
-Webdrivers::Chromedriver.required_version = '114.0.5735.90' # TEMPORARY PATCH
-
 Capybara.default_driver = :rack_test
 
 # Cache for one hour


### PR DESCRIPTION
This PR addresses the rspec test failures due to the incompatibility between Webdrivers 5.2 and Chrome 116+.
- https://github.com/portagenetwork/roadmap/issues/426