### PR TITLE
Prevent Duplicate Options in 'Select Guidance' & Refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@
 
 ### Fixed
 
+ - Fix duplicate guidance choices [#560](https://github.com/portagenetwork/roadmap/issues/560)
+
  - Fix 500 error being thrown for GET api/v0/plans [#569](https://github.com/portagenetwork/roadmap/issues/569)
 
  - Fixed an issue that was preventing uses from leaving the research output byte_size field blank

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -194,7 +194,9 @@ class PlansController < ApplicationController
     @default_orgs = Org.default_orgs
     @all_ggs_grouped_by_org.each do |org, ggs|
       # @default_orgs and already selected guidance groups are important.
-      @important_ggs << [org, ggs] if (@default_orgs.include?(org) || !(ggs & @selected_guidance_groups).empty?) && !@important_ggs.include?([org, ggs])
+      if (@default_orgs.include?(org) || (ggs & @selected_guidance_groups).any?) && !@important_ggs.include?([org, ggs])
+        @important_ggs << [org, ggs]
+      end
     end
 
     # Sort the rest by org name for the accordion

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -193,10 +193,8 @@ class PlansController < ApplicationController
     end
     @default_orgs = Org.default_orgs
     @all_ggs_grouped_by_org.each do |org, ggs|
-      @important_ggs << [org, ggs] if @default_orgs.include?(org)
-
-      # If this is one of the already selected guidance groups its important!
-      @important_ggs << [org, ggs] if !(ggs & @selected_guidance_groups).empty? && !@important_ggs.include?([org, ggs])
+      # @default_orgs and already selected guidance groups are important.
+      @important_ggs << [org, ggs] if (@default_orgs.include?(org) || !(ggs & @selected_guidance_groups).empty?) && !@important_ggs.include?([org, ggs])
     end
 
     # Sort the rest by org name for the accordion


### PR DESCRIPTION
Fixes #560
- #560

Changes proposed in this PR:
- This PR addresses the bug where duplicate guidance options were displayed for some plans.
- Some minor refactoring is done in this PR as well.
