### PR TITLE
Fix URL to API Documentation V1 and Remove Duplicate Code From application_controller.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## Unreleased
 
-### Fixed 
-  - Fixed icons issues with the rebranding [472](https://github.com/portagenetwork/roadmap/pull/472)  
+### Fixed
+
+ - Fixed icons issues with the rebranding [#472](https://github.com/portagenetwork/roadmap/pull/472)
+
+ - Fixed URL for API documentation v1 [#469](https://github.com/portagenetwork/roadmap/issues/469)
+
+ - Removed duplicate line of code from application_controller.rb [#471](https://github.com/portagenetwork/roadmap/issues/471)
   
 ## [3.3.1+portage-3.2.0] - 2023-09-28
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,8 +22,6 @@ class ApplicationController < ActionController::Base
   # When we are in production reroute Record Not Found errors to the branded 404 page
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
 
-  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
-
   private
 
   def current_org

--- a/config/initializers/_dmproadmap.rb
+++ b/config/initializers/_dmproadmap.rb
@@ -77,7 +77,7 @@ module DMPRoadmap
     # The link to the API documentation - used in emails about the API
     config.x.application.api_documentation_urls = {
       v0: 'https://github.com/DMPRoadmap/roadmap/wiki/API-V0-Documentation',
-      v1: 'https://github.com/DMPRoadmap/roadmap/wiki/API-Documentation-V1'
+      v1: 'https://github.com/DMPRoadmap/roadmap/wiki/API-v1-Documentation'
     }
     # The links that appear on the home page. Add any number of links
     config.x.application.welcome_links = [


### PR DESCRIPTION
Fixes # .

#469
- #469

#471
- #471
