### PR TITLE
Add Terms and Conditions For Invitation Form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Bump mysql2 from 0.5.5 to 0.5.6 [#645](https://github.com/portagenetwork/roadmap/pull/645)
 
+- Added "Accept terms and conditions" checkbox to invitation form [#684](https://github.com/portagenetwork/roadmap/pull/684)
+
 ### Fixed
 
 - Updated Webmock's allowed request list to enable fetching of chromedriver [#670](https://github.com/portagenetwork/roadmap/pull/670)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -172,7 +172,7 @@ class ApplicationController < ActionController::Base
   end
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:accept_invitation, keys: %i[firstname surname org_id])
+    devise_parameter_sanitizer.permit(:accept_invitation, keys: %i[firstname surname org_id accept_terms])
   end
 
   def render_not_found(exception)

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -40,7 +40,7 @@
       <div class="form-group">
         <div class="checkbox">
           <%= f.label(:accept_terms) do %>
-            <%= f.check_box(:accept_terms, "aria-required": true) %>
+            <%= f.check_box(:accept_terms, "aria-required": true, required: true) %>
             <%= _('I accept the') %>
             <%= link_to _('terms and conditions'), terms_of_use_path %>
           <% end %>

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -37,6 +37,15 @@
                      required: true
                    } %>
       </div>
+      <div class="form-group">
+        <div class="checkbox">
+          <%= f.label(:accept_terms) do %>
+            <%= f.check_box(:accept_terms, "aria-required": true) %>
+            <%= _('I accept the') %>
+            <%= link_to _('terms and conditions'), terms_of_use_path %>
+          <% end %>
+        </div>
+      </div>
       <%= f.button(_('Create account'), class: "btn btn-default", type: "submit") %>
     <% end %>
   </div>


### PR DESCRIPTION
Fixes #665
 - #665 

Changes proposed in this PR:

1.  Add terms and conditions checkbox to the devise invitation form
    - This was done by copy/pasting the code from `app/views/shared/_create_account_form.html.erb`
    - In addition to the copy/paste, `required: true` was added. As a result, the invitation form cannot be submitted unless the checkbox is currently checked.
2. Add `accept_terms` to  `devise_parameter_sanitizer.permit()`. This enables the `accept_terms` value to be updated within the `update` method of  `Devise::InvitationsController`
