### PR TITLE
Enable Translation of QuestionOption.text (and Refactor Translation of ResearchDomain.label)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+ - Enable Translation of QuestionOption.text (and Refactor Translation of ResearchDomain.label) [#742](https://github.com/portagenetwork/roadmap/pull/742)
+
 ### Changed
 
  - Deactivate Requests to External ROR API [#738](https://github.com/portagenetwork/roadmap/pull/738)

--- a/app/models/concerns/exportable_plan.rb
+++ b/app/models/concerns/exportable_plan.rb
@@ -238,7 +238,7 @@ module ExportablePlan
       answer = self.answer(question[:id], false)
       answer_text = ''
       if answer.present?
-        answer_text += answer.question_options.pluck(:text).join(', ') if answer.question_options.any?
+        answer_text += answer.question_options.pluck(:text).map { |x| _(x) }.join(', ') if answer.question_options.any?
         answer_text += answer.text if answer.answered? && answer.text.present?
       elsif unanswered
         answer_text += _('Not Answered')

--- a/app/models/question_option.rb
+++ b/app/models/question_option.rb
@@ -74,6 +74,12 @@ class QuestionOption < ApplicationRecord
   # = Public instance methods =
   # ===========================
 
+  # text is translated through the translation gem
+  def text
+    text = read_attribute(:text)
+    _(text) unless text.blank?
+  end
+
   def deep_copy(**options)
     copy = dup
     copy.question_id = options.fetch(:question_id, nil)

--- a/app/models/research_domain.rb
+++ b/app/models/research_domain.rb
@@ -29,4 +29,14 @@ class ResearchDomain < ApplicationRecord
   # Self join
   has_many :sub_fields, class_name: 'ResearchDomain', foreign_key: 'parent_id'
   belongs_to :parent, class_name: 'ResearchDomain', optional: true
+
+  # ===========================
+  # = Public instance methods =
+  # ===========================
+
+  # label is translated through the translation gem
+  def label
+    label = read_attribute(:label)
+    _(label) unless label.blank?
+  end
 end

--- a/app/views/plans/_project_details.html.erb
+++ b/app/views/plans/_project_details.html.erb
@@ -47,7 +47,7 @@ ethics_report_tooltip = _("Link to a protocol from a meeting with an ethics comm
     <div class="col-md-8">
       <%= form.label(:research_domain_id, _("Research domain"), class: "control-label") %>
 
-      <% options = research_domains.map { |rd| [_(rd.label), rd.id] } %> <%# rd.label is sync'd to translation.io via config.db_fields %>
+      <% options = research_domains.map { |rd| [rd.label, rd.id] } %>
       <%= form.select :research_domain_id, options_for_select(options, form.object.research_domain_id),
                             {
                               include_blank: _("- Please select one -"),

--- a/config/initializers/translation.rb
+++ b/config/initializers/translation.rb
@@ -37,7 +37,8 @@ TranslationIO.configure do |config|
     'Section' => %w[title description],
     'Question' => %w[text default_value],
     'Annotation' => ['text'],
-    'ResearchDomain' => ['label']
+    'ResearchDomain' => ['label'],
+    'QuestionOption' => ['text']
   }
   # Find other useful usage information here:
   # https://github.com/translation/rails#readme


### PR DESCRIPTION
Fixes #537
 - #537
 
Changes proposed in this PR:
- Enable translation of QuestionOption.text throughout the app.
- Refactor translation of ResearchDomain.label
  - NOTE: The ResearchDomain.label translation was already enabled. However, the approach taken in this refactor is more consistent with the rest of the codebase.