### PR TITLE
Simple code cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+ - General code cleanup
+
 ## [4.1.1+portage-4.2.1] - 2024-09-12
 
 ### Changed


### PR DESCRIPTION
After the release off SSO update we had some rushed code reviews. This PR cleans up a bit of that code.

This PR is very straight forward. Removes commented out code, and rearranges code styling. This is to address technical debt and can wait for a minor regular release.
