### PR TITLE
Migration/Fix For ActiveRecord::StaleObjectError When Answer.lock_version == NULL in DB

### DIFF
--- a/db/migrate/20231107222551_change_column_null_answer_lock_version.rb
+++ b/db/migrate/20231107222551_change_column_null_answer_lock_version.rb
@@ -1,0 +1,6 @@
+class ChangeColumnNullAnswerLockVersion < ActiveRecord::Migration[5.2]
+  def change
+    # Change all nil Answer.lock_version values to 0 and then disallow nil values
+    change_column_null(:answers, :lock_version, false, 0)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_15_104737) do
+ActiveRecord::Schema.define(version: 2023_11_07_222551) do
 
-  create_table "annotations", id: :integer, force: :cascade do |t|
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "annotations", id: :serial, force: :cascade do |t|
     t.integer "question_id"
     t.integer "org_id"
-    t.text "text", limit: 16777215
+    t.text "text"
     t.integer "type", default: 0, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -25,14 +28,14 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["versionable_id"], name: "index_annotations_on_versionable_id"
   end
 
-  create_table "answers", id: :integer, force: :cascade do |t|
-    t.text "text", limit: 16777215
+  create_table "answers", id: :serial, force: :cascade do |t|
+    t.text "text"
     t.integer "plan_id"
     t.integer "user_id"
     t.integer "question_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer "lock_version", default: 0
+    t.integer "lock_version", default: 0, null: false
     t.index ["plan_id"], name: "index_answers_on_plan_id"
     t.index ["question_id"], name: "index_answers_on_question_id"
     t.index ["user_id"], name: "fk_rails_584be190c2"
@@ -51,7 +54,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["question_option_id"], name: "fk_rails_01ba00b569"
   end
 
-  create_table "api_clients", id: :integer, force: :cascade do |t|
+  create_table "api_clients", id: :serial, force: :cascade do |t|
     t.string "name", null: false
     t.string "description"
     t.string "homepage"
@@ -66,7 +69,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["name"], name: "index_api_clients_on_name"
   end
 
-  create_table "comments", id: :integer, force: :cascade do |t|
+  create_table "comments", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "question_id"
     t.text "text"
@@ -77,7 +80,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.integer "archived_by"
   end
 
-  create_table "conditions", id: :integer, force: :cascade do |t|
+  create_table "conditions", id: :serial, force: :cascade do |t|
     t.integer "question_id"
     t.text "option_list"
     t.integer "action_type"
@@ -89,7 +92,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["question_id"], name: "index_conditions_on_question_id"
   end
 
-  create_table "contributors", id: :integer, force: :cascade do |t|
+  create_table "contributors", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "email"
     t.string "phone"
@@ -104,7 +107,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["roles"], name: "index_contributors_on_roles"
   end
 
-  create_table "departments", id: :integer, force: :cascade do |t|
+  create_table "departments", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "code"
     t.integer "org_id"
@@ -113,18 +116,18 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["org_id"], name: "index_departments_on_org_id"
   end
 
-  create_table "dmptemplate_translations", id: :integer, force: :cascade do |t|
+  create_table "dmptemplate_translations", id: :serial, force: :cascade do |t|
     t.integer "dmptemplate_id"
     t.string "locale", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "title"
-    t.text "description", limit: 16777215
+    t.text "description"
     t.index ["dmptemplate_id"], name: "index_dmptemplate_translations_on_dmptemplate_id"
     t.index ["locale"], name: "index_dmptemplate_translations_on_locale"
   end
 
-  create_table "dmptemplates", id: :integer, force: :cascade do |t|
+  create_table "dmptemplates", id: :serial, force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.boolean "published"
@@ -141,7 +144,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.integer "guidance_group_id"
   end
 
-  create_table "exported_plans", id: :integer, force: :cascade do |t|
+  create_table "exported_plans", id: :serial, force: :cascade do |t|
     t.integer "plan_id"
     t.integer "user_id"
     t.string "format"
@@ -150,7 +153,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.integer "phase_id"
   end
 
-  create_table "file_types", id: :integer, force: :cascade do |t|
+  create_table "file_types", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "icon_name"
     t.integer "icon_size"
@@ -159,7 +162,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "file_uploads", id: :integer, force: :cascade do |t|
+  create_table "file_uploads", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "title"
     t.text "description"
