### PR TITLE
Handle Ordering of Templates When "No research organization" Box is Checked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
  - Edit Gemfile config for 'rollbar' to enable app tracking on rollbar.com [#687](https://github.com/portagenetwork/roadmap/pull/687)
 
- - Fxed ordering of templates within the "Create a new plan" template dropdown [#706](https://github.com/portagenetwork/roadmap/pull/706)
+ - Fixed ordering of templates within the "Create a new plan" template dropdown [#706](https://github.com/portagenetwork/roadmap/pull/706) and [#718](https://github.com/portagenetwork/roadmap/pull/718)
 
 ## [4.0.2+portage-4.0.0] - 2024-02-01
 

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -51,7 +51,9 @@ class TemplateOptionsController < ApplicationController
     else
       # if'No Primary Research Institution' checkbox is checked,
       # only show publicly available template without customization
-      @templates = Template.published.publicly_visible.where(org_id: funder.id, customization_of: nil)
+      @templates << Template.default if Template.default.present?
+      @templates << Template.published.publicly_visible.where(org_id: funder.id, customization_of: nil, is_default: false).sort_by(&:title).to_a
+      @templates = @templates.flatten.uniq
     end
     # DMP Assistant: We do not want to include not customized templates from default funder
     # Include customizable funder templates

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -47,14 +47,14 @@ class TemplateOptionsController < ApplicationController
       # Retrieve the Org's templates
       @templates << Template.published.organisationally_visible.where(org_id: org.id,
                                                                       customization_of: nil).sort_by(&:title).to_a
-      @templates = @templates.flatten.uniq
     else
       # if'No Primary Research Institution' checkbox is checked,
       # only show publicly available template without customization
       @templates << Template.default if Template.default.present?
-      @templates << Template.published.publicly_visible.where(org_id: funder.id, customization_of: nil, is_default: false).sort_by(&:title).to_a
-      @templates = @templates.flatten.uniq
+      @templates << Template.published.publicly_visible.where(org_id: funder.id, customization_of: nil,
+                                                              is_default: false).sort_by(&:title).to_a
     end
+    @templates = @templates.flatten
     # DMP Assistant: We do not want to include not customized templates from default funder
     # Include customizable funder templates
     # @templates << funder_templates = Template.latest_customizable


### PR DESCRIPTION
Fixes #685
 - #685

Changes proposed in this PR:
- https://github.com/portagenetwork/roadmap/pull/706 partly addressed #685. However, it did not account for when the "No research organization associated with this plan or my research organization is not listed" box is checked. This PR handles that extra case.
