### PR TITLE
DMP Ass't PATCH template customisation logic For Default Org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [4.0.2+portage-4.0.4] - 2024-05-15
+
+### Fixed
+
+ - Fixed an issue that was preventing users from accessing some customisable templates [#753](https://github.com/portagenetwork/roadmap/pull/753)
+
 ## [4.0.2+portage-4.0.3] - 2024-04-11
 
 ### Added

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -351,7 +351,7 @@ class Template < ApplicationRecord
   # Determines whether or not a customization for the customizing_org passed
   # should be generated
   def customize?(customizing_org)
-    if customizing_org.is_a?(Org) && (org.funder_only? || is_default)
+    if customizing_org.is_a?(Org) && (org.funder_only? || is_default || org == Org.default_orgs.first)
       return !Template.unarchived.where(customization_of: family_id,
                                         org: customizing_org).exists?
     end
@@ -416,7 +416,7 @@ class Template < ApplicationRecord
     raise ArgumentError, _('customize! requires an organisation target') unless customizing_org.is_a?(Org)
 
     # Assume self has org associated
-    raise ArgumentError, _('customize! requires a template from a funder') if !org.funder_only? && !is_default
+    raise ArgumentError, _('customize! requires a template from a funder') if !org.funder_only? && !is_default && (org != Org.default_orgs.first)
 
     deep_copy(
       attributes: {

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -411,12 +411,15 @@ class Template < ApplicationRecord
   end
 
   # Generates a new copy of self for the specified customizing_org
-  def customize!(customizing_org)
+  def customize!(customizing_org) # rubocop:disable Metrics/AbcSize
     # Assume customizing_org is persisted
     raise ArgumentError, _('customize! requires an organisation target') unless customizing_org.is_a?(Org)
 
     # Assume self has org associated
-    raise ArgumentError, _('customize! requires a template from a funder') if !org.funder_only? && !is_default && (org != Org.default_orgs.first)
+    if !org.funder_only? && !is_default && (org != Org.default_orgs.first)
+      raise ArgumentError,
+            _('customize! requires a template from a funder')
+    end
 
     deep_copy(
       attributes: {


### PR DESCRIPTION
This PR seeks to address the issue with users being unable to select some customizable templates.

The main problem appeared to be that the logic used to determine whether or not a customization be generated enforced the check org.funder_only? where org == Template.org. This is an issue for DMP Assistant because many of these customizable templates come from the app's default org which is BOTH a funder AND an institution.

This patch allows the default org public templates to be generated in the customizable templates section.