### PR TITLE
Set "integration" as Target Branch for Dependabot Pull Requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,4 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-    target-branch: deployment-portage
+    target-branch: integration


### PR DESCRIPTION
Changes proposed in this PR:
- This PR aims to set integration, rather than deployment-portage, as the target branch for Dependabot pull requests.
- This change seems to make sense with our changed approach to start targeting integration, rather than deployment-portage, for development work.