### PR TITLE
Fix Display of Plan Titles (Specifically Ampersands) Within Outgoing e-mails 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@
 
 ### Fixed
 
+ - Fixed display of plan titles (specifically ampersands) within outgoing e-mails [#615](https://github.com/portagenetwork/roadmap/issues/615)
+
  - Fixed `gem install bundler` issue that was preventing Github Actions from pushing images to Docker Hub [#599](https://github.com/portagenetwork/roadmap/issues/599)
 
  - Fixed tooltips that were previously rendering 'undefined' as their message [#552](https://github.com/portagenetwork/roadmap/issues/552)
@@ -102,7 +104,7 @@
 
 ### Changed
 
-  - Removed dmp-pgd.ca/?locale=fr_CA links from terms & privacy pages (they had no effect on the app's language selector) [#455](https://github.com/portagenetwork/roadmap/issues/455)
+ - Removed dmp-pgd.ca/?locale=fr_CA links from terms & privacy pages (they had no effect on the app's language selector) [#455](https://github.com/portagenetwork/roadmap/issues/455)
 
  - Updated ruby.yml workflow to use PostgreSQL database [#532](https://github.com/portagenetwork/roadmap/issues/532)
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -4,6 +4,7 @@
 class UserMailer < ActionMailer::Base
   prepend_view_path 'app/views/branded/'
 
+  require 'cgi' # Using CGI.unescapeHTML() on sanitized plan.title within mail(subject: ) to render '&amp;' as '&'
   include MailerHelper
   helper MailerHelper
   helper FeedbacksHelper
@@ -133,11 +134,12 @@ class UserMailer < ActionMailer::Base
       mail(to: recipient.email,
            from: sender,
            subject: format(_('%{tool_name}: Expert feedback has been provided for %{plan_title}'),
-                           tool_name: tool_name, plan_title: @plan.title))
+                           tool_name: tool_name, plan_title: CGI.unescapeHTML(@plan.title)))
     end
   end
   # rubocop:enable Metrics/AbcSize
 
+  # rubocop:disable Metrics/AbcSize
   def plan_visibility(user, plan)
     return unless user.active?
 
@@ -150,9 +152,10 @@ class UserMailer < ActionMailer::Base
 
     I18n.with_locale I18n.locale do
       mail(to: @user.email,
-           subject: format(_('DMP Visibility Changed: %{plan_title}'), plan_title: @plan.title))
+           subject: format(_('DMP Visibility Changed: %{plan_title}'), plan_title: CGI.unescapeHTML(@plan.title)))
     end
   end
+  # rubocop:enable Metrics/AbcSize
 
   # commenter - User who wrote the comment.
   # plan - Plan for which the comment is associated to
@@ -180,7 +183,7 @@ class UserMailer < ActionMailer::Base
     I18n.with_locale I18n.locale do
       mail(to: @plan.owner.email,
            subject: format(_('%{tool_name}: A new comment was added to %{plan_title}'),
-                           tool_name: tool_name, plan_title: @plan.title))
+                           tool_name: tool_name, plan_title: CGI.unescapeHTML(@plan.title)))
     end
   end
   # rubocop:enable Metrics/AbcSize

--- a/app/views/user_mailer/feedback_complete.html.erb
+++ b/app/views/user_mailer/feedback_complete.html.erb
@@ -4,7 +4,7 @@
 <p>
   <%= _("%{commenter} has finished providing feedback on the plan  \"%{link_html}\". Comments can be found in the 'Write plan' tab on the right side of the page (Guidance/Comments).").html_safe % {
     commenter: @requestor_name,
-    link_html: link_to(@plan_name, edit_plan_url(@plan, phase_id: @phase.id)),
+    link_html: link_to(sanitize(@plan_name), edit_plan_url(@plan, phase_id: @phase.id)),
     tool_name: tool_name
   }%>
 </p>

--- a/app/views/user_mailer/feedback_notification.html.erb
+++ b/app/views/user_mailer/feedback_notification.html.erb
@@ -8,7 +8,7 @@
     plan_name: @plan_name,
     tool_name: tool_name,
     allow_change_prefs: false,
-    link_html: link_to(@plan_name, plan_url(@plan))
+    link_html: link_to(sanitize(@plan_name), plan_url(@plan))
     } 
     %>
 </p>

--- a/app/views/user_mailer/new_comment.html.erb
+++ b/app/views/user_mailer/new_comment.html.erb
@@ -2,9 +2,9 @@
   <%= _('Hello %{user_name}') %{ user_name: @user_name } %>
 </p>
 <p>
-  <%= _('%{commenter_name} has commented on your plan %{plan_title}. To view the comments, '\
+  <%= sanitize(_('%{commenter_name} has commented on your plan %{plan_title}. To view the comments, '\
   'follow the link to the DMP below, or navigate to the plan via My Dashboard page in %{tool_name}.') \
-  %{ commenter_name: @commenter_name, plan_title: @plan_title, tool_name: tool_name } %>
+  % { commenter_name: @commenter_name, plan_title: @plan_title, tool_name: tool_name }) %>
 </p>
 <p>
   <%=  _('Below is a summary of the sections and questions which have comments.') %>

--- a/app/views/user_mailer/permissions_change_notification.html.erb
+++ b/app/views/user_mailer/permissions_change_notification.html.erb
@@ -2,11 +2,11 @@
   <%= _('Hello %{recepientname}') %{ recepientname: @recepient.name } %>
 </p>
 <p>
-  <%= _('Your permissions relating to %{plan_title} have changed. You now have %{type} access. This means you can %{placeholder1} %{placeholder2}') % {
+  <%= sanitize(_('Your permissions relating to %{plan_title} have changed. You now have %{type} access. This means you can %{placeholder1} %{placeholder2}') % {
      plan_title: @plan_title,
      type: @messaging[:type],
      placeholder1: @messaging[:placeholder1],
      placeholder2: @messaging[:placeholder2]
-    } %>
+    }) %>
 </p>
 <%= render partial: 'email_signature' %>

--- a/app/views/user_mailer/plan_visibility.html.erb
+++ b/app/views/user_mailer/plan_visibility.html.erb
@@ -2,8 +2,8 @@
   <%= _('Hello %{username}') %{ username: @username } %>
 </p>
 <p>
-  <%= _('The plan %{plan_title} had its visibility changed to %{plan_visibility}.') %{
-    plan_title: @plan_title, plan_visibility: @plan_visibility } %>
+  <%= sanitize(_('The plan %{plan_title} had its visibility changed to %{plan_visibility}.') % {
+    plan_title: @plan_title, plan_visibility: @plan_visibility }) %>
 </p>
 <p>
   <%= _('Visibility definitions:') %>


### PR DESCRIPTION
Fixes #615
- #615 

Changes proposed in this PR:
- sanitize() plan.title in app/views/user_mailer/
- Use CGI.unescapeHTML on plan.title in user_mailer.rb
  - plan.title is sanitized when being saved to the db, so it should be safe to use CGI.unescapeHTML on it (let me know if you have an alternative approach)
