### PR TITLE
Edit Rollbar Gem To Enable Tracking on rollbar.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 ### Added
 
-- Bump mysql2 from 0.5.5 to 0.5.6 [#645](https://github.com/portagenetwork/roadmap/pull/645)
+ - Bump mysql2 from 0.5.5 to 0.5.6 [#645](https://github.com/portagenetwork/roadmap/pull/645)
 
 ### Fixed
 
-- Updated Webmock's allowed request list to enable fetching of chromedriver [#670](https://github.com/portagenetwork/roadmap/pull/670)
+ - Updated Webmock's allowed request list to enable fetching of chromedriver [#670](https://github.com/portagenetwork/roadmap/pull/670)
+
+ - Edit Gemfile config for 'rollbar' to enable app tracking on rollbar.com [#687](https://github.com/portagenetwork/roadmap/pull/687)
 
 ## [4.0.2+portage-4.0.0] - 2024-02-01
 

--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ gem 'bootsnap', require: false
 # Rollbar-gem is the SDK for Ruby apps and includes support for apps using
 # Rails, Sinatra, Rack, plain Ruby, and other frameworks.
 # https://github.com/rollbar/rollbar-gem
-gem 'rollbar', group: :rollbar, require: false
+gem 'rollbar'
 
 # ======== #
 # DATABASE #


### PR DESCRIPTION
Fixes #686
- #686

Changes proposed in this PR:
- This change enables app errors to be sent to rollbar.com. This is achieved by editing the `gem 'rollbar'` config within `Gemfile`.

1. Remove `group: :rollbar`
`config/initializers/rollbar.rb` includes the following line:
```ruby
config.enabled = false if Rails.env.test?
```
Thus, simply having the gem as part of the `:default` group should be okay.

2. Remove `required: :false`
`rake rollbar:test` can be executed to send a test message to rollbar.com. However, this rake task doesn't work when `require: false` is part of the gem 'rollbar' config.
