### PR TITLE
Fix `gem install bundler` Step To Allow GitHub Action to Push Docker Image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@
 
 ### Fixed
 
+ - Fixed `gem install bundler` issue that was preventing Github Actions from pushing images to Docker Hub [#599](https://github.com/portagenetwork/roadmap/issues/599)
+
  - Fixed tooltips that were previously rendering 'undefined' as their message [#552](https://github.com/portagenetwork/roadmap/issues/552)
 
  - Patched a validation check to enable updates for all existing DMP Assistant Orgs [#587](https://github.com/portagenetwork/roadmap/issues/587)

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -33,8 +33,9 @@ ARG INSTALL_PATH=/usr/src/app/
 ENV INSTALL_PATH $INSTALL_PATH
 
 WORKDIR $INSTALL_PATH
-RUN gem install bundler
 COPY Gemfile* $INSTALL_PATH
+# Install Bundler with the specified version from Gemfile.lock
+RUN gem install bundler -v "$(tail -1 Gemfile.lock | tr -d " ")"
 
 # for 3.1.0 test, need both mysql and psql group installed
 RUN bundle config --local build.sassc --disable-march-tune-native


### PR DESCRIPTION
Fixes #599
- #599

Changes proposed in this PR:
- Replaces  `gem install bundler` with `gem install bundler -v ${bundler_version_in_Gemfile}`
- Without this PR, `gem install bundler` will fail, because it installs the latest version of bundler, which requires Ruby >=3.
- To ensure the GitHub Action is now working, I created a tag. It is now executing successfully: https://github.com/portagenetwork/roadmap/actions/runs/7532550039/job/20503402051
- ![Screenshot from 2024-01-15 11-09-36](https://github.com/portagenetwork/roadmap/assets/71047780/fae814ff-07bd-45c6-a398-e590d1f88289)