@@ -171,7 +174,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "friendly_id_slugs", id: :integer, force: :cascade do |t|
+  create_table "friendly_id_slugs", id: :serial, force: :cascade do |t|
     t.string "slug", null: false
     t.integer "sluggable_id", null: false
     t.string "sluggable_type", limit: 40
@@ -181,7 +184,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type"
   end
 
-  create_table "guidance_groups", id: :integer, force: :cascade do |t|
+  create_table "guidance_groups", id: :serial, force: :cascade do |t|
     t.string "name"
     t.integer "org_id"
     t.datetime "created_at", null: false
@@ -197,18 +200,18 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["guidance_id", "guidance_group_id"], name: "index_guidance_in_group_on_guidance_id_and_guidance_group_id"
   end
 
-  create_table "guidance_translations", id: :integer, force: :cascade do |t|
+  create_table "guidance_translations", id: :serial, force: :cascade do |t|
     t.integer "guidance_id"
     t.string "locale", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "text", limit: 16777215
+    t.text "text"
     t.index ["guidance_id"], name: "index_guidance_translations_on_guidance_id"
     t.index ["locale"], name: "index_guidance_translations_on_locale"
   end
 
-  create_table "guidances", id: :integer, force: :cascade do |t|
-    t.text "text", limit: 16777215
+  create_table "guidances", id: :serial, force: :cascade do |t|
+    t.text "text"
     t.integer "guidance_group_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -216,18 +219,18 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["guidance_group_id"], name: "index_guidances_on_guidance_group_id"
   end
 
-  create_table "identifier_schemes", id: :integer, force: :cascade do |t|
+  create_table "identifier_schemes", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "description"
     t.boolean "active"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text "logo_url", limit: 16777215
-    t.text "identifier_prefix", limit: 16777215
+    t.text "logo_url"
+    t.text "identifier_prefix"
     t.integer "context"
   end
 
-  create_table "identifiers", id: :integer, force: :cascade do |t|
+  create_table "identifiers", id: :serial, force: :cascade do |t|
     t.string "value", null: false
     t.text "attrs"
     t.integer "identifier_scheme_id"
@@ -240,7 +243,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["identifier_scheme_id", "value"], name: "index_identifiers_on_identifier_scheme_id_and_value"
   end
 
-  create_table "languages", id: :integer, force: :cascade do |t|
+  create_table "languages", id: :serial, force: :cascade do |t|
     t.string "abbreviation"
     t.string "description"
     t.string "name"
@@ -278,9 +281,9 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["research_output_id"], name: "metadata_research_outputs_on_ro"
   end
 
-  create_table "notes", id: :integer, force: :cascade do |t|
+  create_table "notes", id: :serial, force: :cascade do |t|
     t.integer "user_id"
-    t.text "text", limit: 16777215
+    t.text "text"
     t.boolean "archived", default: false, null: false
     t.integer "answer_id"
     t.integer "archived_by"
@@ -290,7 +293,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["user_id"], name: "fk_rails_7f2323ad43"
   end
 
-  create_table "notification_acknowledgements", id: :integer, force: :cascade do |t|
+  create_table "notification_acknowledgements", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "notification_id"
     t.datetime "created_at"
@@ -299,11 +302,11 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["user_id"], name: "index_notification_acknowledgements_on_user_id"
   end
 
-  create_table "notifications", id: :integer, force: :cascade do |t|
+  create_table "notifications", id: :serial, force: :cascade do |t|
     t.integer "notification_type"
     t.string "title"
     t.integer "level"
-    t.text "body", limit: 16777215
+    t.text "body"
     t.boolean "dismissable"
     t.date "starts_at"
     t.date "expires_at"
@@ -312,7 +315,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.boolean "enabled", default: true
   end
 
-  create_table "option_warnings", id: :integer, force: :cascade do |t|
+  create_table "option_warnings", id: :serial, force: :cascade do |t|
     t.integer "organisation_id"
     t.integer "option_id"
     t.text "text"
@@ -320,7 +323,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "options", id: :integer, force: :cascade do |t|
+  create_table "options", id: :serial, force: :cascade do |t|
     t.integer "question_id"
     t.string "text"
     t.integer "number"
