### PR TITLE
Create rake task to fix User.accept_terms bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 ### Added
 
-- Bump mysql2 from 0.5.5 to 0.5.6 [#645](https://github.com/portagenetwork/roadmap/pull/645)
+ - Bump mysql2 from 0.5.5 to 0.5.6 [#645](https://github.com/portagenetwork/roadmap/pull/645)
+
+ - Create rake task to fix User.accept_terms bug [#674](https://github.com/portagenetwork/roadmap/pull/674)
 
 ### Fixed
 
-- Updated Webmock's allowed request list to enable fetching of chromedriver [#670](https://github.com/portagenetwork/roadmap/pull/670)
+ - Updated Webmock's allowed request list to enable fetching of chromedriver [#670](https://github.com/portagenetwork/roadmap/pull/670)
 
 ## [4.0.2+portage-4.0.0] - 2024-02-01
 

--- a/lib/tasks/user_data.rake
+++ b/lib/tasks/user_data.rake
@@ -98,4 +98,14 @@ namespace :db do
     end
     puts 'Done!'
   end
+
+  desc 'Bugfix for the following issue: https://github.com/portagenetwork/roadmap/issues/664'
+  task correct_accept_terms: :environment do
+    puts 'Retrieving all users where accept_terms == true and invitation_token != nil'
+    users = User.where('accept_terms = ? AND invitation_token IS NOT NULL', true)
+    puts "#{users.count} users retrieved"
+    puts 'Correcting accept_terms to nil for all of the retrieved users'
+    users.update_all(accept_terms: nil)
+    puts 'Done!'
+  end
 end


### PR DESCRIPTION
Fixes #664

Changes proposed in this PR:
- Create a rake task to fix #664.
- The rake task queries for all users where `accept_terms = true` and `invitation_token != nil`. The rake task then performs an update, setting `accept_terms = nil` for all of these users.

NOTE:
- Prior to this PR, the same fix was applied successfully to a single user within the app's production environment.