### PR TITLE
Address "active" Indicator for Various Dropdowns 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,8 @@
 
 ### Fixed
 
+ - Address "active" indicator for various dropdowns [#668](https://github.com/portagenetwork/roadmap/pull/668)
+
  - Removed unwanted text from success notification when permissions are changed for a plan collaborator [#606](https://github.com/portagenetwork/roadmap/issues/606)
 
  - Fixed `gem install bundler` issue that was preventing Github Actions from pushing images to Docker Hub [#599](https://github.com/portagenetwork/roadmap/issues/599)

--- a/app/views/layouts/_branding.html.erb
+++ b/app/views/layouts/_branding.html.erb
@@ -62,7 +62,7 @@
               <%= _('Admin') %>
               <span class="caret"></span>
             </a>
-            <ul class="dropdown-menu" aria-labelledby="admin-menu">
+            <ul class="dropdown-menu inverse-dropdown" aria-labelledby="admin-menu">
               
               <!-- ORGANISATION -->
               <% if current_user.can_super_admin? %>

--- a/app/views/layouts/_branding.html.erb
+++ b/app/views/layouts/_branding.html.erb
@@ -66,7 +66,7 @@
               
               <!-- ORGANISATION -->
               <% if current_user.can_super_admin? %>
-                  <li <%= 'class=active' if active_page?(admin_edit_org_path(current_user.org_id)) %>>
+                  <li <%= 'class=active' if active_page?(super_admin_orgs_path) %>>
                     <%= link_to _('Organisations'), super_admin_orgs_path %>
                   </li>
               <% else %>

--- a/app/views/layouts/_signin_signout.html.erb
+++ b/app/views/layouts/_signin_signout.html.erb
@@ -8,7 +8,7 @@
     </a>
     <ul class="dropdown-menu inverse-dropdown" aria-labelledby="language-menu">
       <% languages.each do |l| %>
-        <li <%= 'class=active' if I18n.locale == l.abbreviation %>>
+        <li <%= 'class=active' if I18n.locale.to_s == l.abbreviation %>>
           <%= link_to l.name, locale_path(l.abbreviation), method: :patch %>
         </li>
       <% end %>
@@ -25,7 +25,7 @@
       <span class="caret"></span>
     </a>
     <ul class="dropdown-menu inverse-dropdown" aria-labelledby="user-menu">
-      <li>
+      <li <%= 'class=active' if active_page?(edit_user_registration_path) %>>
         <%= link_to '<i class="fas fa-pencil-square" aria-hidden="true">&nbsp;</i>&nbsp;'.html_safe + _('Edit profile'), edit_user_registration_path %>
       </li>
       <li>


### PR DESCRIPTION
Fixes #663
 - #663

Changes proposed in this PR:
- Added/updated handling for when a dropdown option is "active"
- Added the "inverse-dropdown" class to the admin dropdown to make it's styling more consistent with other dropdowns.