### PR TITLE
Merge "integration" into deployment-portage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 ### Added
 
-- Bump mysql2 from 0.5.5 to 0.5.6 [#645](https://github.com/portagenetwork/roadmap/pull/645)
+ - Bump mysql2 from 0.5.5 to 0.5.6 [#645](https://github.com/portagenetwork/roadmap/pull/645)
 
 ### Fixed
 
-- Updated Webmock's allowed request list to enable fetching of chromedriver [#670](https://github.com/portagenetwork/roadmap/pull/670)
+ - Updated Webmock's allowed request list to enable fetching of chromedriver [#670](https://github.com/portagenetwork/roadmap/pull/670)
+
+ - Edit Gemfile config for 'rollbar' to enable app tracking on rollbar.com [#687](https://github.com/portagenetwork/roadmap/pull/687)
 
 ## [4.0.2+portage-4.0.0] - 2024-02-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- Bump mysql2 from 0.5.5 to 0.5.6 [#645](https://github.com/portagenetwork/roadmap/pull/645)
+
 ## [4.0.2+portage-4.0.0] - 2024-02-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Bump mysql2 from 0.5.5 to 0.5.6 [#645](https://github.com/portagenetwork/roadmap/pull/645)
 
+- Added "Accept terms and conditions" checkbox to invitation form [#684](https://github.com/portagenetwork/roadmap/pull/684)
+
 ### Fixed
 
 - Updated Webmock's allowed request list to enable fetching of chromedriver [#670](https://github.com/portagenetwork/roadmap/pull/670)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
  - Edit Gemfile config for 'rollbar' to enable app tracking on rollbar.com [#687](https://github.com/portagenetwork/roadmap/pull/687)
 
+ - Fxed ordering of templates within the "Create a new plan" template dropdown [#706](https://github.com/portagenetwork/roadmap/pull/706)
+
 ## [4.0.2+portage-4.0.0] - 2024-02-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Bump mysql2 from 0.5.5 to 0.5.6 [#645](https://github.com/portagenetwork/roadmap/pull/645)
 
+### Fixed
+
+- Updated Webmock's allowed request list to enable fetching of chromedriver [#670](https://github.com/portagenetwork/roadmap/pull/670)
+
 ## [4.0.2+portage-4.0.0] - 2024-02-01
 
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ gem 'bootsnap', require: false
 # Rollbar-gem is the SDK for Ruby apps and includes support for apps using
 # Rails, Sinatra, Rack, plain Ruby, and other frameworks.
 # https://github.com/rollbar/rollbar-gem
-gem 'rollbar', group: :rollbar, require: false
+gem 'rollbar'
 
 # ======== #
 # DATABASE #

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,7 +309,7 @@ GEM
     msgpack (1.7.2)
     multi_json (1.15.0)
     multi_xml (0.6.0)
-    mysql2 (0.5.5)
+    mysql2 (0.5.6)
     nap (1.1.0)
     nenv (0.3.0)
     nio4r (2.7.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -172,7 +172,7 @@ class ApplicationController < ActionController::Base
   end
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:accept_invitation, keys: %i[firstname surname org_id])
+    devise_parameter_sanitizer.permit(:accept_invitation, keys: %i[firstname surname org_id accept_terms])
   end
 
   def render_not_found(exception)

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -64,7 +64,7 @@ class TemplateOptionsController < ApplicationController
       # We want the default template to appear at the beggining of the list
       @templates.unshift(customization)
     end
-    @templates.uniq
+    @templates = @templates.uniq
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
   # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -28,7 +28,7 @@ class TemplateOptionsController < ApplicationController
     if org.present? && !org.new_record?
       # Load the funder's template(s) minus the default template (that gets swapped
       # in below if NO other templates are available)
-      @templates = Template.latest_customizable.where(org_id: funder.id, is_default: false).to_a
+      @templates = Template.latest_customizable.where(org_id: funder.id, is_default: false).sort_by(&:title).to_a
       # Swap out any organisational cusotmizations of a funder template
       @templates = @templates.map do |tmplt|
         customization = Template.published
@@ -47,7 +47,7 @@ class TemplateOptionsController < ApplicationController
       # If the no funder was specified OR the funder matches the org
       # if funder.blank? || funder.id == org&.id
       # Retrieve the Org's templates
-      @templates << Template.published.organisationally_visible.where(org_id: org.id, customization_of: nil).to_a
+      @templates << Template.published.organisationally_visible.where(org_id: org.id, customization_of: nil).sort_by(&:title).to_a
       @templates = @templates.flatten.uniq
     else
       # if'No Primary Research Institution' checkbox is checked,
@@ -65,7 +65,7 @@ class TemplateOptionsController < ApplicationController
       # We want the default template to appear at the beggining of the list
       @templates.unshift(customization)
     end
-    @templates = @templates.uniq.sort_by(&:title)
+    @templates.uniq
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
   # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -47,7 +47,8 @@ class TemplateOptionsController < ApplicationController
       # If the no funder was specified OR the funder matches the org
       # if funder.blank? || funder.id == org&.id
       # Retrieve the Org's templates
-      @templates << Template.published.organisationally_visible.where(org_id: org.id, customization_of: nil).sort_by(&:title).to_a
+      @templates << Template.published.organisationally_visible.where(org_id: org.id,
+                                                                      customization_of: nil).sort_by(&:title).to_a
       @templates = @templates.flatten.uniq
     else
       # if'No Primary Research Institution' checkbox is checked,

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -18,12 +18,10 @@ class TemplateOptionsController < ApplicationController
 
     org = org_from_params(params_in: { org_id: org_hash.to_json }) if org_hash.present?
     funder = Org.find_by(name: Rails.application.config.default_funder_name)
-    # funder = org_from_params(params_in: { org_id: funder_hash.to_json }) if funder_hash.present?
 
     @templates = []
 
     return unless (org.present? && !org.new_record?) || (funder.present? && !funder.new_record?)
-    return unless funder.present? && !funder.new_record?
 
     if org.present? && !org.new_record?
       # Load the funder's template(s) minus the default template (that gets swapped

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -40,7 +40,7 @@
       <div class="form-group">
         <div class="checkbox">
           <%= f.label(:accept_terms) do %>
-            <%= f.check_box(:accept_terms, "aria-required": true) %>
+            <%= f.check_box(:accept_terms, "aria-required": true, required: true) %>
             <%= _('I accept the') %>
             <%= link_to _('terms and conditions'), terms_of_use_path %>
           <% end %>

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -37,6 +37,15 @@
                      required: true
                    } %>
       </div>
+      <div class="form-group">
+        <div class="checkbox">
+          <%= f.label(:accept_terms) do %>
+            <%= f.check_box(:accept_terms, "aria-required": true) %>
+            <%= _('I accept the') %>
+            <%= link_to _('terms and conditions'), terms_of_use_path %>
+          <% end %>
+        </div>
+      </div>
       <%= f.button(_('Create account'), class: "btn btn-default", type: "submit") %>
     <% end %>
   </div>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -121,10 +121,9 @@ RSpec.configure do |config|
 
       # Allow Capybara to make localhost requests and also contact the
       # google api chromedriver store
-      # add googlechromelabs.github.io and edgedl.me.gvt1.com to work with Chrome v116+
       WebMock.disable_net_connect!(
         allow_localhost: true,
-        allow: %w[chromedriver.storage.googleapis.com googlechromelabs.github.io edgedl.me.gvt1.com]
+        allow: %w[storage.googleapis.com googlechromelabs.github.io]
       )
     end
 


### PR DESCRIPTION
As specified by the updated CHANGELOG.md, this merge includes the following code changes:

### Added

 - Bump mysql2 from 0.5.5 to 0.5.6 [#645](https://github.com/portagenetwork/roadmap/pull/645)

- Added "Accept terms and conditions" checkbox to invitation form [#684](https://github.com/portagenetwork/roadmap/pull/684)

### Fixed

 - Updated Webmock's allowed request list to enable fetching of chromedriver [#670](https://github.com/portagenetwork/roadmap/pull/670)

 - Edit Gemfile config for 'rollbar' to enable app tracking on rollbar.com [#687](https://github.com/portagenetwork/roadmap/pull/687)

 - Fxed ordering of templates within the "Create a new plan" template dropdown [#706](https://github.com/portagenetwork/roadmap/pull/706)