### PR TITLE
Optimise Load Time of Profile Edit Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
  - Drop Sessions Table and Delete `lib/tasks/sessions.rake` [#859](https://github.com/portagenetwork/roadmap/pull/859)
 
+ - Optimise Load Time of "Edit Profile" Page [#881](https://github.com/portagenetwork/roadmap/pull/881)
+
 ### Fixed
 
  - Fix triggering and title of autosent email when a user's admin privileges are changed [#858](https://github.com/portagenetwork/roadmap/pull/858)

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -8,7 +8,7 @@ class RegistrationsController < Devise::RegistrationsController
     @user = current_user
     @prefs = @user.get_preferences(:email)
     @languages = Language.sorted_by_abbreviation
-    @orgs = Org.where(managed: true).order('name')
+    @orgs = Org.where(managed: true).includes(identifiers: :identifier_scheme).order('name')
     @other_organisations = Org.where(is_other: true).pluck(:id)
     @identifier_schemes = IdentifierScheme.for_users.order(:name)
     @default_org = current_user.org
@@ -138,7 +138,7 @@ class RegistrationsController < Devise::RegistrationsController
   def update
     if user_signed_in?
       @prefs = @user.get_preferences(:email)
-      @orgs = Org.where(managed: true).order('name')
+      @orgs = Org.where(managed: true).includes(identifiers: :identifier_scheme).order('name')
       @default_org = current_user.org
       @other_organisations = Org.where(is_other: true).pluck(:id)
       @identifier_schemes = IdentifierScheme.for_users.order(:name)
@@ -254,7 +254,7 @@ class RegistrationsController < Devise::RegistrationsController
 
     else
       flash[:alert] = message.blank? ? failure_message(current_user, _('save')) : message
-      @orgs = Org.where(managed: true).order('name')
+      @orgs = Org.where(managed: true).includes(identifiers: :identifier_scheme).order('name')
       render 'edit'
     end
   end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -9,7 +9,6 @@ class RegistrationsController < Devise::RegistrationsController
     @prefs = @user.get_preferences(:email)
     @languages = Language.sorted_by_abbreviation
     @orgs = Org.where(managed: true).includes(identifiers: :identifier_scheme).order('name')
-    @other_organisations = Org.where(is_other: true).pluck(:id)
     @identifier_schemes = IdentifierScheme.for_users.order(:name)
     @default_org = current_user.org
 
@@ -140,7 +139,6 @@ class RegistrationsController < Devise::RegistrationsController
       @prefs = @user.get_preferences(:email)
       @orgs = Org.where(managed: true).includes(identifiers: :identifier_scheme).order('name')
       @default_org = current_user.org
-      @other_organisations = Org.where(is_other: true).pluck(:id)
       @identifier_schemes = IdentifierScheme.for_users.order(:name)
       @languages = Language.sorted_by_abbreviation
       if params[:skip_personal_details] == 'true'

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -8,7 +8,7 @@ class RegistrationsController < Devise::RegistrationsController
     @user = current_user
     @prefs = @user.get_preferences(:email)
     @languages = Language.sorted_by_abbreviation
-    @orgs = Org.order('name')
+    @orgs = Org.where(managed: true).order('name')
     @other_organisations = Org.where(is_other: true).pluck(:id)
     @identifier_schemes = IdentifierScheme.for_users.order(:name)
     @default_org = current_user.org
@@ -138,7 +138,7 @@ class RegistrationsController < Devise::RegistrationsController
   def update
     if user_signed_in?
       @prefs = @user.get_preferences(:email)
-      @orgs = Org.order('name')
+      @orgs = Org.where(managed: true).order('name')
       @default_org = current_user.org
       @other_organisations = Org.where(is_other: true).pluck(:id)
       @identifier_schemes = IdentifierScheme.for_users.order(:name)
@@ -254,7 +254,7 @@ class RegistrationsController < Devise::RegistrationsController
 
     else
       flash[:alert] = message.blank? ? failure_message(current_user, _('save')) : message
-      @orgs = Org.order('name')
+      @orgs = Org.where(managed: true).order('name')
       render 'edit'
     end
   end

--- a/app/views/shared/org_selectors/_local_only.html.erb
+++ b/app/views/shared/org_selectors/_local_only.html.erb
@@ -8,7 +8,7 @@ label = label || _("Organisation")
 # Allows the hidden id field to be renamed for instances where there are
 # multiple org selectors on the same form
 id_field = id_field || :org_id
-presenter = OrgSelectionPresenter.new(orgs: orgs.select{|org| org.managed == true}, selection: default_org)
+presenter = OrgSelectionPresenter.new(orgs: orgs, selection: default_org)
 # add unmanaged filter to local_only to fix issue275, see PR#276 for explaination
 placeholder = _("Begin typing to see a list of suggestions.")
 %>


### PR DESCRIPTION
Fixes #880

Changes proposed in this PR:
- Refactor/optimise filtering of "managed" orgs by performing it within initial `@orgs` db query 9dc8239ab34e233a0b97a165dd2bff52cac25866
-  Address `GET /users/edit` Bullet Warnings 3ab4862ae004a6f23e374c4111250572b14fc94e
- Remove unused `@other_organisations = Org.where(is_other: true).pluck(:id)` statements 195988a09b9ae9d855159e55b8515159848881d9

Optimisation Results:
- The page load time is ~2.85x faster now.
- The following compares the `development` branch to `aaron/issues/880` by making requests to the path affected by this PR (`/users/edit`). The benchmarking was performed via ab - Apache HTTP server benchmarking tool alongside a recent (May 2024) db dump from the production environment of DMP Assistant. In both cases, 100 consecutive requests were performed to each path and the recorded result is the mean request time (ms).
- 
Example request:
```
$ ab -n 100 -k -C "_dmp_roadmap_session=COOKIE_VALUE" -l http://127.0.0.1:3000/users/edit
```
```
integration       Time per request:        1623.190 [ms] (mean)
aaron/issues/880  Time per request:         568.908 [ms] (mean)
```