### PR TITLE
Fix Triggering and Update Title of Admin Privileges Email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+ - Fix triggering and title of autosent email when a user's admin privileges are changed [#858](https://github.com/portagenetwork/roadmap/pull/858)
+
+## [4.1.1+portage-4.1.3] - 2024-08-08
+
 ### Changed
 
  - Bump rexml from 3.2.8 to 3.3.3 [#839](https://github.com/portagenetwork/roadmap/pull/839)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -85,9 +85,7 @@ class UsersController < ApplicationController
         end
       elsif perms.include? perm
         @user.perms << perm
-        if perm.id == Perm.use_api.id
-          @user.keep_or_generate_token!
-        end
+        @user.keep_or_generate_token! if perm.id == Perm.use_api.id
         privileges_changed = true
       end
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -87,8 +87,8 @@ class UsersController < ApplicationController
         @user.perms << perm
         if perm.id == Perm.use_api.id
           @user.keep_or_generate_token!
-          privileges_changed = true
         end
+        privileges_changed = true
       end
     end
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -195,7 +195,7 @@ class UserMailer < ActionMailer::Base
 
     I18n.with_locale I18n.locale do
       mail(to: user.email,
-           subject: format(_('Administrator privileges granted in %{tool_name}'),
+           subject: format(_('Administrator privileges updated in %{tool_name}'),
                            tool_name: tool_name))
     end
   end


### PR DESCRIPTION
Fixes #835
Fixes #836

Changes proposed in this PR:
- Fix triggering of admin privileges email to be sent when any privilege is added (rather than just when granting API access)
- Update title of admin privileges email to `(_('Administrator privileges updated in %{tool_name}'), tool_name: tool_name)`.