### PR TITLE
DMP Ass't PATCH template customisation logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [4.0.2+portage-4.0.4] - 2024-05-15
+
+### Fixed
+
+ - Fixed an issue that was preventing users from accessing some customisable templates [#751](https://github.com/portagenetwork/roadmap/pull/751)
+
 ## [4.0.2+portage-4.0.3] - 2024-04-11
 
 ### Added

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -351,7 +351,7 @@ class Template < ApplicationRecord
   # Determines whether or not a customization for the customizing_org passed
   # should be generated
   def customize?(customizing_org)
-    if customizing_org.is_a?(Org) && (org.funder_only? || is_default)
+    if customizing_org.is_a?(Org) && (org.funder? || is_default)
       return !Template.unarchived.where(customization_of: family_id,
                                         org: customizing_org).exists?
     end
@@ -416,7 +416,7 @@ class Template < ApplicationRecord
     raise ArgumentError, _('customize! requires an organisation target') unless customizing_org.is_a?(Org)
 
     # Assume self has org associated
-    raise ArgumentError, _('customize! requires a template from a funder') if !org.funder_only? && !is_default
+    raise ArgumentError, _('customize! requires a template from a funder') if !org.funder? && !is_default
 
     deep_copy(
       attributes: {


### PR DESCRIPTION
Fixes #755

Changes proposed in this PR:
- Updated the logic that was preventing some templates within `org_admin/templates/customisable` from being accessed.
   - Prior to this change, for a customizable template to be accessed by a user, either `template.org.funder_only?` or `template.default` had to be true.
   - This PR changes this check from `template.org.funder_only?` to `template.funder?`. As a result, rather than having `template.org.org_type` be exclusively funder, it now only has to include `funder` as one of its types.
   - This change is especially important for the default org in DMP Assistant. That is because it has both `funder` and `institution` as its org_type, and also because template.org is the default org for all of DMP Assistant's customizable templates.