### PR TITLE
Bump Ruby to v3.1.4

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -9,22 +9,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: 'Determine Ruby and Bundler Versions from Gemfile.lock'
-      run: |
-        echo "RUBY_VERSION=`cat ./Gemfile.lock | grep -A 1 'RUBY VERSION' | grep 'ruby' | grep -oE '[0-9]\.[0-9]'`" >> $GITHUB_ENV
-        echo "BUNDLER_VERSION=`cat ./Gemfile.lock | grep -A 1 'BUNDLED WITH' | grep -oE '[0-9]\.[0-9]'`" >> $GITHUB_ENV
-
-    # Install Ruby - using the version found in the Gemfile.lock
-    - name: 'Install Ruby'
-      uses: ruby/setup-ruby@v1
+    # Install Ruby and run bundler
+    - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ env.RUBY_VERSION }}
-
-    - name: 'Bundle Install'
-      run: |
-        gem install bundler -v ${{ env.BUNDLER_VERSION }}
-        bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3 --without pgsql rollbar aws
+        ruby-version: '3.1.4'
+        bundler-cache: true
 
     - name: 'Run Danger'
       env:

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -19,7 +19,7 @@ jobs:
     # Install Ruby and run bundler
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.0'
+        ruby-version: '3.1.4'
         bundler-cache: true
     
     # Install Node

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -34,7 +34,7 @@ jobs:
     # Install Ruby and run bundler
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.0'
+        ruby-version: '3.1.4'
         bundler-cache: true
 
     ## - run: echo 'NODE_OPTIONS="--openssl-legacy-provider"' >> $GITHUB_ENV

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -1,6 +1,6 @@
 name: Tests - PostgreSQL
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   postgresql:
@@ -35,7 +35,7 @@ jobs:
     # Install Ruby and run bundler
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.0'
+        ruby-version: '3.1.4'
         bundler-cache: true
 
     ## - run: echo 'NODE_OPTIONS="--openssl-legacy-provider"' >> $GITHUB_ENV
@@ -44,7 +44,7 @@ jobs:
     # Install Node
     - uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: '16.6.0'
         cache: 'yarn'
 
     # Install the Postgres developer packages

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -1,6 +1,6 @@
 name: Tests - PostgreSQL
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   postgresql:
@@ -23,6 +23,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
+    # Define environment variables for Postgres and Rails
     env:
       RAILS_ENV: test
       DATABASE_URL: postgres://postgres:@localhost:5432/roadmap_test
@@ -34,7 +35,7 @@ jobs:
     # Install Ruby and run bundler
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.1.4'
+        ruby-version: '3.0'
         bundler-cache: true
 
     ## - run: echo 'NODE_OPTIONS="--openssl-legacy-provider"' >> $GITHUB_ENV
@@ -43,87 +44,55 @@ jobs:
     # Install Node
     - uses: actions/setup-node@v3
       with:
-        node-version: '16.6.0'
+        node-version: 18
         cache: 'yarn'
 
+    # Install the Postgres developer packages
     - name: 'Install Postgresql Packages'
       run: |
         sudo apt-get update
         sudo apt-get install libpq-dev
 
-    - name: 'Determine Ruby and Bundler Versions from Gemfile.lock'
-      run: |
-        echo "RUBY_VERSION=`cat ./Gemfile.lock | grep -A 1 'RUBY VERSION' | grep 'ruby' | grep -oE '[0-9]\.[0-9]'`" >> $GITHUB_ENV
-        echo "BUNDLER_VERSION=`cat ./Gemfile.lock | grep -A 1 'BUNDLED WITH' | grep -oE '[0-9]\.[0-9]'`" >> $GITHUB_ENV
-
-    # Install Ruby - using the version found in the Gemfile.lock
-    - name: 'Install Ruby'
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ env.RUBY_VERSION }}
-
     # Copy all of the example configs over
     - name: 'Setup Default Configuration'
       run: |
