### PR TITLE
Prevent  '%{org_title} Plans' Section From Displaying Plans Created by Users From Other Organisations

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -186,7 +186,7 @@ class ApplicationController < ActionController::Base
 
     respond_to do |format|
       # Redirect use to the path and display the error message
-      format.html { redirect_to url_or_path, alert: msg }
+      format.any(:html, :pdf) { redirect_to url_or_path, alert: msg }
       # Render the JSON error message (using API V1)
       format.json do
         @payload = { errors: [msg] }

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -166,9 +166,11 @@ class Plan < ApplicationRecord
 
   # Retrieves any plan organisationally or publicly visible for a given org id
   scope :organisationally_or_publicly_visible, lambda { |user|
-    plan_ids = user.org.org_admin_plans.where(complete: true).pluck(:id).uniq
+    org_users_ids = user.org.users.where(active: true).pluck(:id)
+    plan_ids = Role.creator.where(user_id: org_users_ids, active: true).pluck(:plan_id)
     includes(:template, roles: :user)
-      .where(id: plan_ids, visibility: [
+      .where(id: plan_ids, complete: true,
+             visibility: [
                visibilities[:organisationally_visible],
                visibilities[:publicly_visible]
              ])


### PR DESCRIPTION
Fixes #729 
Fixes #732

Changes proposed in this PR:
- Edit `Plan.organisationally_or_publicly_visible(user)` scope to fix #732
  - This DMP Assistant fix was implemented in a way to minimise conflicts with the upstream, DMPRoadmap repo. This issue also exists in the upstream repo, so this commit will be readdressed after a fix is implemented there.

- Add pdf handling in `render_respond_to_format_with_error_message` to fix #729