### PR TITLE
Merge `4.0.2+portage-4.0.4` Changes into "integration"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [4.0.2+portage-4.0.4] - 2024-05-15
+
+### Fixed
+
+ - Fixed an issue that was preventing users from accessing some customisable templates [#751](https://github.com/portagenetwork/roadmap/pull/751)
+
 ## [4.0.2+portage-4.0.3] - 2024-04-11
 
 ### Added

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -351,7 +351,7 @@ class Template < ApplicationRecord
   # Determines whether or not a customization for the customizing_org passed
   # should be generated
   def customize?(customizing_org)
-    if customizing_org.is_a?(Org) && (org.funder_only? || is_default)
+    if customizing_org.is_a?(Org) && (org.funder? || is_default)
       return !Template.unarchived.where(customization_of: family_id,
                                         org: customizing_org).exists?
     end
@@ -416,7 +416,7 @@ class Template < ApplicationRecord
     raise ArgumentError, _('customize! requires an organisation target') unless customizing_org.is_a?(Org)
 
     # Assume self has org associated
-    raise ArgumentError, _('customize! requires a template from a funder') if !org.funder_only? && !is_default
+    raise ArgumentError, _('customize! requires a template from a funder') if !org.funder? && !is_default
 
     deep_copy(
       attributes: {


### PR DESCRIPTION
Changes proposed in this PR:
- Release `4.0.2+portage-4.0.4` was a hotfix, and thus, the changes do not exist on the "integration" branch. This PR merges those missing changes into "integration".
