### PR TITLE
Increase Width of Research Outputs File Size Unit Dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
  - Updated 'translation' gem URL in Gemfile to match moved repository [#725](https://github.com/portagenetwork/roadmap/pull/725)
 
+ - Increased the width of the research outputs file size unit dropdown [#741](https://github.com/portagenetwork/roadmap/pull/741)
+
 ## [4.0.2+portage-4.0.3] - 2024-04-11
 
 ### Added

--- a/app/views/research_outputs/_form.html.erb
+++ b/app/views/research_outputs/_form.html.erb
@@ -163,7 +163,7 @@ repository_tooltip = _("Repositories preserve, manage, and provide access to man
         <% file_size = presenter.converted_file_size(size: f.object.byte_size) %>
         <%= f.number_field "file_size", min: 1, step: 0.1, value: file_size[:size], class: "form-control", aria: { label: _("Anticipated file size") } %>
       </span>
-      <span class="col-md-1">
+      <span class="col-md-2">
         <%= f.select "file_size_unit", options_for_select(presenter.selectable_size_units, file_size[:unit]),
                                        { selected: file_size[:unit] },
                                        { class: "form-control float-left",


### PR DESCRIPTION
Fixes #739

Changes proposed in this PR:
- Increases the width of the `file_size_unit` dropdown to ensure that all of its options are fully visible.
