### PR TITLE
Set licence_key in TinyMCE config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+ - Set `licence_key` in TinyMCE config [#792](https://github.com/portagenetwork/roadmap/pull/792)
+
  - Add .pdf handling in render_respond_to_format_with_error_message [#731](https://github.com/portagenetwork/roadmap/pull/731)
 
  - Fixed handling of Template.visibility in some places [#759](https://github.com/portagenetwork/roadmap/pull/759)

--- a/app/javascript/src/utils/tinymce.js
+++ b/app/javascript/src/utils/tinymce.js
@@ -24,6 +24,7 @@ import { isObject, isString, isUndefined } from './isType';
 // // https://www.tinymce.com/docs/advanced/usage-with-module-loaders/
 export const defaultOptions = {
   selector: '.tinymce',
+  license_key: 'gpl',
   statusbar: true,
   menubar: false,
   toolbar: 'bold italic | bullist numlist | link | table',


### PR DESCRIPTION
Fixes #791

Changes proposed in this PR:
- From https://www.tiny.cloud/docs/tinymce/latest/license-key/?utm_campaign=console_license_key_message&utm_source=tinymce&utm_medium=referral 
- "TinyMCE 7 is licensed under the GNU General Public License Version 2 or later. A new configuration option called 'license_key' requires developers to make a conscious decision to use TinyMCE with the GPLv2+ license or with a commercial license. If you are using TinyMCE in a self-hosted environment, a console log warning message will display if the license key config option is missing or invalid. This message aims to ensure compliance with licensing requirements and provide transparency during the evaluation period."