### PR TITLE
Fix "undefined" Tooltip Messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@
 
 ### Fixed
 
+ - Fixed tooltips that were previously rendering 'undefined' as their message [#552](https://github.com/portagenetwork/roadmap/issues/552)
+
  - Patched a validation check to enable updates for all existing DMP Assistant Orgs [#587](https://github.com/portagenetwork/roadmap/issues/587)
 
  - Fix duplicate guidance choices [#560](https://github.com/portagenetwork/roadmap/issues/560)

--- a/app/javascript/src/utils/requiredField.js
+++ b/app/javascript/src/utils/requiredField.js
@@ -1,7 +1,7 @@
 import getConstant from './constants';
 import { isObject } from './isType';
 
-const asterisk = `<span class="red" title="${getConstant('REQUIRED_FIELD_TEXT')}">* </span>`;
+var asterisk;
 
 export const addAsterisk = (el) => {
   const target = $(el);
@@ -32,5 +32,6 @@ export const addAsterisks = (el) => {
 };
 
 $(() => {
+  asterisk = `<span class="red" title="${getConstant('REQUIRED_FIELD_TEXT')}">* </span>`;
   addAsterisks('body');
 });

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -133,6 +133,7 @@
       MAX_NUMBER_GUIDANCE_SELECTIONS: 6,
 
       REQUIRED_FIELD_TEXT: _('This field is required.'),
+      VALIDATION_MESSAGE_PASSWORDS_MATCH: _('The passwords must match.'),
 
       SHOW_PASSWORD_MESSAGE: _('Show password'),
       SHOW_SELECT_ORG_MESSAGE: _('Select an organisation from the list.'),


### PR DESCRIPTION
Fixes #552
- https://github.com/portagenetwork/roadmap/issues/552

Changes proposed in this PR:
- Prior to this change, `asterisk` was evaluating to `undefined`. Moving `getConstant('REQUIRED_FIELD_TEXT')` inside of the `requiredField.js` jQuery callback ensures that `REQUIRED_FIELD_TEXT` will be loaded before `getConstant()` attempts to retrieve it.
- The constant, `VALIDATION_MESSAGE_PASSWORDS_MATCH` was previously removed ([here](https://github.com/portagenetwork/roadmap/commit/33a60587b5ad60f3dcc1d7864cae5b94a7b7e7a0)). However, this PR puts the constant back, because `getConstant('VALIDATION_MESSAGE_PASSWORDS_MATCH')` is executed in `passwordHelper.js`.