### PR TITLE
Enable Translation of QuestionOption.text (and Refactor Translation of ResearchDomain.label)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+ - Added an extra Google Analytics Tag [#682](https://github.com/portagenetwork/roadmap/pull/682)
+
 ## [4.0.2+portage-4.0.0] - 2024-02-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+ - Enable Translation of QuestionOption.text (and Refactor Translation of ResearchDomain.label) [#662](https://github.com/portagenetwork/roadmap/pull/662)
+
 ### Changed
 
  - Deactivate Requests to External ROR API [#738](https://github.com/portagenetwork/roadmap/pull/738)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 ### Added
 
-- Bump mysql2 from 0.5.5 to 0.5.6 [#645](https://github.com/portagenetwork/roadmap/pull/645)
+ - Bump mysql2 from 0.5.5 to 0.5.6 [#645](https://github.com/portagenetwork/roadmap/pull/645)
 
 ### Fixed
 
-- Updated Webmock's allowed request list to enable fetching of chromedriver [#670](https://github.com/portagenetwork/roadmap/pull/670)
+ - Updated Webmock's allowed request list to enable fetching of chromedriver [#670](https://github.com/portagenetwork/roadmap/pull/670)
+
+ - Edit Gemfile config for 'rollbar' to enable app tracking on rollbar.com [#687](https://github.com/portagenetwork/roadmap/pull/687)
 
 ## [4.0.2+portage-4.0.0] - 2024-02-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
  - Edit Gemfile config for 'rollbar' to enable app tracking on rollbar.com [#687](https://github.com/portagenetwork/roadmap/pull/687)
 
- - Fxed ordering of templates within the "Create a new plan" template dropdown [#706](https://github.com/portagenetwork/roadmap/pull/706)
+ - Fixed ordering of templates within the "Create a new plan" template dropdown [#706](https://github.com/portagenetwork/roadmap/pull/706) and [#718](https://github.com/portagenetwork/roadmap/pull/718)
 
 ## [4.0.2+portage-4.0.0] - 2024-02-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
  - Bump rack from 2.2.8 to 2.2.9 [#714](https://github.com/portagenetwork/roadmap/pull/714)
 
+ - Bump tar from 6.1.13 to 6.2.1 [#719](https://github.com/portagenetwork/roadmap/pull/719)
+
 ### Fixed
 
  - Updated Webmock's allowed request list to enable fetching of chromedriver [#670](https://github.com/portagenetwork/roadmap/pull/670)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Added
 
-- Bump mysql2 from 0.5.5 to 0.5.6 [#645](https://github.com/portagenetwork/roadmap/pull/645)
+ - Bump mysql2 from 0.5.5 to 0.5.6 [#645](https://github.com/portagenetwork/roadmap/pull/645)
+
+ - Enable Translation of QuestionOption.text (and Refactor Translation of ResearchDomain.label) [#662](https://github.com/portagenetwork/roadmap/pull/662)
 
 ## [4.0.2+portage-4.0.0] - 2024-02-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [4.0.2+portage-4.0.3] - 2024-04-11
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
  - Bump mysql2 from 0.5.5 to 0.5.6 [#645](https://github.com/portagenetwork/roadmap/pull/645)
 
-- Added "Accept terms and conditions" checkbox to invitation form [#684](https://github.com/portagenetwork/roadmap/pull/684)
+ - Added "Accept terms and conditions" checkbox to invitation form [#684](https://github.com/portagenetwork/roadmap/pull/684)
+
+ - Bump rack from 2.2.8 to 2.2.9 [#714](https://github.com/portagenetwork/roadmap/pull/714)
 
 ### Fixed
 
@@ -14,7 +16,7 @@
 
  - Edit Gemfile config for 'rollbar' to enable app tracking on rollbar.com [#687](https://github.com/portagenetwork/roadmap/pull/687)
 
- - Fxed ordering of templates within the "Create a new plan" template dropdown [#706](https://github.com/portagenetwork/roadmap/pull/706)
+ - Fixed ordering of templates within the "Create a new plan" template dropdown [#706](https://github.com/portagenetwork/roadmap/pull/706)
 
 ## [4.0.2+portage-4.0.2] - 2024-03-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## [Unreleased]
+## [4.0.2+portage-4.0.2] - 2024-03-04
 
 ### Added
 
  - Added an extra Google Analytics Tag [#682](https://github.com/portagenetwork/roadmap/pull/682)
 
-## [4.0.2+portage-4.0.0] - 2024-02-01
+## [4.0.2+portage-4.0.0] [4.0.2+portage-4.0.1] - 2024-02-01
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+ - Updated 'translation' gem URL in Gemfile to match moved repository [#725](https://github.com/portagenetwork/roadmap/pull/725)
+
 ## [4.0.2+portage-4.0.3] - 2024-04-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+ - Deactivate Requests to External ROR API [#738](https://github.com/portagenetwork/roadmap/pull/738)
+
  - Updated 'translation' gem URL in Gemfile to match moved repository [#725](https://github.com/portagenetwork/roadmap/pull/725)
 
 ## [4.0.2+portage-4.0.3] - 2024-04-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Bump mysql2 from 0.5.5 to 0.5.6 [#645](https://github.com/portagenetwork/roadmap/pull/645)
 
+- Added "Accept terms and conditions" checkbox to invitation form [#684](https://github.com/portagenetwork/roadmap/pull/684)
+
 ### Fixed
 
 - Updated Webmock's allowed request list to enable fetching of chromedriver [#670](https://github.com/portagenetwork/roadmap/pull/670)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
  - Edit Gemfile config for 'rollbar' to enable app tracking on rollbar.com [#687](https://github.com/portagenetwork/roadmap/pull/687)
 
+ - Fxed ordering of templates within the "Create a new plan" template dropdown [#706](https://github.com/portagenetwork/roadmap/pull/706)
+
 ## [4.0.2+portage-4.0.0] - 2024-02-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Bump mysql2 from 0.5.5 to 0.5.6 [#645](https://github.com/portagenetwork/roadmap/pull/645)
 
+### Fixed
+
+- Updated Webmock's allowed request list to enable fetching of chromedriver [#670](https://github.com/portagenetwork/roadmap/pull/670)
+
 ## [4.0.2+portage-4.0.0] - 2024-02-01
 
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -205,7 +205,7 @@ gem 'htmltoword'
 # INTERNATIONALIZATION #
 # ==================== #
 
-gem 'translation', git: 'https://github.com/lagoan/translation_io_rails',
+gem 'translation', git: 'https://github.com/ualbertalib/translation_io_rails',
                    branch: 'fix/broken_db_fake_method_calls'
 
 # ========= #

--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ gem 'bootsnap', require: false
 # Rollbar-gem is the SDK for Ruby apps and includes support for apps using
 # Rails, Sinatra, Rack, plain Ruby, and other frameworks.
 # https://github.com/rollbar/rollbar-gem
-gem 'rollbar', group: :rollbar, require: false
+gem 'rollbar'
 
 # ======== #
 # DATABASE #

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: https://github.com/lagoan/translation_io_rails
+  remote: https://github.com/ualbertalib/translation_io_rails
   revision: 6fbb2cd619e7bf01b37b9b8916b0f345899f876b
   branch: fix/broken_db_fake_method_calls
   specs:
@@ -286,7 +286,7 @@ GEM
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    locale (2.1.3)
+    locale (2.1.4)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -371,7 +371,7 @@ GEM
     pundit-matchers (2.0.0)
       rspec-rails (>= 3.0.0)
     racc (1.7.3)
-    rack (2.2.8)
+    rack (2.2.9)
     rack-mini-profiler (3.3.0)
       rack (>= 1.2.0)
     rack-protection (3.2.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -172,7 +172,7 @@ class ApplicationController < ActionController::Base
   end
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:accept_invitation, keys: %i[firstname surname org_id])
+    devise_parameter_sanitizer.permit(:accept_invitation, keys: %i[firstname surname org_id accept_terms])
   end
 
   def render_not_found(exception)

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -51,7 +51,9 @@ class TemplateOptionsController < ApplicationController
     else
       # if'No Primary Research Institution' checkbox is checked,
       # only show publicly available template without customization
-      @templates = Template.published.publicly_visible.where(org_id: funder.id, customization_of: nil)
+      @templates << Template.default if Template.default.present?
+      @templates << Template.published.publicly_visible.where(org_id: funder.id, customization_of: nil, is_default: false).sort_by(&:title).to_a
+      @templates = @templates.flatten.uniq
     end
     # DMP Assistant: We do not want to include not customized templates from default funder
     # Include customizable funder templates

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -47,14 +47,14 @@ class TemplateOptionsController < ApplicationController
       # Retrieve the Org's templates
       @templates << Template.published.organisationally_visible.where(org_id: org.id,
                                                                       customization_of: nil).sort_by(&:title).to_a
-      @templates = @templates.flatten.uniq
     else
       # if'No Primary Research Institution' checkbox is checked,
       # only show publicly available template without customization
       @templates << Template.default if Template.default.present?
-      @templates << Template.published.publicly_visible.where(org_id: funder.id, customization_of: nil, is_default: false).sort_by(&:title).to_a
-      @templates = @templates.flatten.uniq
+      @templates << Template.published.publicly_visible.where(org_id: funder.id, customization_of: nil,
+                                                              is_default: false).sort_by(&:title).to_a
     end
+    @templates = @templates.flatten
     # DMP Assistant: We do not want to include not customized templates from default funder
     # Include customizable funder templates
     # @templates << funder_templates = Template.latest_customizable

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -64,7 +64,7 @@ class TemplateOptionsController < ApplicationController
       # We want the default template to appear at the beggining of the list
       @templates.unshift(customization)
     end
-    @templates.uniq
+    @templates = @templates.uniq
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
   # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -28,7 +28,7 @@ class TemplateOptionsController < ApplicationController
     if org.present? && !org.new_record?
       # Load the funder's template(s) minus the default template (that gets swapped
       # in below if NO other templates are available)
-      @templates = Template.latest_customizable.where(org_id: funder.id, is_default: false).to_a
+      @templates = Template.latest_customizable.where(org_id: funder.id, is_default: false).sort_by(&:title).to_a
       # Swap out any organisational cusotmizations of a funder template
       @templates = @templates.map do |tmplt|
         customization = Template.published
@@ -47,7 +47,7 @@ class TemplateOptionsController < ApplicationController
       # If the no funder was specified OR the funder matches the org
       # if funder.blank? || funder.id == org&.id
       # Retrieve the Org's templates
-      @templates << Template.published.organisationally_visible.where(org_id: org.id, customization_of: nil).to_a
+      @templates << Template.published.organisationally_visible.where(org_id: org.id, customization_of: nil).sort_by(&:title).to_a
       @templates = @templates.flatten.uniq
     else
       # if'No Primary Research Institution' checkbox is checked,
@@ -65,7 +65,7 @@ class TemplateOptionsController < ApplicationController
       # We want the default template to appear at the beggining of the list
       @templates.unshift(customization)
     end
-    @templates = @templates.uniq.sort_by(&:title)
+    @templates.uniq
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
   # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -47,7 +47,8 @@ class TemplateOptionsController < ApplicationController
       # If the no funder was specified OR the funder matches the org
       # if funder.blank? || funder.id == org&.id
       # Retrieve the Org's templates
-      @templates << Template.published.organisationally_visible.where(org_id: org.id, customization_of: nil).sort_by(&:title).to_a
+      @templates << Template.published.organisationally_visible.where(org_id: org.id,
+                                                                      customization_of: nil).sort_by(&:title).to_a
       @templates = @templates.flatten.uniq
     else
       # if'No Primary Research Institution' checkbox is checked,

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -18,12 +18,10 @@ class TemplateOptionsController < ApplicationController
 
     org = org_from_params(params_in: { org_id: org_hash.to_json }) if org_hash.present?
     funder = Org.find_by(name: Rails.application.config.default_funder_name)
-    # funder = org_from_params(params_in: { org_id: funder_hash.to_json }) if funder_hash.present?
 
     @templates = []
 
     return unless (org.present? && !org.new_record?) || (funder.present? && !funder.new_record?)
-    return unless funder.present? && !funder.new_record?
 
     if org.present? && !org.new_record?
       # Load the funder's template(s) minus the default template (that gets swapped

--- a/app/models/concerns/exportable_plan.rb
+++ b/app/models/concerns/exportable_plan.rb
@@ -238,7 +238,7 @@ module ExportablePlan
       answer = self.answer(question[:id], false)
       answer_text = ''
       if answer.present?
-        answer_text += answer.question_options.pluck(:text).join(', ') if answer.question_options.any?
+        answer_text += answer.question_options.pluck(:text).map { |x| _(x) }.join(', ') if answer.question_options.any?
         answer_text += answer.text if answer.answered? && answer.text.present?
       elsif unanswered
         answer_text += _('Not Answered')

--- a/app/models/question_option.rb
+++ b/app/models/question_option.rb
@@ -74,6 +74,12 @@ class QuestionOption < ApplicationRecord
   # = Public instance methods =
   # ===========================
 
+  # text is translated through the translation gem
+  def text
+    text = read_attribute(:text)
+    _(text) unless text.blank?
+  end
+
   def deep_copy(**options)
     copy = dup
     copy.question_id = options.fetch(:question_id, nil)

--- a/app/models/research_domain.rb
+++ b/app/models/research_domain.rb
@@ -29,4 +29,14 @@ class ResearchDomain < ApplicationRecord
   # Self join
   has_many :sub_fields, class_name: 'ResearchDomain', foreign_key: 'parent_id'
   belongs_to :parent, class_name: 'ResearchDomain', optional: true
+
+  # ===========================
+  # = Public instance methods =
+  # ===========================
+
+  # label is translated through the translation gem
+  def label
+    label = read_attribute(:label)
+    _(label) unless label.blank?
+  end
 end

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -40,7 +40,7 @@
       <div class="form-group">
         <div class="checkbox">
           <%= f.label(:accept_terms) do %>
-            <%= f.check_box(:accept_terms, "aria-required": true) %>
+            <%= f.check_box(:accept_terms, "aria-required": true, required: true) %>
             <%= _('I accept the') %>
             <%= link_to _('terms and conditions'), terms_of_use_path %>
           <% end %>

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -37,6 +37,15 @@
                      required: true
                    } %>
       </div>
+      <div class="form-group">
+        <div class="checkbox">
+          <%= f.label(:accept_terms) do %>
+            <%= f.check_box(:accept_terms, "aria-required": true) %>
+            <%= _('I accept the') %>
+            <%= link_to _('terms and conditions'), terms_of_use_path %>
+          <% end %>
+        </div>
+      </div>
       <%= f.button(_('Create account'), class: "btn btn-default", type: "submit") %>
     <% end %>
   </div>

--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -11,3 +11,13 @@
 </script>
 <!-- End Google Analytics -->
 <% end %>
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-63J2F1MNJW"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-63J2F1MNJW');
+</script>

--- a/app/views/plans/_project_details.html.erb
+++ b/app/views/plans/_project_details.html.erb
@@ -47,7 +47,7 @@ ethics_report_tooltip = _("Link to a protocol from a meeting with an ethics comm
     <div class="col-md-8">
       <%= form.label(:research_domain_id, _("Research domain"), class: "control-label") %>
 
-      <% options = research_domains.map { |rd| [_(rd.label), rd.id] } %> <%# rd.label is sync'd to translation.io via config.db_fields %>
+      <% options = research_domains.map { |rd| [rd.label, rd.id] } %>
       <%= form.select :research_domain_id, options_for_select(options, form.object.research_domain_id),
                             {
                               include_blank: _("- Please select one -"),

--- a/config/initializers/external_apis/ror.rb
+++ b/config/initializers/external_apis/ror.rb
@@ -11,4 +11,4 @@ Rails.configuration.x.ror.search_path = "organizations"
 Rails.configuration.x.ror.max_pages = 2
 Rails.configuration.x.ror.max_results_per_page = 20
 Rails.configuration.x.ror.max_redirects = 3
-Rails.configuration.x.ror.active = true
+Rails.configuration.x.ror.active = false

--- a/config/initializers/translation.rb
+++ b/config/initializers/translation.rb
@@ -37,7 +37,8 @@ TranslationIO.configure do |config|
     'Section' => %w[title description],
     'Question' => %w[text default_value],
     'Annotation' => ['text'],
-    'ResearchDomain' => ['label']
+    'ResearchDomain' => ['label'],
+    'QuestionOption' => ['text']
   }
   # Find other useful usage information here:
   # https://github.com/translation/rails#readme

--- a/spec/services/external_apis/ror_service_spec.rb
+++ b/spec/services/external_apis/ror_service_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe ExternalApis::RorService do
+  Rails.configuration.x.ror.active = true # Override actual config value for duration of tests
   describe '#ping' do
     before(:each) do
       @headers = described_class.headers

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -121,10 +121,9 @@ RSpec.configure do |config|
 
       # Allow Capybara to make localhost requests and also contact the
       # google api chromedriver store
-      # add googlechromelabs.github.io and edgedl.me.gvt1.com to work with Chrome v116+
       WebMock.disable_net_connect!(
         allow_localhost: true,
-        allow: %w[chromedriver.storage.googleapis.com googlechromelabs.github.io edgedl.me.gvt1.com]
+        allow: %w[storage.googleapis.com googlechromelabs.github.io]
       )
     end
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5268,10 +5268,10 @@ minipass@^3.0.0, minipass@^3.1.1:
   dependencies:
     yallist "^4.0.0"
 
-minipass@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-4.0.1.tgz#2b9408c6e81bb8b338d600fb3685e375a370a057"
-  integrity sha512-V9esFpNbK0arbN3fm2sxDKqMYgIp7XtVdE4Esj+PE4Qaaxdg1wIw48ITQIOn1sc8xXSmUviVL3cyjMqPlrVkiA==
+minipass@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-5.0.0.tgz#3e9788ffb90b694a5d0ec94479a45b5d8738133d"
+  integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
 
 minizlib@^2.1.1:
   version "2.1.2"
@@ -7663,13 +7663,13 @@ tapable@^1.0.0, tapable@^1.1.3:
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
 tar@^6.0.2:
-  version "6.1.13"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.13.tgz#46e22529000f612180601a6fe0680e7da508847b"
-  integrity sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.2.1.tgz#717549c541bc3c2af15751bea94b1dd068d4b03a"
+  integrity sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"
-    minipass "^4.0.0"
+    minipass "^5.0.0"
     minizlib "^2.1.1"
     mkdirp "^1.0.3"
     yallist "^4.0.0"


### PR DESCRIPTION
Fixes #537
 - #537
 
Changes proposed in this PR:
- Enable translation of QuestionOption.text throughout the app.
- Refactor translation of ResearchDomain.label
  - NOTE: The ResearchDomain.label translation was already enabled. However, the approach taken in this refactor is more consistent with the rest of the codebase.