### PR TITLE
Patch to Put Back ORCID Linking Functionality

### DIFF
--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -73,4 +73,6 @@ jobs:
 
     # Run the time consuming integration tests (using Chrome headless browser)
     - name: 'Run Rspec Integration Tests'
-      run: bundle exec rspec spec/features/
+      run: |
+        bundle exec rspec spec/features/
+        bundle exec rspec spec/integration/

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -95,4 +95,6 @@ jobs:
 
     # Run the time consuming integration tests (using Chrome headless browser)
     - name: 'Run Integration Tests'
-      run: bundle exec rspec spec/features/
+      run: |
+        bundle exec rspec spec/features/
+        bundle exec rspec spec/integration/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
  - Fix flaky tests / Optimize Checking Of `plan.title` Within `spec/features/plans/exports_spec.rb` [#871](https://github.com/portagenetwork/roadmap/pull/871)
 
+ - Patch to Put Back ORCID Linking Functionality [#891](https://github.com/portagenetwork/roadmap/pull/891)
+
 ## [4.1.1+portage-4.1.3] - 2024-08-08
 
 ### Changed

--- a/app/views/devise/registrations/_personal_details.html.erb
+++ b/app/views/devise/registrations/_personal_details.html.erb
@@ -67,6 +67,16 @@
   <% end %>
 
   <div class="form-group col-xs-8">
+    <% scheme = IdentifierScheme.find_by(name: 'orcid')%> 
+    <%= label_tag(:scheme_name, 'ORCID', class: 'control-label') %>
+    <div class='identifier-scheme'>
+        <%= render partial: "external_identifier",
+                   locals: { scheme: scheme,
+                             id: current_user.identifier_for(scheme.name)} %>
+    </div>
+  </div>
+
+  <div class="form-group col-xs-8">
         <label class='control-label'>
           <span class="aria-only" aria-hidden="false"><%= _('Institutional credentials') %></span>
         </label>

--- a/spec/integration/openid_connect_sso_spec.rb
+++ b/spec/integration/openid_connect_sso_spec.rb
@@ -13,6 +13,13 @@ RSpec.describe 'Openid_connection SSO', type: :feature do
                                   active: true,
                                   identifier_prefix: 'https://www.cilogon.org/')
 
+      # Adding this identifier scheme as it is needed in view but we are not testing for it
+      create(:identifier_scheme,
+             name: 'orcid',
+             description: 'ORCID',
+             active: true,
+             identifier_prefix: 'https://orcid.org/')
+
       Rails.application.env_config['devise.mapping'] = Devise.mappings[:user]
       Rails.application.env_config['omniauth.auth'] = OmniAuth.config.mock_auth[:openid_connect]
     end


### PR DESCRIPTION
Changes proposed in this PR:
- Commit f76758ba7a7e88b22eb74c7432e00bca5a5c3d84 - "Add link account with CILogon" added the functionality to link an external account via CILogon. However, the commit also removed the functionality to link one's ORCID credentials within the app. This commit adds the ORCID functionality back.