### PR TITLE
Remove "You must answer at least ..." Message When default_percentage_answered is Set to Zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,9 @@
 
 ### Changed
 
-  - Removed dmp-pgd.ca/?locale=fr_CA links from terms & privacy pages (they had no effect on the app's language selector) [#455](https://github.com/portagenetwork/roadmap/issues/455)
+ - Remove "You must answer at least" message when plans.default_percentage_answered is set to 0 [#607](https://github.com/portagenetwork/roadmap/issues/607)
+
+ - Removed dmp-pgd.ca/?locale=fr_CA links from terms & privacy pages (they had no effect on the app's language selector) [#455](https://github.com/portagenetwork/roadmap/issues/455)
 
  - Updated ruby.yml workflow to use PostgreSQL database [#532](https://github.com/portagenetwork/roadmap/issues/532)
 

--- a/app/views/plans/_share_form.html.erb
+++ b/app/views/plans/_share_form.html.erb
@@ -4,13 +4,20 @@
 <% administerable = @plan.administerable_by?(current_user.id) %>
 <% email_tooltip = _("Enter the email address of your collaborator: If they are already using #{ApplicationService.application_name}, they will see this plan on their dashboard, and recieve an email. If they are not currently using #{ApplicationService.application_name}, they will recieve an email inviting them to the tool so they can collaborate on your plan.") %>
 <% permissions_tooltip = _('Co-owner: Has admin-rights to the plan (can invite other users, view the plan, answer questions, or comment). Editor: Has edit-rights to the plan (can view the plan, answer questions, or comment). Read Only: Has read-rights to the plan (can view the plan or comment)') %>
+<% percentage = Rails.configuration.x.plans.default_percentage_answered %>
+<% visibility_message = if percentage&.nonzero?
+                          _('Public or organisational visibility is intended for finished plans. You must answer at least %{percentage}%% of the questions to enable these options. Note: test plans are set to private visibility by default.') % { percentage: percentage }
+                        else
+                          _('Public or organisational visibility is intended for finished plans. Note: test plans are set to private visibility by default.')
+                        end
+%>
 
 <h2><%= _('Set plan visibility') %></h2>
 <% allow_visibility = @plan.visibility_allowed? %>
 <%= form_with model: @plan, id: "set_visibility" do |f| %>
   <fieldset<%= (allow_visibility ? '' : ' disabled') %>>
     <legend>
-      <p class="form-control-static"><%= _('Public or organisational visibility is intended for finished plans. You must answer at least %{percentage}%% of the questions to enable these options. Note: test plans are set to private visibility by default.') % { :percentage => Rails.configuration.x.plans.default_percentage_answered } %></p>
+      <p class="form-control-static"><%= visibility_message %></p>
     </legend>
     <div class="form-group col-xs-8">
       <div class="radio">


### PR DESCRIPTION
Fixes #607
- #607

Changes proposed in this PR:
- If Rails.configuration.x.plans.default_percentage_answered is non-zero, then the visibility_message prior to this commit does not change. Otherwise, the "You must answer at least 0% of the questions to enable these options." part of the visibility_message is removed.