### PR TITLE
Add release tag and tomorrow's date to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [3.3.1+portage-3.2.0] - 2023-09-28
+
 ### Fixed
 
  - Fixed margin issues with the rebranding [#446](https://github.com/portagenetwork/roadmap/issues/446)


### PR DESCRIPTION
This PR modifies CHANGELOG.md by adding the the release tag for the newest release and and adding tomorrow's date.