### PR TITLE
Optimise Load Time of "Edit Profile" Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
  - Drop Sessions Table and Delete `lib/tasks/sessions.rake` [#859](https://github.com/portagenetwork/roadmap/pull/859)
 
+ - Optimise Load Time of "Edit Profile" Page [#883](https://github.com/portagenetwork/roadmap/pull/883)
+
 ### Fixed
 
  - Fix triggering and title of autosent email when a user's admin privileges are changed [#858](https://github.com/portagenetwork/roadmap/pull/858)

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -8,7 +8,7 @@ class RegistrationsController < Devise::RegistrationsController
     @user = current_user
     @prefs = @user.get_preferences(:email)
     @languages = Language.sorted_by_abbreviation
-    @orgs = Org.order('name')
+    @orgs = Org.includes(identifiers: :identifier_scheme).order('name')
     @identifier_schemes = IdentifierScheme.for_users.order(:name)
     @default_org = current_user.org
 
@@ -137,7 +137,7 @@ class RegistrationsController < Devise::RegistrationsController
   def update
     if user_signed_in?
       @prefs = @user.get_preferences(:email)
-      @orgs = Org.order('name')
+      @orgs = Org.includes(identifiers: :identifier_scheme).order('name')
       @default_org = current_user.org
       @identifier_schemes = IdentifierScheme.for_users.order(:name)
       @languages = Language.sorted_by_abbreviation
@@ -252,7 +252,7 @@ class RegistrationsController < Devise::RegistrationsController
 
     else
       flash[:alert] = message.blank? ? failure_message(current_user, _('save')) : message
-      @orgs = Org.order('name')
+      @orgs = Org.includes(identifiers: :identifier_scheme).order('name')
       render 'edit'
     end
   end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -9,7 +9,6 @@ class RegistrationsController < Devise::RegistrationsController
     @prefs = @user.get_preferences(:email)
     @languages = Language.sorted_by_abbreviation
     @orgs = Org.order('name')
-    @other_organisations = Org.where(is_other: true).pluck(:id)
     @identifier_schemes = IdentifierScheme.for_users.order(:name)
     @default_org = current_user.org
 
@@ -140,7 +139,6 @@ class RegistrationsController < Devise::RegistrationsController
       @prefs = @user.get_preferences(:email)
       @orgs = Org.order('name')
       @default_org = current_user.org
-      @other_organisations = Org.where(is_other: true).pluck(:id)
       @identifier_schemes = IdentifierScheme.for_users.order(:name)
       @languages = Language.sorted_by_abbreviation
       if params[:skip_personal_details] == 'true'


### PR DESCRIPTION
Fixes #880

Changes proposed in this PR:
-  Address `GET /users/edit` Bullet Warnings 907bb88a54c7bb2e01b10c873c30586bdb1f1d7b
- Remove unused `@other_organisations = Org.where(is_other: true).pluck(:id)` statements 4deb17279ff85890103e06fe0e4bd50f5d3d4d2b

Optimisation Results:
- The page load time is ~1.42x faster now.
- The following compares the `development` branch to `aaron/issues/880` by making requests to the path affected by this PR (`/users/edit`). The benchmarking was performed via ab - Apache HTTP server benchmarking tool alongside a recent (May 2024) db dump from the production environment of DMP Assistant. In both cases, 100 consecutive requests were performed to each path and the recorded result is the mean request time (ms).
- 
Example request:
```
$ ab -n 100 -k -C "_dmp_roadmap_session=COOKIE_VALUE" -l http://127.0.0.1:3000/users/edit
```
```
integration       Time per request:        1632.494 [ms] (mean)
aaron/issues/880  Time per request:        1147.324 [ms] (mean)
```