### PR TITLE
Fix to the Share Email notifications when User Name  is not updated

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -52,7 +52,8 @@ class UserMailer < ActionMailer::Base
     @role       = role
     @user       = user
     @user_email = @user.email
-    @username   = @user.name
+    @username   = @user.name(false)
+    @resource_name = (@username.nil? || @username == "First Name Surname") ? @user_email : @username
     @inviter    = inviter
     @link       = url_for(action: 'show', controller: 'plans', id: @role.plan.id)
     @helpdesk_email = helpdesk_email(org: @inviter.org)

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -3,7 +3,8 @@
   link = accept_invitation_url(@resource, :invitation_token => @token)
   contact_us = (Rails.configuration.x.organisation.contact_us_url || contact_us_url)
   email_subject = _('Query or feedback related to %{tool_name}') %{ :tool_name => tool_name }
-  user_name = User.find_by(email: @resource.email).nil? ?  @resource.email : User.find_by(email: @resource.email).name(false)
+  user_name = @username.nil? ? @resource.email : @username 
+  #= User.find_by(email: @resource.email).nil? ?  @resource.email : User.find_by(email: @resource.email).name(false)
   inviter =  @resource.invited_by
   inviter_name = inviter.name
   helpdesk_email = inviter.org&.helpdesk_email ||

--- a/app/views/user_mailer/sharing_notification.html.erb
+++ b/app/views/user_mailer/sharing_notification.html.erb
@@ -1,5 +1,5 @@
 <p>
-  <%= _('Hello %{username}') %{ username: @username } %>
+  <%= _('Hello %{username}') %{ username: @resource_name } %>
 </p>
 <p>
   <%= _("Your colleague %{inviter_name} has invited you to contribute to


### PR DESCRIPTION
Fixes # [701](https://github.com/portagenetwork/roadmap/issues/701).

Changes proposed in this PR:
- When adding a collaborator to a plan, the added email may or may not already exist in the db. When it does not, the sent email greets the recipient with the message Hello First Name Surname 

