### PR TITLE
Create `GET "/api/ca_dashboard/stats"` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+ - Create GET "/api/ca_dashboard/stats" endpoint to fetch Plan, User, and Org-related statistics [#852](https://github.com/portagenetwork/roadmap/pull/852)
+
 ### Changed
 
  - Bump rexml from 3.2.8 to 3.3.3 [#839](https://github.com/portagenetwork/roadmap/pull/839)

--- a/app/controllers/api/ca_dashboard/stats_controller.rb
+++ b/app/controllers/api/ca_dashboard/stats_controller.rb
@@ -4,11 +4,11 @@ module Api
   module CaDashboard
     # Handles CRUD operations for "/api/ca_dashboard/stats"
     class StatsController < Api::V1::BaseApiController
+      # Allow public access / bypass JWT authentication via "POST /api/v1/authenticate"
+      skip_before_action :authorize_request, only: [:index]
 
       # GET /api/ca_dashboard/stats
       def index
-        # To access this endpoint, the user must provide a valid JWT
-        # JWT is acquired by authenticating via POST /api/v1/authenticate
         base_hash = {
           'plans' => Plan.all,
           'orgs' => Org.where(managed: true).all,

--- a/app/controllers/api/ca_dashboard/stats_controller.rb
+++ b/app/controllers/api/ca_dashboard/stats_controller.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Api
+  module CaDashboard
+    # Handles CRUD operations for "/api/ca_dashboard/stats"
+    class StatsController < Api::V1::BaseApiController
+
+      # GET /api/ca_dashboard/stats
+      def index
+        # To access this endpoint, the user must provide a valid JWT
+        # JWT is acquired by authenticating via POST /api/v1/authenticate
+        base_hash = {
+          'plans' => Plan.all,
+          'orgs' => Org.where(managed: true).all,
+          'users' => User.all
+        }
+        @totals = {
+          'all_time' => all_time_counts(base_hash),
+          'last_30_days' => last_30_days_counts(base_hash)
+        }
+        begin
+          @totals['custom_range'] = custom_range_counts(base_hash) if date_params_present?
+          render 'api/ca_dashboard/stats/index', status: :ok
+        rescue ArgumentError
+          error_msg = _('Invalid date format. please use YYYY-MM-DD when supplying `start` or `end` params.')
+          render_error(errors: [error_msg], status: :bad_request)
+        end
+      end
+
+      private
+
+      def all_time_counts(base_hash)
+        base_hash.transform_values(&:count)
+      end
+
+      def last_30_days_counts(base_hash)
+        base_hash.transform_values do |scope|
+          scope.where('created_at >= ?', 30.days.ago).count
+        end
+      end
+
+      def custom_range_counts(base_hash)
+        start_date = parse_date(params[:start])
+        end_date = parse_date(params[:end])
+        base_hash.transform_values do |scope|
+          scope.where(created_at: start_date..end_date).count
+        end
+      end
+
+      def date_params_present?
+        params[:start].present? || params[:end].present?
+      end
+
+      def parse_date(date_string)
+        Date.strptime(date_string, '%Y-%m-%d') if date_string.present?
+      end
+    end
+  end
+end

--- a/app/views/api/ca_dashboard/stats/index.json.jbuilder
+++ b/app/views/api/ca_dashboard/stats/index.json.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+json.partial! 'api/v1/standard_response'
+json.stats do
+  json.totals @totals
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -204,6 +204,10 @@ Rails.application.routes.draw do
       resources :plans, only: %i[create show index]
       resources :templates, only: [:index]
     end
+
+    namespace :ca_dashboard do
+      resources :stats, only: [:index]
+    end
   end
 
   namespace :paginable do


### PR DESCRIPTION
Changes proposed in this PR:
- Add `GET "/api/ca_dashboard/stats"` endpoint to fetch "stats"
- The following is an example JSON response returned after a proper request to `GET "/api/ca_dashboard/stats"`:
  ```json
  {
      "application": "DMP Assistant",
      "source": "GET /api/ca_dashboard/stats",
      "time": "2024-08-14T18:53:15-06:00",
      "caller": "DMP Administrator",
      "code": 200,
      "message": "OK",
      "total_items": 0,
      "stats": {
          "totals": {
              "all_time": {
                  "plans": 13696,
                  "orgs": 127,
                  "users": 17823
              },
              "last_30_days": {
                  "plans": 0,
                  "orgs": 0,
                  "users": 0
              },
              "custom_range": {
                  "plans": 2429,
                  "orgs": 27,
                  "users": 1848
              }
          }
      }
  }
  ```
  - The `"custom_range": { "plans": 2429, "orgs": 27, "users": 1848 }` part of the above JSON structure is only returned when the user specifies a valid `start` and/or `end` parameter when making the API request. Otherwise, the following JSON structure is returned:
  ```json
  {
      "application": "DMP Assistant",
      "source": "GET /api/ca_dashboard/stats",
      "time": "2024-08-14T19:04:31-06:00",
      "caller": "DMP Administrator",
      "code": 200,
      "message": "OK",
      "total_items": 0,
      "stats": {
          "totals": {
              "all_time": {
                  "plans": 13696,
                  "orgs": 127,
                  "users": 17823
              },
              "last_30_days": {
                  "plans": 0,
                  "orgs": 0,
                  "users": 0
              }
          }
      }
  }
  ```