### PR TITLE
Enable "Download Monthly Usage" Download Functionality For "Portage Network"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Changed
 
+ - Enabled "Download Monthly Usage" Functionality For "Portage Network" [#761](https://github.com/portagenetwork/roadmap/pull/761)
+
  - Deactivate Requests to External ROR API [#738](https://github.com/portagenetwork/roadmap/pull/738)
 
  - Updated 'translation' gem URL in Gemfile to match moved repository [#725](https://github.com/portagenetwork/roadmap/pull/725)

--- a/app/views/usage/_total_usage.html.erb
+++ b/app/views/usage/_total_usage.html.erb
@@ -38,11 +38,9 @@
       <% end %>
     </div>
   <% end %>
-  <% unless @funder.present? %>
     <div class="col-md-3">
       <%= link_to usage_org_statistics_path(sep: ",", filtered: @filtered), class: 'stat btn btn-default pull-right', role: 'button', target: '_blank' do %>
         <%= _('Download Monthly Usage') %> <i class="fas fa-download" aria-hidden="true"></i>
       <% end %>
     </div>
-  <% end %>
 </div>


### PR DESCRIPTION
Fixes #722 

Changes proposed in this PR:
- `app/controllers/usage_controller.rb` includes the following assignment: `@funder = current_user.org.funder?`. But "Portage Network" is the only org within DMP Assistant such that `org.funder? == true`. This PR re-enables the 'Download Monthly Usage' functionality for Portage Network.