### PR TITLE
Add New Google Analytics Tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+ - Added an extra Google Analytics Tag [#682](https://github.com/portagenetwork/roadmap/pull/682)
+
 ## [4.0.2+portage-4.0.0] - 2024-02-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## [Unreleased]
+## [4.0.2+portage-4.0.2] - 2024-03-04
 
 ### Added
 
  - Added an extra Google Analytics Tag [#682](https://github.com/portagenetwork/roadmap/pull/682)
 
-## [4.0.2+portage-4.0.0] - 2024-02-01
+## [4.0.2+portage-4.0.0] [4.0.2+portage-4.0.1] - 2024-02-01
 
 ### Added
 

--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -11,3 +11,13 @@
 </script>
 <!-- End Google Analytics -->
 <% end %>
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-63J2F1MNJW"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-63J2F1MNJW');
+</script>


### PR DESCRIPTION
Changes proposed in this PR:
- This PR adds a second Google Analytics tag to the codebase.

NOTE:
- If permissions are resolved regarding the first Google Analytics tag, then this second tag should probably be removed from the codebase.