### PR TITLE
Fix Notification Message When Updating Permissions Of Plan Collaborators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@
 
 ### Fixed
 
+ - Removed unwanted text from success notification when permissions are changed for a plan collaborator [#606](https://github.com/portagenetwork/roadmap/issues/606)
+
  - Fixed `gem install bundler` issue that was preventing Github Actions from pushing images to Docker Hub [#599](https://github.com/portagenetwork/roadmap/issues/599)
 
  - Fixed tooltips that were previously rendering 'undefined' as their message [#552](https://github.com/portagenetwork/roadmap/issues/552)

--- a/app/javascript/src/plans/share.js
+++ b/app/javascript/src/plans/share.js
@@ -20,7 +20,7 @@ $(() => {
   $('.toggle-existing-user-access')
     .on('ajax:success', (e) => {
       const data = e.detail[0];
-      notifier.renderNotice(`foo: ${data.msg}`);
+      notifier.renderNotice(data.msg);
     })
     .on('ajax:error', (e) => {
       const xhr = e.detail[2];


### PR DESCRIPTION
Fixes #606
- #606

Changes proposed in this PR:
- Removes hardcoded "foo:" string from success notification when permissions are changed for a plan collaborator.