### PR TITLE
Fix Carriage Return Issue When Uploading DB Fields to Translation.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+ - Fixed handling of `\r` when syncing db fields to translation.io [#523](https://github.com/portagenetwork/roadmap/issues/523)
+
 ## [3.3.1+portage-3.2.1] - 2023-10-19
 
 ### Fixed

--- a/Gemfile
+++ b/Gemfile
@@ -203,7 +203,7 @@ gem 'zaru'
 # ==================== #
 
 gem 'translation', git: 'https://github.com/lagoan/translation_io_rails',
-                   branch: 'fix/broken_db_fake_method_calls'
+                   branch: 'fix/carriage-return-issue'
 
 # ========= #
 # UTILITIES #

--- a/Gemfile
+++ b/Gemfile
@@ -203,7 +203,7 @@ gem 'zaru'
 # ==================== #
 
 gem 'translation', git: 'https://github.com/lagoan/translation_io_rails',
-                   branch: 'fix/carriage-return-issue'
+                   branch: 'fix/broken_db_fake_method_calls'
 
 # ========= #
 # UTILITIES #

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/lagoan/translation_io_rails
-  revision: 1975821394c8c84da9458d7c6a588c862cdcb46e
-  branch: fix/broken_db_fake_method_calls
+  revision: 5fb2d5cea54a1b684ae1d3d6fb1226c0fcab8564
+  branch: fix/carriage-return-issue
   specs:
     translation (1.22)
       gettext (~> 3.2, >= 3.2.5)
@@ -206,10 +206,11 @@ GEM
     fuubar (2.5.1)
       rspec-core (~> 3.0)
       ruby-progressbar (~> 1.4)
-    gettext (3.4.3)
+    gettext (3.4.9)
       erubi
       locale (>= 2.0.5)
       prime
+      racc
       text (>= 1.3.0)
     git (1.18.0)
       addressable (~> 2.8)
@@ -514,7 +515,7 @@ GEM
       activesupport (>= 4.2.0)
     simpleidn (0.2.1)
       unf (~> 0.1.4)
-    singleton (0.1.1)
+    singleton (0.2.0)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/lagoan/translation_io_rails
-  revision: 5fb2d5cea54a1b684ae1d3d6fb1226c0fcab8564
-  branch: fix/carriage-return-issue
+  revision: 6fbb2cd619e7bf01b37b9b8916b0f345899f876b
+  branch: fix/broken_db_fake_method_calls
   specs:
     translation (1.22)
       gettext (~> 3.2, >= 3.2.5)


### PR DESCRIPTION
Fixes #523
- #523

Changes proposed in this PR:
- This PR addresses the `\r` issue that was occurring when syncing db values to translation.io
- The target branch for the translation gem has been changed. It is based off of the previous `fix/broken_db_fake_method_calls` and adds one additional change via the following commit: https://github.com/lagoan/translation_io_rails/commit/5fb2d5cea54a1b684ae1d3d6fb1226c0fcab8564
- The extra `Gemfile.lock` changes are the result of running `bundle install` after replacing the translation target branch in `Gemfile`