### PR TITLE
Add pdf handling in render_respond_to_format_with_error_message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
  - Enable Translation of QuestionOption.text (and Refactor Translation of ResearchDomain.label) [#742](https://github.com/portagenetwork/roadmap/pull/742)
 
+### Fixed
+
+ - Add .pdf handling in render_respond_to_format_with_error_message [#731](https://github.com/portagenetwork/roadmap/pull/731)
+
 ### Changed
 
  - Deactivate Requests to External ROR API [#738](https://github.com/portagenetwork/roadmap/pull/738)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -186,7 +186,7 @@ class ApplicationController < ActionController::Base
 
     respond_to do |format|
       # Redirect use to the path and display the error message
-      format.html { redirect_to url_or_path, alert: msg }
+      format.any(:html, :pdf) { redirect_to url_or_path, alert: msg }
       # Render the JSON error message (using API V1)
       format.json do
         @payload = { errors: [msg] }


### PR DESCRIPTION
Fixes #729

- #729

Changes proposed in this PR:
- `render_respond_to_format_with_error_message` is called both when rescuing from Pundit::NotAuthorizedError and ActiveRecord::RecordNotFound. The method works properly with .html format, but prior to this change, ActionController::UnknownFormat was thrown for .pdf format.

