### PR TITLE
Patch to allow multiple hosts when setting config of some environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [4.1.1+portage-4.2.1] - 2024-09-12
+
+### Changed
+
+ - Patch to allow multiple hosts when setting config of some environments [#899](https://github.com/portagenetwork/roadmap/pull/899)
+
 ## [4.1.1+portage-4.2.0] - 2024-09-11
 
 ### Added

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,7 +96,11 @@ Rails.application.configure do
   # This allows us to define the hostname and add it to the whitelist. If you attempt
   # to access the site and receive a 'Blocked host' error then you will need to
   # set this environment variable
-  config.hosts << Rails.application.secrets.dmproadmap_host if Rails.application.secrets.dmproadmap_host.present?
+  # Convert comma-separated string to array
+  dmproadmap_hosts = Rails.application.secrets.dmproadmap_host.to_s.split(',').map(&:strip)
+  dmproadmap_hosts.each do |host|
+    config.hosts << host
+  end
 end
 # Used by Rails' routes url_helpers (typically when including a link in an email)
 Rails.application.routes.default_url_options[:host] = Rails.application.secrets.dmproadmap_host

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,6 +2,7 @@
 
 require 'syslog/logger'
 
+# rubocop:disable Metrics/BlockLength
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -102,5 +103,6 @@ Rails.application.configure do
     config.hosts << host
   end
 end
+# rubocop:enable Metrics/BlockLength
 # Used by Rails' routes url_helpers (typically when including a link in an email)
 Rails.application.routes.default_url_options[:host] = Rails.application.secrets.dmproadmap_host

--- a/config/environments/sandbox.rb
+++ b/config/environments/sandbox.rb
@@ -90,7 +90,11 @@ Rails.application.configure do
     enable_starttls_auto: true
   }
 
-  config.hosts << Rails.application.secrets.dmproadmap_host if Rails.application.secrets.dmproadmap_host.present?
+  # Convert comma-separated string to array
+  dmproadmap_hosts = Rails.application.secrets.dmproadmap_host.to_s.split(',').map(&:strip)
+  dmproadmap_hosts.each do |host|
+    config.hosts << host
+  end
 end
 # Fix JSON Download Error
 Rails.application.routes.default_url_options[:host] = Rails.application.secrets.dmproadmap_host

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -88,6 +88,10 @@ Rails.application.configure do
     authentication: Rails.application.secrets.smtp_authentication || 'plain',
     enable_starttls_auto: true
   }
-  config.hosts << Rails.application.secrets.dmproadmap_host if Rails.application.secrets.dmproadmap_host.present?
+  # Convert comma-separated string to array
+  dmproadmap_hosts = Rails.application.secrets.dmproadmap_host.to_s.split(',').map(&:strip)
+  dmproadmap_hosts.each do |host|
+    config.hosts << host
+  end
 end
 Rails.application.routes.default_url_options[:host] = Rails.application.secrets.dmproadmap_host


### PR DESCRIPTION
Changes proposed in this PR:
- This PR allows for the production, sandbox, and staging environments to have multiple hosts added to config.hosts. (config.hosts sets the allowed list. A 403 will be encountered by the user if they try to navigate to a hostname that is missing from config.hosts)