### PR TITLE
Guidance bar collapse issue fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+ - Fixed guidance collapse issues [#467](https://github.com/portagenetwork/roadmap/issues/467)
+
  - Fixed icons issues with the rebranding [#472](https://github.com/portagenetwork/roadmap/pull/472)
 
  - Fixed URL for API documentation v1 [#469](https://github.com/portagenetwork/roadmap/issues/469)

--- a/app/assets/stylesheets/rebranding-animation.scss
+++ b/app/assets/stylesheets/rebranding-animation.scss
@@ -40,7 +40,8 @@ $color-alliance-light-grey: #999;
   cursor: pointer;
   transition: color 1s ease, background 1s ease; /* Combine transitions */
 
-  &:hover {
+  &:hover,
+  &:focus {
     background-color: $color-alliance-yellow;
     i.fas.fa-plus.pull-right,
     i.fas.pull-right.fa-minus{
@@ -49,7 +50,17 @@ $color-alliance-light-grey: #999;
   }
 }
 
-
+/* Guidance collapse bar in Templates section icon color issues fix on-hover OR on focus*/
+.panel-heading {
+  &:hover,
+  &:focus {
+    i.fas.pull-left.fa-minus,
+    i.fas.fa-plus.pull-left,
+    i.fas.fa-arrows-alt.pull-right{
+      color: $color-alliance-digital-grey !important;
+    }
+  }
+}
 // form > fieldset > button.btn.btn-default {
 //   animation: wiggle 2s linear infinite;
 // }

--- a/app/views/org_admin/questions/_show.html.erb
+++ b/app/views/org_admin/questions/_show.html.erb
@@ -127,13 +127,13 @@
                           <div class="heading-button"
                                role="button"
                                data-toggle="collapse"
-                               href="#collapseGuidance-<%= guidance.id%>-<%= question.id %>"
+                               href="#collapseGuidance-<%= guidance.id%>-<%= question.id %>-<%= theme.id%>"
                                aria-expanded="false"
-                               aria-controls="#collapseGuidance-<%= guidance.id%>-<%= question.id %>">
+                               aria-controls="#collapseGuidance-<%= guidance.id%>-<%= question.id %>-<%= theme.id%>">
 
                             <div class="panel-heading"
                                         role="tab"
-                                        id="#headingGuidance-<%= guidance.id%>-<%= question.id %>">
+                                        id="#headingGuidance-<%= guidance.id%>-<%= question.id %>-<%= theme.id%>">
                               <div class="panel-title">
                                   <i class="fas fa-plus pull-left" aria-hidden="true"></i>
                                 &nbsp;<%= theme.title %>
@@ -144,10 +144,10 @@
                               <div class="clearfix"></div>
                             </div>
                           </div>
-                          <div id="collapseGuidance-<%= guidance.id%>-<%= question.id %>"
+                          <div id="collapseGuidance-<%= guidance.id%>-<%= question.id %>-<%= theme.id%>"
                                class="panel-collapse collapse"
                                role="tabpanel"
-                               aria-labelledby="headingGuidance-<%= guidance.id%>-<%= question.id %>">
+                               aria-labelledby="headingGuidance-<%= guidance.id%>-<%= question.id %>-<%= theme.id%>">
                             <div class="panel-body allow-break-words">
                               <div class="display-readonly-textarea-content">
                                 <%= sanitize guidance.text %>


### PR DESCRIPTION
Fixes #467  .

Changes proposed in this PR: The issue with guidance bar collapse is fixed by adding the theme id to create an unique id for the each css div
-
