### PR TITLE
Deactivate Requests to External ROR API 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+ - Deactivate Requests to External ROR API [#738](https://github.com/portagenetwork/roadmap/pull/738)
+
  - Updated 'translation' gem URL in Gemfile to match moved repository [#725](https://github.com/portagenetwork/roadmap/pull/725)
 
 ## [4.0.2+portage-4.0.3] - 2024-04-11

--- a/config/initializers/external_apis/ror.rb
+++ b/config/initializers/external_apis/ror.rb
@@ -11,4 +11,4 @@ Rails.configuration.x.ror.search_path = "organizations"
 Rails.configuration.x.ror.max_pages = 2
 Rails.configuration.x.ror.max_results_per_page = 20
 Rails.configuration.x.ror.max_redirects = 3
-Rails.configuration.x.ror.active = true
+Rails.configuration.x.ror.active = false

--- a/spec/services/external_apis/ror_service_spec.rb
+++ b/spec/services/external_apis/ror_service_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe ExternalApis::RorService do
+  Rails.configuration.x.ror.active = true # Override actual config value for duration of tests
   describe '#ping' do
     before(:each) do
       @headers = described_class.headers


### PR DESCRIPTION
Changes proposed in this PR:
- Deactivate External Requests to ROR API
  - Requests to `https://api.ror.org/` are used for fetching organisations that may not already exist within the local db. At this time, DMP Assistant is limiting organisations to only those that exist within the local db. (New organisations are currently only created manually by DMP super admins).
  - The app is meant to handle the toggling of this config value. Setting `Rails.configuration.x.ror.active = false` as we did here should limit searching to only the local db (to verify this handling, see `app/services/org_selection/search_service.rb`).

- Override `Rails.configuration.x.ror.active` to true for duration of `ExternalApis::RorService` RSpect tests.
  - Without this change, setting `Rails.configuration.x.ror.active = false` in `config/initializers/external_apis/ror.rb` breaks many of the `ExternalApis::RorService` RSpect tests.