### PR TITLE
Bump docker db image to postgres:15-alpine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 
  - Bump webmock from 3.19.1 to 3.23.1 [#762](https://github.com/portagenetwork/roadmap/pull/762)
  
+ - Bump docker db image from postgres:12.14 to postgres:15-alpine [#749](https://github.com/portagenetwork/roadmap/pull/749) 
+ 
 ## V4.1.1
 
 ### Added

--- a/docker-compose-development.yml
+++ b/docker-compose-development.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   db:
-    image: postgres:12.14
+    image: postgres:15-alpine
     volumes:
       - db_volume:/var/lib/postgresql/data
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - db
 
   db:
-    image: postgres:12.14
+    image: postgres:15-alpine
     volumes:
       - db_volume:/var/lib/mysql
     env_file:


### PR DESCRIPTION
Changes proposed in this PR:
- This commit is being made to match the Postgres version with that of DMP Assistant's production environment, which is set to upgrade to v15.