### PR TITLE
Patch Validation Check to Enable Updates Of All Existing DMP Assistant Orgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@
 
 ### Fixed
 
+ - Patched a validation check to enable updates for all existing DMP Assistant Orgs [#587](https://github.com/portagenetwork/roadmap/issues/587)
+
  - Fix duplicate guidance choices [#560](https://github.com/portagenetwork/roadmap/issues/560)
 
  - Fix 500 error being thrown for GET api/v0/plans [#569](https://github.com/portagenetwork/roadmap/issues/569)

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -92,9 +92,11 @@ class Org < ApplicationRecord
   # = Validations =
   # ===============
 
+  # DMP Assistant has some org names that are non-unique in there .downcase form
+  # Set `case_sensitive: false` after all such orgs names have been addressed
   validates :name, presence: { message: PRESENCE_MESSAGE },
                    uniqueness: { message: UNIQUENESS_MESSAGE,
-                                 case_sensitive: false }
+                                 case_sensitive: true }
 
   validates :is_other, inclusion: { in: BOOLEAN_VALUES,
                                     message: PRESENCE_MESSAGE }

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -93,7 +93,7 @@ class Org < ApplicationRecord
   # ===============
 
   # DMP Assistant has some org names that are non-unique in there .downcase form
-  # Set `case_sensitive: false` after all such orgs names have been addressed
+  # TODO: Set `case_sensitive: false` after all such orgs names have been addressed
   validates :name, presence: { message: PRESENCE_MESSAGE },
                    uniqueness: { message: UNIQUENESS_MESSAGE,
                                  case_sensitive: true }

--- a/spec/models/org_spec.rb
+++ b/spec/models/org_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe Org, type: :model do
 
     it {
       subject.name = 'DMP Company'
-      is_expected.to validate_uniqueness_of(:name).case_insensitive
-                                                  .with_message('must be unique')
+      is_expected.to validate_uniqueness_of(:name).with_message('must be unique')
     }
 
     it { is_expected.to allow_values(true, false).for(:is_other) }


### PR DESCRIPTION
Fixes #587

Changes proposed in this PR:
- https://github.com/portagenetwork/roadmap/issues/587
- DMP Assistant's production db currently includes some org names that would not pass the uniqueness validation check with the previous `case_sensitive: false` statement.
- This change can be reverted when the affected Org names are addressed (this PR also includes a code comment pointing this out).