### PR TITLE
feat(translation)!: migrate TranslationIO config to `db_query_procs`

### DIFF
--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -216,13 +216,26 @@ class Template < ApplicationRecord
   }
 
   scope :for_api_v2, lambda { |org_id|
-    org_templates = organisationally_visible.where(org_id: org_id)
-    public_templates = publicly_visible.where(customization_of: nil)
-    includes(org: { identifiers: :identifier_scheme }, phases: { sections: :questions })
-      .joins(:org)
-      .published
-      .merge(org_templates.or(public_templates))
-      .order(:title)
+                       org_templates = organisationally_visible.where(org_id: org_id)
+                       public_templates = publicly_visible.where(customization_of: nil)
+                       includes(org: { identifiers: :identifier_scheme }, phases: { sections: :questions })
+                         .joins(:org)
+                         .published
+                         .merge(org_templates.or(public_templates))
+                         .order(:title)
+                     }
+
+  # For DMP Assistant's customisation of the `translation` gem
+  scope :for_translation_sync, lambda {
+    includes(phases: { sections: { questions: %i[annotations question_options] } })
+      .where(org_id: Rails.application.secrets.default_funder_id, published: true)
+      .pluck(:title, :description,
+             'phases.title', 'phases.description',
+             'sections.title', 'sections.description',
+             'questions.text', 'questions.default_value',
+             'annotations.text',
+             'question_options.text')
+      .flatten.uniq
   }
 
   # defines the export setting for a template object

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -215,6 +215,22 @@ class Template < ApplicationRecord
              term: "%#{term}%")
   }
 
+  # (For DMP Assistant's customisation of the `translation` gem)
+  # Plucks Template-associated columns (filtered by default_funder)
+  # for syncing to translation.io, enabling in-app translations.
+  scope :translation_sync_data, lambda {
+    includes(phases: { sections: { questions: %i[annotations question_options] } })
+      # Filter by default_funder_id
+      .where(org_id: Rails.application.secrets.default_funder_id)
+      .pluck(:title, :description,
+             'phases.title', 'phases.description',
+             'sections.title', 'sections.description',
+             'questions.text', 'questions.default_value',
+             'annotations.text',
+             'question_options.text')
+      .flatten.uniq
+  }
+
   # defines the export setting for a template object
   has_settings :export, class_name: 'Settings::Template' do |s|
     s.key :export, defaults: Settings::Template::DEFAULT_SETTINGS

--- a/config/initializers/translation.rb
+++ b/config/initializers/translation.rb
@@ -31,17 +31,12 @@ TranslationIO.configure do |config|
   config.locales_path = File.join('config', 'locale')
 
   unless Rails.env.in?(%w[test development uat])
-    config.db_fields = {
-      'Theme' => %w[title description],
-      'QuestionFormat' => %w[title description],
-      'Template' => %w[title description],
-      'Phase' => %w[title description],
-      'Section' => %w[title description],
-      'Question' => %w[text default_value],
-      'Annotation' => ['text'],
-      'ResearchDomain' => ['label'],
-      'QuestionOption' => ['text']
-    }
+    config.db_query_procs = [
+      proc { Theme.pluck(:title, :description).flatten.uniq },
+      proc { QuestionFormat.pluck(:title, :description).flatten.uniq },
+      proc { ResearchDomain.pluck(:label) },
+      proc { Template.for_translation_sync }
+    ]
   end
   # Find other useful usage information here:
   # https://github.com/translation/rails#readme

--- a/config/initializers/translation.rb
+++ b/config/initializers/translation.rb
@@ -31,17 +31,12 @@ TranslationIO.configure do |config|
   config.locales_path = File.join('config', 'locale')
 
   unless Rails.env.in?(%w[test development uat])
-    config.db_fields = {
-      'Theme' => %w[title description],
-      'QuestionFormat' => %w[title description],
-      'Template' => %w[title description],
-      'Phase' => %w[title description],
-      'Section' => %w[title description],
-      'Question' => %w[text default_value],
-      'Annotation' => ['text'],
-      'ResearchDomain' => ['label'],
-      'QuestionOption' => ['text']
-    }
+    config.db_query_procs = [
+      proc { Theme.pluck(:title, :description).flatten.uniq },
+      proc { QuestionFormat.pluck(:title, :description).flatten.uniq },
+      proc { ResearchDomain.pluck(:label) },
+      proc { Template.translation_sync_data }
+    ]
   end
   # Find other useful usage information here:
   # https://github.com/translation/rails#readme