-        # Make copies of all the example config files
         cp config/database.yml.sample config/database.yml
         cp config/initializers/contact_us.rb.example config/initializers/contact_us.rb
         cp config/initializers/wicked_pdf.rb.example config/initializers/wicked_pdf.rb
         cp .env.postgresql .env
 
-    # Try to retrieve the gems from the cache
-    - name: 'Cache Gems'
-      uses: actions/cache@v2.1.5
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gem-
-
-    - name: 'Bundle Install'
-      run: |
-        gem install bundler -v ${{ env.BUNDLER_VERSION }}
-        bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3 --without mysql rollbar aws
-
+    # Stub out the Rails credentials file so that we can start the Rails app
     - name: 'Setup Credentials'
       run: |
         # generate a default credential file and key
         EDITOR='echo "$(cat config/credentials.yml.postgresql)" >' bundle exec rails credentials:edit
 
-    # Try to retrieve the yarn JS dependencies from the cache
-    - name: 'Cache Yarn Packages'
-      uses: actions/cache@v2.1.5
-      with:
-        path: node_modules/
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-yarn-
-          ${{ runner.os }}-
-
+    # Set the path to the wkhtmltopdf executable
     - name: 'Determine wkhtmltopdf location'
       run: echo "WICKED_PDF_PATH=`bundle exec which wkhtmltopdf`" >> $GITHUB_ENV
 
+    # Run yarn install for JS dependencies
     - name: 'Yarn Install'
       run: |
         yarn install
 
+    # Initialize the DB
     - name: 'Setup Test DB'
       run: |
         bundle exec rails db:setup RAILS_ENV=test
         bundle exec rails db:migrate RAILS_ENV=test
 
+    # Prebuild the CSS, JS and image assets
     - name: 'Compile Assets'
       run: bundle exec rails assets:precompile
 
+    # Run  the unit and functional tests
     - name: 'Run Rspec Unit and Functional Tests'
       run: |
         bundle exec rspec spec/models/ spec/policies/ spec/services/ spec/helpers/
         bundle exec rspec spec/controllers/ spec/presenters/ spec/requests/ spec/views
         bundle exec rspec spec/mixins/
 
-    # Integration Tests are only run if PR or Push is to master or development branches
+    # Run the time consuming integration tests (using Chrome headless browser)
     - name: 'Run Integration Tests'
       run: bundle exec rspec spec/features/

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -18,7 +18,7 @@ jobs:
     - name: 'Install Ruby'
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.0'
+        ruby-version: '3.1.4'
         bundler-cache: true
 
     - name: 'Run Rubocop'

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -41,26 +41,24 @@ jobs:
     steps:
     # Checkout the repo
     - uses: actions/checkout@v3
+
+    # Install Ruby and run bundler
+    - uses: ruby/setup-ruby@v1
       with:
-        fetch-depth: 1
+        ruby-version: '3.1.4'
+        bundler-cache: true
+
+    # Install Node
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: '16.6.0'
+        cache: 'yarn'
 
+    # Install the Postgres developer packages
     - name: 'Install Postgresql Packages'
       run: |
         sudo apt-get update
         sudo apt-get install libpq-dev
-
-    - name: 'Determine Ruby and Bundler Versions from Gemfile.lock'
-      run: |
-        echo "RUBY_VERSION=`cat ./Gemfile.lock | grep -A 1 'RUBY VERSION' | grep 'ruby' | grep -oE '[0-9]\.[0-9]'`" >> $GITHUB_ENV
-        echo "BUNDLER_VERSION=`cat ./Gemfile.lock | grep -A 1 'BUNDLED WITH' | grep -oE '[0-9]\.[0-9]'`" >> $GITHUB_ENV
-
-    - name: 'Install Ruby'
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ env.RUBY_VERSION }}
 
     # Copy all of the example configs over
     - name: 'Setup Default Configuration'
