### PR TITLE
Enable Various Translations Within /usage Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 ### Added
 
-- Bump mysql2 from 0.5.5 to 0.5.6 [#645](https://github.com/portagenetwork/roadmap/pull/645)
+ - Bump mysql2 from 0.5.5 to 0.5.6 [#645](https://github.com/portagenetwork/roadmap/pull/645)
+
+ - Enable Various Translations Within `/usage` Page [#697](https://github.com/portagenetwork/roadmap/pull/697)
 
 ### Fixed
 
-- Updated Webmock's allowed request list to enable fetching of chromedriver [#670](https://github.com/portagenetwork/roadmap/pull/670)
+ - Updated Webmock's allowed request list to enable fetching of chromedriver [#670](https://github.com/portagenetwork/roadmap/pull/670)
 
 ## [4.0.2+portage-4.0.0] - 2024-02-01
 

--- a/app/controllers/usage_controller.rb
+++ b/app/controllers/usage_controller.rb
@@ -99,7 +99,7 @@ class UsageController < ApplicationController
       csv << [_('Month'), _('No. Users joined')]
       total = 0
       @users_per_month.each do |data|
-        csv << [data.date.strftime('%b-%y'), data.count]
+        csv << [I18n.l(data.date, format: :month_year_abbr), data.count]
         total += data.count
       end
       csv << [_('Total'), total]
@@ -120,7 +120,7 @@ class UsageController < ApplicationController
       csv << [_('Month'), _('No. Created Plans')]
       total = 0
       @plans_per_month.each do |data|
-        csv << [data.date.strftime('%b-%y'), data.count]
+        csv << [I18n.l(data.date, format: :month_year_abbr), data.count]
         total += data.count
       end
       csv << [_('Total'), total]

--- a/app/helpers/usage_helper.rb
+++ b/app/helpers/usage_helper.rb
@@ -34,12 +34,12 @@ module UsageHelper
         # We need a placeholder for each month/year - template combo. The
         # default is to assume that there are zero plans for that month/year + template
         dflt = {
-          label: template['name'],
+          label: _(template['name']),
           backgroundColor: random_rgb,
           data: labels.map { |lbl| { x: 0, y: lbl } }
         }
 
-        template_hash = datasets.fetch(template['name'], dflt)
+        template_hash = datasets.fetch(_(template['name']), dflt)
 
         # Replace any of the month/year plan counts for this template IF it has
         # any plans defined

--- a/app/helpers/usage_helper.rb
+++ b/app/helpers/usage_helper.rb
@@ -17,7 +17,7 @@ module UsageHelper
   # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def prep_data_for_template_plans_chart(data:, subset: 'by_template')
-    last_month = Date.today.last_month.end_of_month.strftime('%b-%y')
+    last_month = I18n.localize(Date.today.last_month.end_of_month, format: :month_year_abbr)
     return { labels: [last_month], datasets: [] }.to_json if data.blank? || data.empty?
 
     datasets = {}
@@ -81,7 +81,8 @@ module UsageHelper
   end
 
   def prep_date_for_charts(date:)
-    date.is_a?(Date) ? date.strftime('%b-%y') : Date.parse(date).strftime('%b-%y')
+    date = Date.parse(date) unless date.is_a?(Date)
+    I18n.l(date, format: :month_year_abbr)
   end
 
   def random_rgb

--- a/app/models/stat_created_plan.rb
+++ b/app/models/stat_created_plan.rb
@@ -63,7 +63,7 @@ class StatCreatedPlan < Stat
       end.call(created_plans)
 
       data = created_plans.map do |created_plan|
-        tuple = { Date: created_plan.date.strftime('%b %Y') }
+        tuple = { Date: I18n.l(created_plan.date, format: '%b %Y') }
         template_names.each_with_object(tuple) do |name, acc|
           acc[name] = 0
         end

--- a/app/services/org/monthly_usage_service.rb
+++ b/app/services/org/monthly_usage_service.rb
@@ -26,7 +26,7 @@ class Org
       end
 
       def reducer_body(acc, rec, key_target)
-        month = rec.date.strftime('%b-%y')
+        month = I18n.l(rec.date, format: :month_year_abbr)
         count = rec.count
 
         if acc[month].present?

--- a/app/views/translation_io_exports/_csv_headers.erb
+++ b/app/views/translation_io_exports/_csv_headers.erb
@@ -1,0 +1,20 @@
+
+<%=
+# /usage
+
+# Download global usage
+_('Org name')
+
+# Download Monthly Usage
+_('New plans')
+_('New users')
+_('Downloads')
+_('Plans shared')
+
+# No. plans during last year Download
+_('No. Created Plans')
+
+
+# No. plans by template Download
+_('Count')
+%>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,7 @@ en:
       short: "%d %b"
       csv: "%d/%m/%Y"
       readable: "%d %B %Y"
+      month_year_abbr: "%b-%y"
     month_names:
     -
     - January

--- a/config/locales/localization.en-CA.yml
+++ b/config/locales/localization.en-CA.yml
@@ -18,6 +18,7 @@ en-CA:
       short: "%d %b"
       csv: "%d/%m/%Y"
       readable: "%B %d, %Y"
+      month_year_abbr: "%b-%y"
     order:
     - :day
     - :month

--- a/config/locales/localization.fr-CA.yml
+++ b/config/locales/localization.fr-CA.yml
@@ -18,6 +18,7 @@ fr-CA:
       long: "%e %B %Y"
       csv: "%Y-%m-%d"
       readable: "%d %b %Y"
+      month_year_abbr: "%b-%y"
     order:
     - :year
     - :month

--- a/lib/csvable.rb
+++ b/lib/csvable.rb
@@ -11,11 +11,10 @@ module Csvable
 
       headers = if humanize
                   data.first.keys
-                      .map(&:to_s)
-                      .map(&:humanize)
+                      .map { |x| _(x.to_s.humanize) }
                 else
                   data.first.keys
-                      .map(&:to_s)
+                      .map { |x| _(x.to_s) }
                 end
 
       CSV.generate({ col_sep: sep }) do |csv|

--- a/lib/csvable.rb
+++ b/lib/csvable.rb
@@ -4,8 +4,7 @@
 module Csvable
   require 'csv'
   class << self
-    # rubocop:disable Style/OptionalBooleanParameter
-    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    # rubocop:disable Style/OptionalBooleanParameter, Metrics/AbcSize
     def from_array_of_hashes(data = [], humanize = true, sep = ',')
       return '' unless data.first&.keys
 
@@ -24,7 +23,6 @@ module Csvable
         end
       end
     end
-    # rubocop:enable Style/OptionalBooleanParameter
-    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    # rubocop:enable Style/OptionalBooleanParameter, Metrics/AbcSize
   end
 end

--- a/spec/controllers/usage_controller_spec.rb
+++ b/spec/controllers/usage_controller_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe UsageController, type: :controller do
     end
     it 'assigns the correct csv data' do
       expected = "Month,No. Users joined\n" \
-                 "#{@date.strftime('%b-%y')},#{@user_stat.count}\n" \
+                 "#{I18n.l(@date, format: :month_year_abbr)},#{@user_stat.count}\n" \
                  "Total,#{@user_stat.count}\n"
       expect(response.content_type).to eq('text/csv')
       expect(response.body).to eql(expected)
@@ -93,7 +93,7 @@ RSpec.describe UsageController, type: :controller do
     end
     it 'assigns the correct csv data' do
       expected = "Month,No. Created Plans\n" \
-                 "#{@date.strftime('%b-%y')},#{@plan_stat.count}\n" \
+                 "#{I18n.l(@date, format: :month_year_abbr)},#{@plan_stat.count}\n" \
                  "Total,#{@plan_stat.count}\n"
       expect(response.content_type).to eq('text/csv')
       expect(response.body).to eql(expected)
@@ -108,7 +108,7 @@ RSpec.describe UsageController, type: :controller do
       name = @details[:by_template].first[:name]
       count = @details[:by_template].first[:count]
       expected = "Date,#{name},Count\n" \
-                 "#{@date.strftime('%b %Y')},#{count},#{@plan_stat.count}\n"
+                 "#{I18n.l(@date, format: '%b %Y')},#{count},#{@plan_stat.count}\n"
       expect(response.content_type).to eq('text/csv')
       expect(response.body).to eql(expected)
     end

--- a/spec/helpers/usage_helper_spec.rb
+++ b/spec/helpers/usage_helper_spec.rb
@@ -39,7 +39,7 @@ describe UsageHelper do
       # }
       it 'returns an empty hash if no data was available' do
         expected = {
-          labels: [Date.today.last_month.end_of_month.strftime('%b-%y')],
+          labels: [I18n.l(Date.today.last_month.end_of_month, format: :month_year_abbr)],
           datasets: []
         }
         expect(prep_data_for_template_plans_chart(data: nil)).to eql(expected.to_json)
@@ -132,7 +132,7 @@ describe UsageHelper do
   describe '#prep_date_for_charts' do
     it 'converts the date' do
       rslt = prep_date_for_charts(date: Date.today.to_s)
-      expect(rslt).to eql(Date.today.strftime('%b-%y'))
+      expect(rslt).to eql(I18n.l(Date.today, format: :month_year_abbr))
     end
   end
 


### PR DESCRIPTION
Fixes #696
- #696

Changes proposed in this PR:
- Enable translations within usage statistic graphs. Specifically, dates and template names (see screenshot below):
![Screenshot from 2024-03-21 13-14-16](https://github.com/portagenetwork/roadmap/assets/71047780/c9eae9b6-370c-4422-baff-234aa6df1612)
- Enable translations within downloadable Usage Statistic CSV files.
  - Added [app/views/translation_io_exports/_csv_headers.erb](https://github.com/portagenetwork/roadmap/compare/integration...portagenetwork:roadmap:aaron/issues/696?expand=1#diff-deb095a94a3d4ba249b206f7352cf6fde48f7556d48277115e29f2c11ba64c18) along with segments that exist within CSV files, but not on translation.io site.

NOTE:
- The commit descriptions are quite detailed. Reading them should help with reviewing this PR.
