### PR TITLE
Create rake task to fix User.accept_terms bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Added
 
-- Bump mysql2 from 0.5.5 to 0.5.6 [#645](https://github.com/portagenetwork/roadmap/pull/645)
+ - Bump mysql2 from 0.5.5 to 0.5.6 [#645](https://github.com/portagenetwork/roadmap/pull/645)
+
+ - Create rake task to fix User.accept_terms bug [#672](https://github.com/portagenetwork/roadmap/pull/672)
 
 ## [4.0.2+portage-4.0.0] - 2024-02-01
 

--- a/lib/tasks/user_data.rake
+++ b/lib/tasks/user_data.rake
@@ -98,4 +98,14 @@ namespace :db do
     end
     puts 'Done!'
   end
+
+  desc 'Update accept terms value for users with outstanding invitation tokens'
+  task update_accept_terms: :environment do
+    puts 'Querying for all users where accept_terms = TRUE and invitation_token IS NOT NULL'
+    users = User.where('accept_terms = ? AND invitation_token IS NOT NULL', true)
+    puts "Query returned #{users.count} users"
+    puts "Setting accept_terms = NULL for each of these #{users.count} users"
+    users.update_all(accept_terms: nil)
+    puts 'Done!'
+  end
 end


### PR DESCRIPTION
Fixes #664

Changes proposed in this PR:
- Create a rake task to fix #664.
- The rake task queries for all users where `accept_terms = true` and `invitation_token != nil`. The rake task then performs an update, setting `accept_terms = nil` for all of these users.

NOTE:
- Prior to this PR, the same fix was applied successfully to a single user within the app's production environment.