@@ -329,7 +332,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "org_token_permissions", id: :integer, force: :cascade do |t|
+  create_table "org_token_permissions", id: :serial, force: :cascade do |t|
     t.integer "org_id"
     t.integer "token_permission_type_id"
     t.datetime "created_at"
@@ -338,14 +341,14 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["token_permission_type_id"], name: "fk_rails_2aa265f538"
   end
 
-  create_table "organisation_types", id: :integer, force: :cascade do |t|
+  create_table "organisation_types", id: :serial, force: :cascade do |t|
     t.string "name"
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "organisations", id: :integer, force: :cascade do |t|
+  create_table "organisations", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "abbreviation"
     t.string "target_url"
@@ -370,7 +373,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.string "contact_email"
   end
 
-  create_table "orgs", id: :integer, force: :cascade do |t|
+  create_table "orgs", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "abbreviation"
     t.string "target_url"
@@ -386,36 +389,36 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.integer "language_id"
     t.string "contact_email"
     t.integer "org_type", default: 0, null: false
-    t.text "links", limit: 16777215
+    t.text "links"
     t.string "contact_name"
     t.boolean "feedback_enabled", default: false
-    t.text "feedback_msg", limit: 16777215
+    t.text "feedback_msg"
     t.boolean "managed", default: false, null: false
     t.string "helpdesk_email"
     t.index ["language_id"], name: "fk_rails_5640112cab"
     t.index ["region_id"], name: "fk_rails_5a6adf6bab"
   end
 
-  create_table "perms", id: :integer, force: :cascade do |t|
+  create_table "perms", id: :serial, force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "phase_translations", id: :integer, force: :cascade do |t|
+  create_table "phase_translations", id: :serial, force: :cascade do |t|
     t.integer "phase_id"
     t.string "locale", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "title"
-    t.text "description", limit: 16777215
+    t.text "description"
     t.index ["locale"], name: "index_phase_translations_on_locale"
     t.index ["phase_id"], name: "index_phase_translations_on_phase_id"
   end
 
-  create_table "phases", id: :integer, force: :cascade do |t|
+  create_table "phases", id: :serial, force: :cascade do |t|
     t.string "title"
-    t.text "description", limit: 16777215
+    t.text "description"
     t.integer "number"
     t.integer "template_id"
     t.datetime "created_at"
@@ -426,7 +429,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["versionable_id"], name: "index_phases_on_versionable_id"
   end
 
-  create_table "plan_sections", id: :integer, force: :cascade do |t|
+  create_table "plan_sections", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "section_id"
     t.integer "plan_id"
@@ -435,13 +438,13 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.datetime "release_time"
   end
 
-  create_table "plans", id: :integer, force: :cascade do |t|
+  create_table "plans", id: :serial, force: :cascade do |t|
     t.string "title"
     t.integer "template_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "identifier"
-    t.text "description", limit: 16777215
+    t.text "description"
     t.integer "visibility", default: 3, null: false
     t.boolean "feedback_requested", default: false
     t.boolean "complete", default: false
@@ -462,19 +465,19 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["template_id"], name: "index_plans_on_template_id"
   end
 
-  create_table "plans_guidance_groups", id: :integer, force: :cascade do |t|
+  create_table "plans_guidance_groups", id: :serial, force: :cascade do |t|
     t.integer "guidance_group_id"
     t.integer "plan_id"
     t.index ["guidance_group_id", "plan_id"], name: "index_plans_guidance_groups_on_guidance_group_id_and_plan_id"
     t.index ["plan_id"], name: "fk_rails_13d0671430"
   end
 
-  create_table "prefs", id: :integer, force: :cascade do |t|
-    t.text "settings", limit: 16777215
+  create_table "prefs", id: :serial, force: :cascade do |t|
+    t.text "settings"
     t.integer "user_id"
   end
 
-  create_table "project_groups", id: :integer, force: :cascade do |t|
+  create_table "project_groups", id: :serial, force: :cascade do |t|
     t.boolean "project_creator"
     t.boolean "project_editor"
     t.integer "user_id"
@@ -490,7 +493,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["project_id", "guidance_group_id"], name: "index_project_guidance_on_project_id_and_guidance_group_id"
   end
 
