### PR TITLE
Prevent Duplicate Options in 'Select Guidance' & Refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@
 
 ### Fixed
 
+ - Fix duplicate guidance choices [#560](https://github.com/portagenetwork/roadmap/issues/560)
+
  - Fix 500 error being thrown for GET api/v0/plans [#569](https://github.com/portagenetwork/roadmap/issues/569)
 
  - Fixed an issue that was preventing uses from leaving the research output byte_size field blank

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -188,15 +188,11 @@ class PlansController < ApplicationController
     # "Organisation" org type GGs
     @important_ggs = []
 
-    if @all_ggs_grouped_by_org.include?(current_user.org)
-      @important_ggs << [current_user.org, @all_ggs_grouped_by_org[current_user.org]]
-    end
     @default_orgs = Org.default_orgs
     @all_ggs_grouped_by_org.each do |org, ggs|
-      @important_ggs << [org, ggs] if @default_orgs.include?(org) && !@important_ggs.include?([org, ggs])
-
-      # If this is one of the already selected guidance groups its important!
-      @important_ggs << [org, ggs] if !(ggs & @selected_guidance_groups).empty? && !@important_ggs.include?([org, ggs])
+      if (org == current_user.org) || @default_orgs.include?(org) || !(ggs & @selected_guidance_groups).empty?
+        @important_ggs << [org, ggs]
+      end
     end
 
     # Sort the rest by org name for the accordion

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -193,7 +193,7 @@ class PlansController < ApplicationController
     end
     @default_orgs = Org.default_orgs
     @all_ggs_grouped_by_org.each do |org, ggs|
-      @important_ggs << [org, ggs] if @default_orgs.include?(org)
+      @important_ggs << [org, ggs] if @default_orgs.include?(org) && !@important_ggs.include?([org, ggs])
 
       # If this is one of the already selected guidance groups its important!
       @important_ggs << [org, ggs] if !(ggs & @selected_guidance_groups).empty? && !@important_ggs.include?([org, ggs])


### PR DESCRIPTION
Fixes #560
- #560

Changes proposed in this PR:
- This PR addresses the bug where duplicate guidance options were displayed for some plans. The PR consists of two commits:
  - Commit 1 addresses the duplicate guidances bug by preventing the addition of `[org, ggs]` to `@important_ggs` when it is already included.
  - Commit 2 refactors the overall assigning of `[org, ggs]` to `@important_ggs`. The following is documented in the commit's description:
    - Explanation of re-factor:
      - `@all_ggs_grouped_by_org.include?(current_user.org)` iterates through `@all_ggs_grouped_by_org` to find `current_user.org`. But then the code iterates through `@all_ggs_grouped_by_org` again at `@all_ggs_grouped_by_org.each do |org, ggs|`. This refactor adds the `(org == current_user.org)` check inside `@all_ggs_grouped_by_org.each do |org, ggs|` and allows us to remove the `@all_ggs_grouped_by_org.include?(current_user.org)` section.

      - Before this refactor, we had multiple if statements inside the `@all_ggs_grouped_by_org.each do |org, ggs|` section that each included a `!@important_ggs.include?([org, ggs])`check. The refactor instead uses a single if statement inside the loop `if (org == current_user.org) || @default_orgs.include?(org) || !(ggs & @selected_guidance_groups).empty?`. This prevents the addition of duplicate `[org, ggs]` to `@important_ggs`, and allows us to remove the `!@important_ggs.include?([org, ggs])`check.