### PR TITLE
Add Rake Task For `4.1.1+portage-4.2.0` Upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+ - Add Rake Upgrade Task For `4.1.1+portage-4.2.0` [#892](https://github.com/portagenetwork/roadmap/pull/892)
+
  - Test cases for CILogon(openid_connection) changes in Omniauth controller - [#869](https://github.com/portagenetwork/roadmap/pull/869/)
 
  - Implemented openid_connection SSO with CILogon [#872](https://github.com/portagenetwork/roadmap/pull/872)


### PR DESCRIPTION

Fixes #890

Changes proposed in this PR:
- Release `4.1.1+portage-4.2.0` includes a migration and it requires a specific new entry to the `identifier_schemes` table for openid_connect / CILogon to work properly. This rake task is intended to take care of all of that.

Note: The changes applied via this rake task have already been executed manually on the staging environment. However, performing the rake task on staging should still have no adverse effects.