-  create_table "projects", id: :integer, force: :cascade do |t|
+  create_table "projects", id: :serial, force: :cascade do |t|
     t.string "title"
     t.integer "dmptemplate_id"
     t.datetime "created_at", null: false
@@ -507,27 +510,27 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["slug"], name: "index_projects_on_slug", unique: true
   end
 
-  create_table "question_format_translations", id: :integer, force: :cascade do |t|
+  create_table "question_format_translations", id: :serial, force: :cascade do |t|
     t.integer "question_format_id"
     t.string "locale", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "title"
-    t.text "description", limit: 16777215
+    t.text "description"
     t.index ["locale"], name: "index_question_format_translations_on_locale"
     t.index ["question_format_id"], name: "index_question_format_translations_on_question_format_id"
   end
 
-  create_table "question_formats", id: :integer, force: :cascade do |t|
+  create_table "question_formats", id: :serial, force: :cascade do |t|
     t.string "title"
-    t.text "description", limit: 16777215
+    t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "option_based", default: false
     t.integer "formattype", default: 0
   end
 
-  create_table "question_options", id: :integer, force: :cascade do |t|
+  create_table "question_options", id: :serial, force: :cascade do |t|
     t.integer "question_id"
     t.string "text"
     t.integer "number"
@@ -539,20 +542,20 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["versionable_id"], name: "index_question_options_on_versionable_id"
   end
 
-  create_table "question_translations", id: :integer, force: :cascade do |t|
+  create_table "question_translations", id: :serial, force: :cascade do |t|
     t.integer "question_id"
     t.string "locale", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "text", limit: 16777215
-    t.text "guidance", limit: 16777215
+    t.text "text"
+    t.text "guidance"
     t.index ["locale"], name: "index_question_translations_on_locale"
     t.index ["question_id"], name: "index_question_translations_on_question_id"
   end
 
-  create_table "questions", id: :integer, force: :cascade do |t|
-    t.text "text", limit: 16777215
-    t.text "default_value", limit: 16777215
+  create_table "questions", id: :serial, force: :cascade do |t|
+    t.text "text"
+    t.text "default_value"
     t.integer "number"
     t.integer "section_id"
     t.datetime "created_at"
@@ -573,12 +576,12 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["theme_id"], name: "fk_rails_0489d5eeba"
   end
 
-  create_table "region_groups", id: :integer, force: :cascade do |t|
+  create_table "region_groups", id: :serial, force: :cascade do |t|
     t.integer "super_region_id"
     t.integer "region_id"
   end
 
-  create_table "regions", id: :integer, force: :cascade do |t|
+  create_table "regions", id: :serial, force: :cascade do |t|
     t.string "abbreviation"
     t.string "description"
     t.string "name"
@@ -637,7 +640,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["plan_id"], name: "index_research_outputs_on_plan_id"
   end
 
-  create_table "roles", id: :integer, force: :cascade do |t|
+  create_table "roles", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "plan_id"
     t.datetime "created_at"
@@ -648,20 +651,20 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["user_id"], name: "index_roles_on_user_id"
   end
 
-  create_table "section_translations", id: :integer, force: :cascade do |t|
+  create_table "section_translations", id: :serial, force: :cascade do |t|
     t.integer "section_id"
     t.string "locale", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "title"
-    t.text "description", limit: 16777215
+    t.text "description"
     t.index ["locale"], name: "index_section_translations_on_locale"
     t.index ["section_id"], name: "index_section_translations_on_section_id"
   end
 
-  create_table "sections", id: :integer, force: :cascade do |t|
+  create_table "sections", id: :serial, force: :cascade do |t|
     t.string "title"
-    t.text "description", limit: 16777215
+    t.text "description"
     t.integer "number"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -672,42 +675,42 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["versionable_id"], name: "index_sections_on_versionable_id"
   end
 
-  create_table "sessions", id: :integer, force: :cascade do |t|
+  create_table "sessions", id: :serial, force: :cascade do |t|
     t.string "session_id", limit: 64, null: false
-    t.text "data", limit: 16777215
+    t.text "data"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
     t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
-  create_table "settings", id: :integer, force: :cascade do |t|
+  create_table "settings", id: :serial, force: :cascade do |t|
     t.string "var", null: false
-    t.text "value", limit: 16777215
+    t.text "value"
     t.integer "target_id", null: false
     t.string "target_type", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "splash_logs", id: :integer, force: :cascade do |t|
