### PR TITLE
Add Wildcard Route to Prevent ActionController::RoutingError

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,6 +22,12 @@ class ApplicationController < ActionController::Base
   # When we are in production reroute Record Not Found errors to the branded 404 page
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
 
+  def route_not_found
+    msg = "404 Error: [#{request.method}] \"#{request.path}\" was not found."
+    Rails.logger.warn msg
+    render file: Rails.public_path.join('404.html'), status: :not_found, layout: false
+  end
+
   private
 
   def current_org

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -379,5 +379,8 @@ Rails.application.routes.draw do
   get 'research_projects/(:type)', action: 'index',
                                    controller: 'research_projects',
                                    constraints: { format: 'json' }
+
+  # Wildcard route for anything not defined above (prevents ActionController::RoutingError)
+  match '*unmatched_route', to: 'application#route_not_found', via: :all
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
Fixes #727
- #727

Changes proposed in this PR:
- This fix comes from the following link: https://rollbar.com/blog/ruby-on-rails-routingerror/

According to https://stackoverflow.com/a/37174557/17842948, "The ActionController::RoutingError is raised when Rails tries to match the request with a route. This happens before Rails even initializes a controller - thus your ApplicationController never has a chance to rescue the exception."

This fix prevents the ActionController::RoutingError by adding a catch-all/wildcard route to config/routes.rb.
