### PR TITLE
Update "Welcome" and "About" Pages For Alliance Rebrand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
  - Bump rexml from 3.2.8 to 3.3.3 [#839](https://github.com/portagenetwork/roadmap/pull/839)
 
+ - Update "Welcome" and "About" Pages For Alliance Rebrand [#844](https://github.com/portagenetwork/roadmap/pull/844)
+
 ### Fixed
 
  - Remove Vulnerable ws@8.11.0 Dependency by Upgrading `karma` [#841](https://github.com/portagenetwork/roadmap/pull/841)

--- a/app/views/home/_welcome.html.erb
+++ b/app/views/home/_welcome.html.erb
@@ -12,7 +12,7 @@
     landing_page_content = format(_(%{
       <!-- landing page content -->
       <p>
-        The <strong>DMP Assistant</strong> is a national, online, bilingual data management planning tool developed by the <strong>Digital Research Alliance of Canada (the Alliance)</strong> in collaboration with host institution <strong>University of Alberta</strong> to assist researchers in preparing <strong>data management plans (DMPs)</strong>. This tool is freely available to all researchers, and develops a DMP through a series of key data management questions, supported by best-practice guidance and examples.
+        <strong>DMP Assistant</strong> is a national, online, bilingual data management planning tool developed by the <strong>Digital Research Alliance of Canada (the Alliance)</strong> in collaboration with host institution <strong>University of Alberta</strong> to assist researchers in preparing <strong>data management plans (DMPs)</strong>. This tool is freely available to all researchers, and develops a DMP through a series of key data management questions, supported by best-practice guidance and examples.
       </p>
 
       <p>
@@ -52,6 +52,9 @@
           Webinars:
           <ul>
             <li>
+              <a href="https://www.youtube.com/watch?v=uJYdlo0HeCk">Supporting researchers in meeting DMP requirements - introducing a new DMP template!</a>
+            </li>
+            <li>
               <a href="https://www.youtube.com/watch?v=Cp1O7vXLPao">Support Your Research with DMP Assistant 2.0</a>
             </li>
             <li>
@@ -62,11 +65,15 @@
       </ul>
 
       <p>
-        For more resources and training materials spanning the entire research data life cycle, see the <a href="%{training_resources_path}"> Portage Network Training Resources. </a>
+        For more resources and training materials spanning the entire research data life cycle, see the <a href="%{training_resources_path}"> Alliance Training Resources. </a>
       </p>
 
       <p>
-        The DMP Assistant was adapted from the <a href="https://dcc.ac.uk/"> Digital Curation Centre (DCC)</a>’s <a href="https://dmponline.dcc.ac.uk/">DMPonline</a> tool, and uses the DMP Roadmap codebase developed by DCC and the <a href="https://cdlib.org/services/uc3/">University of California Curation Center (UC3).</a>
+        DMP Assistant was adapted from the <a href="https://dcc.ac.uk/"> Digital Curation Centre (DCC)</a>’s <a href="https://dmponline.dcc.ac.uk/">DMPonline</a> tool, and uses the DMP Roadmap codebase developed by DCC and the <a href="https://cdlib.org/services/uc3/">University of California Curation Center (UC3).</a>
+      </p>
+
+      <p>
+        DMP Assistant was originally developed for Canada by the Portage Network, then a part of the Canadian Association of Research Libraries (CARL). In 2021, Portage Network and its portfolio of platforms and services merged into the Digital Research Alliance of Canada. In 2023 and 2024, we have undertaken a rebrand of the platform, several templates and the organization previously called Portage have transitioned to Alliance branding.
       </p>
     }),how_to_manage_your_data_path: how_to_manage_your_data_path, training_resources_path: training_resources_path)
 

--- a/app/views/static_pages/about_us.html.erb
+++ b/app/views/static_pages/about_us.html.erb
@@ -22,7 +22,7 @@
 
       <h2 class="fontsize-h3"><%= _('How the tool works') %></h2>
       
-      <p><%= _('Currently, this tool includes a generic Portage Data Stewardship template for researchers to use. Guidance is provided to help you interpret and answer the questions.') %></p>
+      <p><%= _('Currently, this tool includes a generic Alliance template for researchers to use. Guidance is provided to help you interpret and answer the questions.') %></p>
     
 
       <p>
@@ -41,10 +41,14 @@
           <% sign_up_url = request.base_url %>
           <%= sanitize(_('If you do not have a DMP Assistant account, click on <a href="%{sign_up_url}"> \'Sign up\' </a> on the homepage.') % { sign_up_url: sign_up_url} ) %>
         </p>
+
+        <p>
+          <%= _('You may sign up for an account as part of your institution, or if you do not have one you may sign up under the Digital Research Alliance of Canada.') %>
+        </p>
       <% end %>
 
       <p>
-        <%= _('Please note that we are currently working on single sign-in authentication with your campus ID. You will have the option to link your existing account to your campus ID when that feature becomes available.') %>
+        <%= _('Please note that we are currently working on single sign-in authentication with your institutional accounts (such as your college or university sign on). You will have the option to link your existing account to your  institutional account when that feature becomes available.') %>
       </p>
 
       <p>
@@ -58,14 +62,14 @@
         <%= sanitize(_('If you have any questions or comments about the DMP Assistant, <a href="%{contact_your_institution_url}"> contact your local institution </a> or email us at  <a href="mailto:%{email_link}?Subject=%{email_subject}">%{email_link}</a>.') % { contact_your_institution_url: contact_your_institution_url, email_link: email_link, email_subject: email_subject} )  %>
       </p>
 
-      <h2 class="fontsize-h3"><%= _('Portage data stewardship template') %></h2>
+      <h2 class="fontsize-h3"><%= _('About templates') %></h2>
       
       <p>
-        <%= _('The Portage Data Stewardship template is based on internationally accepted standards and best practices. It has been prepared and is maintained by a group of research data management experts from research libraries across Canada.') %>
+        <%= _('The Alliance template is based on internationally accepted standards and best practices. It has been prepared and is maintained by a group of research data management experts from research libraries across Canada. It was developed by the Data Management Planning Expert Group, then part of the Portage Network. Portage became part of the Digital Research Alliance of Canada in 2021.') %>
       </p>
 
       <p>
-        <%= _('Organizations may provide their own DMP templates. The Portage template is the default DMP. Select templates from other organizations from the drop-down Organization list.') %>
+        <%= _('Organizations may provide their own DMP templates. The Alliance is the default DMP. Select templates from other organizations from the drop-down Organization list when creating your plan. Users can make use of templates in any available organization, and collaborate across organizations.') %>
       </p>
 
       <p>


### PR DESCRIPTION
Changes proposed in this PR:
- Implemented changes to "Welcome" and "About" pages as outlined in "Rebrand 2024" documents.