+  create_table "splash_logs", id: :serial, force: :cascade do |t|
     t.string "destination"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "stats", id: :integer, force: :cascade do |t|
+  create_table "stats", id: :serial, force: :cascade do |t|
     t.bigint "count", default: 0
     t.date "date", null: false
     t.string "type", null: false
     t.integer "org_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "details", limit: 16777215
+    t.text "details"
     t.boolean "filtered", default: false
   end
 
-  create_table "stylesheets", id: :integer, force: :cascade do |t|
+  create_table "stylesheets", id: :serial, force: :cascade do |t|
     t.string "file_uid"
     t.string "file_name"
     t.integer "organisation_id"
@@ -715,7 +718,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "suggested_answers", id: :integer, force: :cascade do |t|
+  create_table "suggested_answers", id: :serial, force: :cascade do |t|
     t.integer "question_id"
     t.integer "organisation_id"
     t.text "text"
@@ -724,9 +727,9 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.boolean "is_example"
   end
 
-  create_table "templates", id: :integer, force: :cascade do |t|
+  create_table "templates", id: :serial, force: :cascade do |t|
     t.string "title"
-    t.text "description", limit: 16777215
+    t.text "description"
     t.boolean "published"
     t.integer "org_id"
     t.string "locale"
@@ -738,16 +741,16 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.integer "customization_of"
     t.integer "family_id"
     t.boolean "archived"
-    t.text "links", limit: 16777215
+    t.text "links"
     t.index ["family_id", "version"], name: "index_templates_on_family_id_and_version", unique: true
     t.index ["family_id"], name: "index_templates_on_family_id"
     t.index ["org_id", "family_id"], name: "template_organisation_dmptemplate_index"
     t.index ["org_id"], name: "index_templates_on_org_id"
   end
 
-  create_table "themes", id: :integer, force: :cascade do |t|
+  create_table "themes", id: :serial, force: :cascade do |t|
     t.string "title"
-    t.text "description", limit: 16777215
+    t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "locale"
@@ -760,14 +763,14 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["theme_id"], name: "index_themes_in_guidance_on_theme_id"
   end
 
-  create_table "token_permission_types", id: :integer, force: :cascade do |t|
+  create_table "token_permission_types", id: :serial, force: :cascade do |t|
     t.string "token_type"
-    t.text "text_description", limit: 16777215
+    t.text "text_description"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "trackers", id: :integer, force: :cascade do |t|
+  create_table "trackers", id: :serial, force: :cascade do |t|
     t.integer "org_id"
     t.string "code"
     t.datetime "created_at", null: false
@@ -775,28 +778,28 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["org_id"], name: "index_trackers_on_org_id"
   end
 
-  create_table "user_role_types", id: :integer, force: :cascade do |t|
+  create_table "user_role_types", id: :serial, force: :cascade do |t|
     t.string "name"
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "user_statuses", id: :integer, force: :cascade do |t|
+  create_table "user_statuses", id: :serial, force: :cascade do |t|
     t.string "name"
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "user_types", id: :integer, force: :cascade do |t|
+  create_table "user_types", id: :serial, force: :cascade do |t|
     t.string "name"
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "users", id: :integer, force: :cascade do |t|
+  create_table "users", id: :serial, force: :cascade do |t|
     t.string "firstname"
     t.string "surname"
     t.string "email", limit: 80, default: "", null: false
@@ -849,18 +852,18 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.index ["user_id", "role_id"], name: "index_users_roles_on_user_id_and_role_id"
   end
 
-  create_table "version_translations", id: :integer, force: :cascade do |t|
+  create_table "version_translations", id: :serial, force: :cascade do |t|
     t.integer "version_id"
     t.string "locale", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "title"
-    t.text "description", limit: 16777215
+    t.text "description"
     t.index ["locale"], name: "index_version_translations_on_locale"
     t.index ["version_id"], name: "index_version_translations_on_version_id"
   end
 
-  create_table "versions", id: :integer, force: :cascade do |t|
+  create_table "versions", id: :serial, force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.boolean "published"


### PR DESCRIPTION
Fixes #525
- #525

Changes proposed in this PR:
- Replace all NULL answer.lock_version values with 0
- Enforce that answer.lock_version always be non-NULL value