### PR TITLE
Use "id" Instead of "name" For `default_funder` Org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+ - Use "id" instead of "name" for `default_funder` Org [#814](https://github.com/portagenetwork/roadmap/pull/814)
+
  - Bump jwt from 2.7.1 to 2.8.2 [#803](https://github.com/portagenetwork/roadmap/pull/803)
 
  - Bump cssbundling-rails from 1.3.3 to 1.4.0 [#796](https://github.com/portagenetwork/roadmap/pull/796)

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -17,7 +17,7 @@ class TemplateOptionsController < ApplicationController
     authorize Template.new, :template_options?
 
     org = org_from_params(params_in: { org_id: org_hash.to_json }) if org_hash.present?
-    funder = Org.find_by(name: Rails.application.config.default_funder_name)
+    funder = Org.find(Rails.application.config.default_funder_id)
 
     @templates = []
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -108,6 +108,6 @@ module DMPRoadmap
     # removed the option for selecting a funder. A funder is needed to show the
     # customized templates. For this reason we are specifying in the
     # documentation the funder that
-    config.default_funder_name = Rails.application.secrets.default_funder_name
+    config.default_funder_id = Rails.application.secrets.default_funder_id.to_i
   end
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -30,7 +30,7 @@ test:
   translation_io_api_key: <%= ENV['TRANSLATION_IO_API_KEY'] %>
   wicked_pdf_path: <%= ENV['WICKED_PDF_PATH'] %>
   wicked_pdf_proxy: <%= ENV['WICKED_PDF_PROXY'] %>
-  default_funder_name: <%= ENV['DEFAULT_FUNDER_NAME'] %>
+  default_funder_id: <%= ENV['DEFAULT_FUNDER_ID'] %>
   super_admin_password: <%= ENV["SUPER_ADMIN_PASSWORD"] %>
   test_password: <%= ENV["TEST_PASSWORD"] %>
   user_password: <%= ENV["USER_PASSWORD"] %>
@@ -61,7 +61,7 @@ development:
   translation_io_api_key: <%= ENV['TRANSLATION_IO_API_KEY'] %>
   wicked_pdf_path: <%= ENV['WICKED_PDF_PATH'] %>
   wicked_pdf_proxy: <%= ENV['WICKED_PDF_PROXY'] %>
-  default_funder_name: <%= ENV['DEFAULT_FUNDER_NAME'] %>
+  default_funder_id: <%= ENV['DEFAULT_FUNDER_ID'] %>
   super_admin_password: <%= ENV["SUPER_ADMIN_PASSWORD"] %>
   test_password: <%= ENV["TEST_PASSWORD"] %>
   user_password: <%= ENV["USER_PASSWORD"] %>
@@ -101,7 +101,7 @@ staging:
   translation_io_api_key: <%= ENV['TRANSLATION_IO_API_KEY'] %>
   wicked_pdf_path: <%= ENV['WICKED_PDF_PATH'] %>
   wicked_pdf_proxy: <%= ENV['WICKED_PDF_PROXY'] %>
-  default_funder_name: <%= ENV['DEFAULT_FUNDER_NAME'] %>
+  default_funder_id: <%= ENV['DEFAULT_FUNDER_ID'] %>
   super_admin_password: <%= ENV["SUPER_ADMIN_PASSWORD"] %>
   test_password: <%= ENV["TEST_PASSWORD"] %>
   user_password: <%= ENV["USER_PASSWORD"] %>
@@ -141,7 +141,7 @@ uat:
   translation_io_api_key: <%= ENV['TRANSLATION_IO_API_KEY'] %>
   wicked_pdf_path: <%= ENV['WICKED_PDF_PATH'] %>
   wicked_pdf_proxy: <%= ENV['WICKED_PDF_PROXY'] %>
-  default_funder_name: <%= ENV['DEFAULT_FUNDER_NAME'] %>
+  default_funder_id: <%= ENV['DEFAULT_FUNDER_ID'] %>
   super_admin_password: <%= ENV["SUPER_ADMIN_PASSWORD"] %>
   test_password: <%= ENV["TEST_PASSWORD"] %>
   user_password: <%= ENV["USER_PASSWORD"] %>
@@ -181,7 +181,7 @@ sandbox:
   translation_io_api_key: <%= ENV['TRANSLATION_IO_API_KEY'] %>
   wicked_pdf_path: <%= ENV['WICKED_PDF_PATH'] %>
   wicked_pdf_proxy: <%= ENV['WICKED_PDF_PROXY'] %>
-  default_funder_name: <%= ENV['DEFAULT_FUNDER_NAME'] %>
+  default_funder_id: <%= ENV['DEFAULT_FUNDER_ID'] %>
   super_admin_password: <%= ENV["SUPER_ADMIN_PASSWORD"] %>
   test_password: <%= ENV["TEST_PASSWORD"] %>
   user_password: <%= ENV["USER_PASSWORD"] %>
@@ -221,7 +221,7 @@ production:
   translation_io_api_key: <%= ENV['TRANSLATION_IO_API_KEY'] %>
   wicked_pdf_path: <%= ENV['WICKED_PDF_PATH'] %>
   wicked_pdf_proxy: <%= ENV['WICKED_PDF_PROXY'] %>
-  default_funder_name: <%= ENV['DEFAULT_FUNDER_NAME'] %>
+  default_funder_id: <%= ENV['DEFAULT_FUNDER_ID'] %>
   super_admin_password: <%= ENV["SUPER_ADMIN_PASSWORD"] %>
   test_password: <%= ENV["TEST_PASSWORD"] %>
   user_password: <%= ENV["USER_PASSWORD"] %>


### PR DESCRIPTION
**NOTE:** The following issue must be addressed when this PR's changes are eventually released into production: https://github.com/portagenetwork/roadmap/issues/815

Fixes #813

Changes proposed in this PR:
- Use `id` rather than `name` for identifying the app's default_funder Org.