### PR TITLE
Override contact_us_url value from contact-us gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
  - Increased the width of the research outputs file size unit dropdown [#741](https://github.com/portagenetwork/roadmap/pull/741)
 
+ - Updated the "contact-us" link in some places [#660](https://github.com/portagenetwork/roadmap/pull/660)
+
 ## [4.0.2+portage-4.0.3] - 2024-04-11
 
 ### Added

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -53,6 +53,7 @@ module ApplicationHelper
     end
   end
 
+  # Override the contact_us_path value set by the contact-us gem
   def contact_us_path
     if I18n.locale == :'fr-CA'
       'https://portagenetwork.ca/fr/contactez-nous/'
@@ -61,6 +62,9 @@ module ApplicationHelper
       'https://portagenetwork.ca/contact-us/'
     end
   end
+
+  # Override the contact_us_url value set by the contact-us gem
+  alias contact_us_url contact_us_path
 
   # TODO: Replace function body with the commented-out code when French version of this path is made available.
   def terms_of_use_path


### PR DESCRIPTION
Fixes #632
- #632

Changes proposed in this PR:
- Our app uses the `contact_us` gem, which handles the values of `contact_us_path` and `contact_us_url`. However, DMP Assistant requires a custom a custom "contact-us" value. We currently have a solution for overriding `contact_us_path`. This PR modifies the codebase to apply that solution to `contact_us_url` as well.
- Note that because our "contact-us" url is separate from our domain, I think it's ok to assign the url to both `contact_us_path` and `contact_us_url`.