### PR TITLE
Fix Flaky Tests / Optimize Checking Of `plan.title` Within `spec/features/plans/exports_spec.rb`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
  - Fix triggering and title of autosent email when a user's admin privileges are changed [#858](https://github.com/portagenetwork/roadmap/pull/858)
 
+ - Fix flaky tests / Optimize Checking Of `plan.title` Within `spec/features/plans/exports_spec.rb` [#871](https://github.com/portagenetwork/roadmap/pull/871)
+
 ## [4.1.1+portage-4.1.3] - 2024-08-08
 
 ### Changed

--- a/spec/features/plans/exports_spec.rb
+++ b/spec/features/plans/exports_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'PlansExports', type: :feature, js: true do
     select('html')
     new_window = window_opened_by { click_button 'Download Plan' }
     within_window new_window do
-      expect(page.source).to have_text(plan.title)
+      expect(page.title).to have_text(plan.title)
     end
   end
 
@@ -60,7 +60,7 @@ RSpec.describe 'PlansExports', type: :feature, js: true do
     select('html')
     new_window = window_opened_by { click_button 'Download Plan' }
     within_window new_window do
-      expect(page.source).to have_text(plan.title)
+      expect(page.title).to have_text(plan.title)
     end
   end
 
@@ -91,7 +91,7 @@ RSpec.describe 'PlansExports', type: :feature, js: true do
         click_button 'Download Plan'
       end
       within_window new_window do
-        expect(page.source).to have_text(plan.title)
+        expect(page.title).to have_text(plan.title)
         plan.phases.each do |phase|
           expect(page.source).to have_text(phase.title)
         end
@@ -101,7 +101,7 @@ RSpec.describe 'PlansExports', type: :feature, js: true do
         click_button 'Download Plan'
       end
       within_window new_window do
-        expect(page.source).to have_text(plan.title)
+        expect(page.title).to have_text(plan.title)
         expect(page.source).to have_text(plan.phases[1].title)
         expect(page.source).not_to have_text(plan.phases[2].title) if plan.phases.length > 2
       end
@@ -173,18 +173,18 @@ RSpec.describe 'PlansExports', type: :feature, js: true do
         click_button 'Download Plan'
       end
       within_window new_window do
-        expect(page.source).to have_text(plan.title)
+        expect(page.title).to have_text(plan.title)
       end
     else
       click_button 'Download Plan'
-      expect(page.source).to have_text(plan.title)
+      expect(page.title).to have_text(plan.title)
     end
   end
 
   def _all_phase_download
     _select_option('phase_id', 'All')
     click_button 'Download Plan'
-    expect(page.source).to have_text(plan.title)
+    expect(page.title).to have_text(plan.title)
     plan.phases.each do |phase| # All phase titles should be included in output
       expect(page.source).to have_text(phase.title)
     end
@@ -193,7 +193,7 @@ RSpec.describe 'PlansExports', type: :feature, js: true do
   def _single_phase_download
     _select_option('phase_id', plan.phases[1].id)
     click_button 'Download Plan'
-    expect(page.source).to have_text(plan.title)
+    expect(page.title).to have_text(plan.title)
     expect(page.source).to have_text(plan.phases[1].title)
     expect(page.source).not_to have_text(plan.phases[2].title) if plan.phases.length > 2
   end


### PR DESCRIPTION
Fixes #870

Changes proposed in this PR:
- Fixes the flaky tests within `spec/features/plans/exports_spec.rb` (see #870)
  - While inspecting these sometimes failing tests, it was found that `expect(page.source).to have_text(plan.title)` sometimes failed because sometimes `page.source == ""`.
  - Rather than `page.source`, which returns the entire HTML content of the page, this PR uses `page.title`, which only returns the contents inside of the `<title>` tags.
    - `page.title` does not seem to encounter the unwanted behaviour of returning a blank string. Maybe because it is faster (only returning the title should be faster than returning the entire HTML content via `page.source`)?
    - Also, the `<title>` title tags and their contents are part of the entire HTML content. So despite `page.source` returning a blank string, because `page.title` is not blank, it follows that the DOM is not blank.