### PR TITLE
Fix GET api/v0/plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@
 
 ### Fixed
 
+ - Fix 500 error being thrown for GET api/v0/plans [#569](https://github.com/portagenetwork/roadmap/issues/569)
+
  - Fixed an issue that was preventing uses from leaving the research output byte_size field blank
 
  - Patched issue that was causing template visibility to default to organizationally visible after saving

--- a/app/controllers/api/v0/plans_controller.rb
+++ b/app/controllers/api/v0/plans_controller.rb
@@ -101,7 +101,7 @@ module Api
         max_per_page = Rails.configuration.x.application.api_max_page_size
         page = params.fetch('page', 1).to_i
         per_page = params.fetch('per_page', max_per_page).to_i
-        per_page = max_per_page if @per_page > max_per_page
+        per_page = max_per_page if per_page > max_per_page
         @args = { per_page: per_page, page: page }
         @plans = refine_query(@plans)
         respond_with @plans


### PR DESCRIPTION
Fixes #569
- #569

Changes proposed in this PR:
- Fixes a typo (changes `@per_page` to `per_page`) which solves a 500 error that was being thrown when calling `GET api/v0/plans`.
- Commit was cherry-picked from upstream. The fix is included in [DMPRoadmap release v4.1.1](https://github.com/DMPRoadmap/roadmap/releases/tag/v4.1.1). However, this bug currently exists in our codebase.