### PR TITLE
Update translation gem git: url in Gemfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+ - Updated 'translation' gem URL in Gemfile to match moved repository [#725](https://github.com/portagenetwork/roadmap/pull/725)
+
 ## [4.0.2+portage-4.0.3] - 2024-04-11
 
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -205,7 +205,7 @@ gem 'htmltoword'
 # INTERNATIONALIZATION #
 # ==================== #
 
-gem 'translation', git: 'https://github.com/lagoan/translation_io_rails',
+gem 'translation', git: 'https://github.com/ualbertalib/translation_io_rails',
                    branch: 'fix/broken_db_fake_method_calls'
 
 # ========= #

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: https://github.com/lagoan/translation_io_rails
+  remote: https://github.com/ualbertalib/translation_io_rails
   revision: 6fbb2cd619e7bf01b37b9b8916b0f345899f876b
   branch: fix/broken_db_fake_method_calls
   specs:
@@ -286,7 +286,7 @@ GEM
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    locale (2.1.3)
+    locale (2.1.4)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)


### PR DESCRIPTION
`bundle install` was executed after the Gemfile update.

Fixes #724
- #724

Changes proposed in this PR:
- Update translation gem git: url in Gemfile. The updated url corresponds with the changed location of our fork of the translation repository.
- Execute `bundle install after updating Gemfile.