--- a/spec/models/template_spec.rb
+++ b/spec/models/template_spec.rb
@@ -53,6 +53,101 @@ RSpec.describe Template, type: :model do
     it { is_expected.to have_many :annotations }
   end
 
+  describe '.for_translation_sync' do
+    subject(:translation_strings) { Template.for_translation_sync }
+
+    let(:default_funder) { create(:org, :funder) }
+    let(:other_org) { create(:org) }
+
+    before do
+      Rails.application.secrets.stubs(:default_funder_id).returns(default_funder.id)
+    end
+
+    context 'when the template belongs to the default funder and is published' do
+      let!(:template) do
+        create(:template,
+               org: default_funder,
+               published: true,
+               title: 'Template title',
+               description: 'Template description')
+      end
+
+      let!(:phase) do
+        create(:phase,
+               template: template,
+               title: 'Phase title',
+               description: 'Phase description')
+      end
+
+      let!(:section) do
+        create(:section,
+               phase: phase,
+               title: 'Section title',
+               description: 'Section description')
+      end
+
+      let!(:question) do
+        create(:question,
+               section: section,
+               text: 'Question text',
+               default_value: 'Question default value')
+      end
+
+      let!(:annotation) do
+        create(:annotation,
+               question: question,
+               org: default_funder,
+               text: 'Annotation text')
+      end
+
+      let!(:question_option) do
+        create(:question_option,
+               question: question,
+               text: 'Option text')
+      end
+
+      it 'returns template and nested translation strings' do
+        expect(translation_strings).to match_array(
+          [
+            template.title, template.description,
+            phase.title, phase.description,
+            section.title, section.description,
+            question.text, question.default_value,
+            annotation.text,
+            question_option.text
+          ]
+        )
+      end
+    end
+
+    context 'when the template is unpublished or belongs to another org' do
+      let!(:published_other_template) do
+        create(:template,
+               org: other_org,
+               published: true,
+               title: 'Other org title',
+               description: 'Other org description')
+      end
+
+      let!(:unpublished_default_funder_template) do
+        create(:template,
+               org: default_funder,
+               published: false,
+               title: 'Unpublished title',
+               description: 'Unpublished description')
+      end
+
+      it 'does not include their strings' do
+        expect(translation_strings).not_to include(
+          published_other_template.title,
+          published_other_template.description,
+          unpublished_default_funder_template.title,
+          unpublished_default_funder_template.description
+        )
+      end
+    end
+  end
+
   describe '.archived' do
     subject { Template.archived }
 


### PR DESCRIPTION
⚠️ Breaking change: These changes will also require updates to our custom TranslationIO gem (https://github.com/ualbertalib/translation_io_rails) (e.g., DumpDBTextKeysStep).

Fixes #553

# Changes proposed in this PR

## Add `Template.for_translation_sync` scope

Add a new `Template.for_translation_sync` scope to support DMP Assistant's customization of the TranslationIO gem.

This scope collects translation strings from published templates belonging to the default funder organization, including associated `phases`, `sections`, `questions`, `annotations`, and `question_options`.

The returned data is used by TranslationIO to synchronize database-backed strings for in-app translations.

## Migrate `TranslationIO.config.db_fields` to `config.db_query_procs`

Update the TranslationIO configuration from a `db_fields` hash to a `db_query_procs` proc array.

This replaces static model/field mappings with query-based translation sources:

- `Theme`:
  ```ruby
  proc { Theme.pluck(:title, :description).flatten.uniq }
  ```
- `QuestionFormat`
  ```ruby
  proc { QuestionFormat.pluck(:title, :description).flatten.uniq }
  ```
- `ResearchDomain`:
  ```ruby
  proc { ResearchDomain.pluck(:label) }
  ```
- `Template-related translations:`
  ```ruby
  proc { Template.for_translation_sync }
  ```

`Template.for_translation_sync` replaces the previous individual mappings:
- `'Template' => %w[title description]`
- `'Phase' => %w[title description]`
- `'Section' => %w[title description]`
- `'Question' => %w[text default_value]`
- `'Annotation' => ['text']`
- `'QuestionOption' => ['text']`


# Performance notes
Measured `translation:sync` execution time before and after this change:
Branch | Real time | User time | Sys time
-- | -- | -- | --
integration (before) | 3m 11.062s | 2m 47.294s | 1.039s
aaron/issues/553 (after) | 2m 51.611s | 2m 42.557s | 1.016s