@@ -70,37 +68,10 @@ jobs:
         cp config/initializers/contact_us.rb.example config/initializers/contact_us.rb
         cp config/initializers/wicked_pdf.rb.example config/initializers/wicked_pdf.rb
 
-    # Try to retrieve the gems from the cache
-    - name: 'Cache Gems'
-      uses: actions/cache@v2.1.5
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gem-
-
-    - name: 'Bundle Install'
-      run: |
-        gem install bundler -v ${{ env.BUNDLER_VERSION }}
-        bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3 --without mysql rollbar aws
-
     - name: 'Setup Credentials'
       run: |
         # generate a default credential file and key
         EDITOR='echo "$(cat config/credentials.yml.mysql2)" >' bundle exec rails credentials:edit
-
-    # Try to retrieve the yarn JS dependencies from the cache
-    - name: 'Cache Yarn Packages'
-      uses: actions/cache@v2.1.5
-      with:
-        path: node_modules/
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-yarn-
-          ${{ runner.os }}-
 
     - name: 'Determine wkhtmltopdf location'
       run: echo "WICKED_PDF_PATH=`bundle exec which wkhtmltopdf`" >> $GITHUB_ENV

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -198,3 +198,9 @@ Style/StringLiterals:
     - 'config/**/*'
 Style/SwapValues: # new in 1.1
   Enabled: true
+
+Style/HashSyntax:
+  Enabled: false
+
+Style/ArrayIntersect:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@
 
  - Bump braces from 3.0.2 to 3.0.3 [#795](https://github.com/portagenetwork/roadmap/pull/795)
 
+ - Bump Ruby from 3.0.4 to 3.1.4 [#808](https://github.com/portagenetwork/roadmap/pull/808)
+
 ## V4.1.1
 
 ### Added

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,4 +1,4 @@
-FROM ruby:3.0.5
+FROM ruby:3.1.4
 
 # Setup bundle to install gems to volume
 ENV BUNDLE_PATH=/bundle/ \

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-ruby '>= 3.0'
+ruby '3.1.4'
 
 # ===========#
 # CORE RAILS #

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,7 +195,8 @@ GEM
       faraday (>= 0.8)
     faraday-net_http (3.1.0)
       net-http
-    ffi (1.17.0)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
     flag_shih_tzu (0.3.23)
     fog-aws (3.21.0)
       fog-core (~> 2.1)
@@ -648,7 +649,7 @@ DEPENDENCIES
   yard-tomdoc
 
 RUBY VERSION
-   ruby 3.0.4p208
+   ruby 3.1.4p223
 
 BUNDLED WITH
    2.4.15


### PR DESCRIPTION
Changes proposed in this PR:
- Bump Ruby from v3.0 to v3.1:
  - The upcoming  `4.1.1+portage-4.1.0` release bumped Ruby from version 2.7.6 to v3.0.
    - All of the other UAlberta Libraries Projects are currently using Ruby v3.1.
    - Although this bump puts DMP Assistant out of alignment with DMP Roadmap, it does put it in alignment with all of the other UAlberta libraries projects. Also, the build process was experiencing difficulties when set to Ruby v3.0.

- Set `.github/workflows` to execute using Ruby v3.1.
  - Some of the workflows were failing after merely setting `ruby-version: '3.1.4'` within them. Errors would occur due to conflicting ruby versions (possibly because our codebase doesn't include a `.ruby-version` file). Further changes were made to these workflows/ files to address these errors.

- Disable some "Style-Cops" within `.rubocop.yml` (see below). Although, this PR does not change the version of `rubocop` that we're using, the Ruby bump does result in new offences. This PR suppresses those offences to avoid DMP Assistant and DMP Roadmap's codebases from being too misaligned with one another:
  - ```
    Style/HashSyntax:
    Enabled: false

    Style/ArrayIntersect:
    Enabled: false
    ```