### PR TITLE
Match reCaptcha's Language to Language Selected Within App

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+ - Enabled reCaptcha widget's language to match app's selected language [#558](https://github.com/portagenetwork/roadmap/pull/558)
+
  - Bump follow-redirects from 1.15.2 to 1.15.4 [#596](https://github.com/portagenetwork/roadmap/pull/596)
 
  - Bump puma from 6.4.1 to 6.4.2 [#592](https://github.com/portagenetwork/roadmap/pull/592)

--- a/app/views/contact_us/contacts/_new_left.html.erb
+++ b/app/views/contact_us/contacts/_new_left.html.erb
@@ -37,7 +37,7 @@
 <% if !user_signed_in? && Rails.configuration.x.recaptcha.enabled then %>
     <div class="form-group">
         <%= label_tag(nil, _('Security check')) %>
-        <%= recaptcha_tags %>
+        <%= recaptcha_tags(hl: @current_locale) %>
     </div>
 <% end %>
     <%= f.button(_('Submit'), class: "btn btn-default", type: "submit") %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -28,7 +28,7 @@
       <% if Rails.configuration.x.recaptcha.enabled %>
         <div class="form-group">
           <%= label_tag(nil, _('Security check')) %>
-          <%= recaptcha_tags %>
+          <%= recaptcha_tags(hl: @current_locale) %>
         </div>
       <% end %>
 

--- a/app/views/shared/_create_account_form.html.erb
+++ b/app/views/shared/_create_account_form.html.erb
@@ -47,7 +47,7 @@
   <% if Rails.configuration.x.recaptcha.enabled %>
     <div class="form-group">
       <%= label_tag(nil, _('Security check')) %>
-      <%= recaptcha_tags %>
+      <%= recaptcha_tags(hl: @current_locale) %>
     </div>
   <% end %>
   <%= f.button(_('Create account'), class: "btn btn-default", type: "submit") %>


### PR DESCRIPTION
Fixes #549
- #549

Changes proposed in this PR:
- This PR enables the language of reCaptcha's rendered text to match the language selected within the app.
