### PR TITLE
Enable translations for Template Question Options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Added
 
-- Bump mysql2 from 0.5.5 to 0.5.6 [#645](https://github.com/portagenetwork/roadmap/pull/645)
+ - Bump mysql2 from 0.5.5 to 0.5.6 [#645](https://github.com/portagenetwork/roadmap/pull/645)
+
+ - Enable translations for Template Question Options [#539](https://github.com/portagenetwork/roadmap/pull/539)
 
 ## [4.0.2+portage-4.0.0] - 2024-02-01
 

--- a/app/views/org_admin/phases/_phase.html.erb
+++ b/app/views/org_admin/phases/_phase.html.erb
@@ -56,7 +56,7 @@
                           <% if question.question_options.length > 0 %>
                             <ul>
                               <% question.question_options.each do |option| %>
-                                <li><%= option.text %></li>
+                                <li><%= _(option.text) %></li>
                               <% end %>
                             </ul>
                           <% end %>

--- a/app/views/org_admin/questions/_show.html.erb
+++ b/app/views/org_admin/questions/_show.html.erb
@@ -21,7 +21,7 @@
           <!-- question.option_based? -->
           <% if question.option_based? %>
             <dt><%= _('Question options') %></dt>
-            <dd><%= question.question_options.order(:number).collect(&:text).join(', ') %></dd>
+            <dd><%= question.question_options.order(:number).collect{|x| _(x.text)}.join(', ') %></dd>
           <% end %>
           <!-- Default value -->
           <% if q_format.textfield? || q_format.textarea? %>

--- a/app/views/template_exports/template_export.docx.erb
+++ b/app/views/template_exports/template_export.docx.erb
@@ -26,7 +26,7 @@
             <% if q_format.option_based? %>
               <ul>
                 <% question.question_options.each do |option| %>
-                  <li><%= option.text.chomp.strip %><%= option.is_default? ? ' - ' + _('default') : '' %></li>
+                  <li><%= _(option.text.chomp.strip) %><%= option.is_default? ? ' - ' + _('default') : '' %></li>
                 <% end %>
               </ul>
             <% end %>

--- a/app/views/template_exports/template_export.pdf.erb
+++ b/app/views/template_exports/template_export.pdf.erb
@@ -70,7 +70,7 @@
           <% if q_format.option_based? %>
             <ul>
             <% question.question_options.each do |option| %>
-              <li><%= option.text.chomp.strip %><%= option.is_default? ? ' - ' + _('default') : '' %></li>
+              <li><%= _(option.text.chomp.strip) %><%= option.is_default? ? ' - ' + _('default') : '' %></li>
             <% end %>
             </ul>
           <% end %>

--- a/config/initializers/translation.rb
+++ b/config/initializers/translation.rb
@@ -37,7 +37,8 @@ TranslationIO.configure do |config|
     'Section' => %w[title description],
     'Question' => %w[text default_value],
     'Annotation' => ['text'],
-    'ResearchDomain' => ['label']
+    'ResearchDomain' => ['label'],
+    'QuestionOption' => ['text']
   }
   # Find other useful usage information here:
   # https://github.com/translation/rails#readme


### PR DESCRIPTION
Fixes #537
 - #537

Changes proposed in this PR:
- Enables French translations of question options within templates
  - This includes question options within .pdf and .docx files, and the following paths:
    - `org_admin/templates/:id/`
    - `org_admin/templates/:id/edit`
- Adds `QuestionOption.text` to translation sync's list of enabled db fields.

`Portage CRDCN Template for Accessing Data from Research Data Centres` is one potential template to use when reviewing this pull request.
