### PR TITLE
Edit Webmock allowed requests  to get chromedriver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Bump mysql2 from 0.5.5 to 0.5.6 [#645](https://github.com/portagenetwork/roadmap/pull/645)
 
+### Fixed
+
+- Updated Webmock's allowed request list to enable fetching of chromedriver [#670](https://github.com/portagenetwork/roadmap/pull/670)
+
 ## [4.0.2+portage-4.0.0] - 2024-02-01
 
 ### Added

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -121,10 +121,9 @@ RSpec.configure do |config|
 
       # Allow Capybara to make localhost requests and also contact the
       # google api chromedriver store
-      # add googlechromelabs.github.io and edgedl.me.gvt1.com to work with Chrome v116+
       WebMock.disable_net_connect!(
         allow_localhost: true,
-        allow: %w[chromedriver.storage.googleapis.com googlechromelabs.github.io edgedl.me.gvt1.com]
+        allow: %w[storage.googleapis.com googlechromelabs.github.io]
       )
     end
 


### PR DESCRIPTION
Fixes #669
- #669

Changes proposed in this PR:
- Edit Webmock's allowed request list to enable fetching of chromedriver (The selenium/features tests cannot be run without this change.).