### PR TITLE
icons bug fixes #464 #trivial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed 
+  - Fixed icons issues with the rebranding [472](https://github.com/portagenetwork/roadmap/pull/472)  
+  
 ## [3.3.1+portage-3.2.0] - 2023-09-28
 
 ### Fixed

--- a/app/assets/stylesheets/grey-branding.scss
+++ b/app/assets/stylesheets/grey-branding.scss
@@ -117,6 +117,9 @@ a#language-menu, a#reference-menu, a#user-menu{
 
 button.close{
   position: relative;
-  margin-top: -7px;
   margin-right: -12px;
+} 
+
+.alert-info, .alert-warning, .alert-danger {
+  display: inline-block;
 }

--- a/app/assets/stylesheets/grey-branding.scss
+++ b/app/assets/stylesheets/grey-branding.scss
@@ -122,4 +122,5 @@ button.close{
 
 .alert-info, .alert-warning, .alert-danger {
   display: inline-block;
+  width: 100%;
 }

--- a/app/assets/stylesheets/grey-branding.scss
+++ b/app/assets/stylesheets/grey-branding.scss
@@ -109,3 +109,14 @@ thead th{
 a#language-menu, a#reference-menu, a#user-menu{
   margin-bottom: 3px !important;
 }
+
+/* Notification close icon visibility and position*/
+.close {
+  opacity: 1 !important;
+}
+
+button.close{
+  position: relative;
+  margin-top: -7px;
+  margin-right: -12px;
+}

--- a/app/assets/stylesheets/rebranding-animation.scss
+++ b/app/assets/stylesheets/rebranding-animation.scss
@@ -42,6 +42,10 @@ $color-alliance-light-grey: #999;
 
   &:hover {
     background-color: $color-alliance-yellow;
+    i.fas.fa-plus.pull-right,
+    i.fas.pull-right.fa-minus{
+      color: $color-alliance-digital-grey;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes # .

fixing bugs related to the icons of notification close buttons and write plans on-hover plus icons color contrast. 

[464](https://github.com/portagenetwork/roadmap/issues/464)
-
