### PR TITLE
Fix Ordering of Templates Within Create Plan Template Dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 ### Added
 
-- Bump mysql2 from 0.5.5 to 0.5.6 [#645](https://github.com/portagenetwork/roadmap/pull/645)
+ - Bump mysql2 from 0.5.5 to 0.5.6 [#645](https://github.com/portagenetwork/roadmap/pull/645)
 
 ### Fixed
 
-- Updated Webmock's allowed request list to enable fetching of chromedriver [#670](https://github.com/portagenetwork/roadmap/pull/670)
+ - Updated Webmock's allowed request list to enable fetching of chromedriver [#670](https://github.com/portagenetwork/roadmap/pull/670)
+
+ - Fxed ordering of templates within the "Create a new plan" template dropdown [#705](https://github.com/portagenetwork/roadmap/pull/705)
 
 ## [4.0.2+portage-4.0.0] - 2024-02-01
 

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -47,7 +47,8 @@ class TemplateOptionsController < ApplicationController
       # If the no funder was specified OR the funder matches the org
       # if funder.blank? || funder.id == org&.id
       # Retrieve the Org's templates
-      @templates << Template.published.organisationally_visible.where(org_id: org.id, customization_of: nil).sort_by(&:title).to_a
+      @templates << Template.published.organisationally_visible.where(org_id: org.id,
+                                                                      customization_of: nil).sort_by(&:title).to_a
       @templates = @templates.flatten.uniq
     else
       # if'No Primary Research Institution' checkbox is checked,
@@ -58,13 +59,13 @@ class TemplateOptionsController < ApplicationController
     # Include customizable funder templates
     # @templates << funder_templates = Template.latest_customizable
     # Always use the default template
-    if Template.default.present? && org.present?
-      customization = Template.published.latest_customized_version(Template.default.family_id, org.id).first
-      customization ||= Template.default
-      @templates.select! { |t| t.id != Template.default.id && t.id != customization.id }
-      # We want the default template to appear at the beggining of the list
-      @templates.unshift(customization).uniq
-    end
+    return unless Template.default.present? && org.present?
+
+    customization = Template.published.latest_customized_version(Template.default.family_id, org.id).first
+    customization ||= Template.default
+    @templates.select! { |t| t.id != Template.default.id && t.id != customization.id }
+    # We want the default template to appear at the beggining of the list
+    @templates.unshift(customization).uniq
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
   # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -28,7 +28,7 @@ class TemplateOptionsController < ApplicationController
     if org.present? && !org.new_record?
       # Load the funder's template(s) minus the default template (that gets swapped
       # in below if NO other templates are available)
-      @templates = Template.latest_customizable.where(org_id: funder.id, is_default: false).to_a
+      @templates = Template.latest_customizable.where(org_id: funder.id, is_default: false).sort_by(&:title).to_a
       # Swap out any organisational cusotmizations of a funder template
       @templates = @templates.map do |tmplt|
         customization = Template.published
@@ -47,7 +47,7 @@ class TemplateOptionsController < ApplicationController
       # If the no funder was specified OR the funder matches the org
       # if funder.blank? || funder.id == org&.id
       # Retrieve the Org's templates
-      @templates << Template.published.organisationally_visible.where(org_id: org.id, customization_of: nil).to_a
+      @templates << Template.published.organisationally_visible.where(org_id: org.id, customization_of: nil).sort_by(&:title).to_a
       @templates = @templates.flatten.uniq
     else
       # if'No Primary Research Institution' checkbox is checked,
@@ -63,9 +63,8 @@ class TemplateOptionsController < ApplicationController
       customization ||= Template.default
       @templates.select! { |t| t.id != Template.default.id && t.id != customization.id }
       # We want the default template to appear at the beggining of the list
-      @templates.unshift(customization)
+      @templates.unshift(customization).uniq
     end
-    @templates = @templates.uniq.sort_by(&:title)
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
   # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -18,12 +18,10 @@ class TemplateOptionsController < ApplicationController
 
     org = org_from_params(params_in: { org_id: org_hash.to_json }) if org_hash.present?
     funder = Org.find_by(name: Rails.application.config.default_funder_name)
-    # funder = org_from_params(params_in: { org_id: funder_hash.to_json }) if funder_hash.present?
 
     @templates = []
 
     return unless (org.present? && !org.new_record?) || (funder.present? && !funder.new_record?)
-    return unless funder.present? && !funder.new_record?
 
     if org.present? && !org.new_record?
       # Load the funder's template(s) minus the default template (that gets swapped


### PR DESCRIPTION
Fixes #685
- #685

Changes proposed in this PR:
- Fixes the order of templates within the create plan template dropdown
  - Prior to this PR, all of the listed template titles were simply sorted in alphabetical order
  - Now, the templates are sorted according the following specification: https://github.com/portagenetwork/roadmap/issues/685#issuecomment-2004404407
