### PR TITLE
Fix/Re-Enable "Create Plan" RSpec Test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,17 @@
 
 ## [Unreleased]
 
-## Added 
+### Added 
 
 
-## Fixed
+### Fixed
  - Fix Translation of Permissions in Email [#1123](https://github.com/portagenetwork/roadmap/pull/1123)
+ - Fix/Re-Enable "Create Plan" RSpec Test [#798](https://github.com/portagenetwork/roadmap/pull/798)
 
-## Changed
+### Changed
 
 
-## Dependency Updates
+### Dependency Updates
 
 ## [4.1.1+portage-4.4.0]
 

--- a/spec/features/plans_spec.rb
+++ b/spec/features/plans_spec.rb
@@ -10,47 +10,39 @@ RSpec.describe 'Plans', type: :feature do
     @org = create(:org)
     @research_org = create(:org, :organisation, :research_institute,
                            name: 'Test Research Org', templates: 1)
-    @funding_org  = create(:org, :funder, name: 'Test Funder Org', templates: 1)
+    # Create the required default_funder org for DMP Assistant
+    @funding_org  = create(:org, :funder, templates: 1)
+    @original_default_funder_id = Rails.application.config.default_funder_id
+    Rails.application.config.default_funder_id = @funding_org.id
     @template     = create(:template, org: @org)
     @user         = create(:user, org: @org)
     sign_in(@user)
-
-    stub_openaire
-
-    #     OpenURI.expects(:open_uri).returns(<<~XML
-    #       <form-value-pairs>
-    #         <value-pairs value-pairs-name="H2020projects" dc-term="relation">
-    #           <pair>
-    #             <displayed-value>
-    #               115797 - INNODIA - Translational approaches to disease modifying therapy of ...
-    #             </displayed-value>
-    #             <stored-value>info:eu-repo/grantAgreement/EC/H2020/115797/EU</stored-value>
-    #           </pair>
-    #         </value-pairs>
-    #       </form-value-pairs>
-    #     XML
-    #     )
   end
 
-  xit 'User creates a new Plan', :js do
-    # TODO: Revisit this after we start refactoring/building out or tests for
-    #       the new create plan workflow. For some reason the plans/new.js isn't
-    #       firing here but works fine in the UI with manual testing
-    # Action
+  after do
+    Rails.application.config.default_funder_id = @original_default_funder_id
+  end
+
+  it 'User creates a new Plan', :js do
     click_link 'Create plan'
     fill_in :plan_title, with: 'My test plan'
     choose_suggestion('plan_org_org_name', @research_org)
 
-    choose_suggestion('plan_funder_org_name', @funding_org)
+    within('#plan_template_id') do
+      select @default_template.title
+    end
     click_button 'Create plan'
 
     # Expectations
-    expect(@user.plans).to be_one
+    expect(find('#notification-area')).to have_text(
+      "Notice: Successfully created the plan.\nThis plan is based on the default template."
+    )
     @plan = Plan.last
+    expect(@user.plans).to be_one
     expect(current_path).to eql(plan_path(@plan))
     expect(page).to have_css("input[type=text][value='#{@plan.title}']")
     expect(@plan.title).to eql('My test plan')
     expect(@plan.org_id).to eql(@research_org.id)
-    expect(@plan.funder_id).to eql(@funding_org.id)
+    expect(@plan.template_id).to eql(@default_template.id)
   end
 end


### PR DESCRIPTION
Fixes #797

Changes proposed in this PR:

[Fix "Create a new plan" features test](https://github.com/portagenetwork/roadmap/pull/798/commits/1b082dc1494aa8ed54eee79139fbca19903759b2)
- The "Create Plan" UI and logic For DMP Assistant diverges from that of DMP Roadmap. This commit adapts the tests within `spec/features/plans_spec.rb` to be compatible with DMP Assistant.
- NOTE: I don't believe the `stub_openaire` call is required, so it has been removed for this test.