### PR TITLE
WIP DO NOT MERGE - First draft at adding email confirmation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ public/javascripts/*
 public/stylesheets/*
 public/system/*
 public/videos/*
+public/tinymce/skins/*
 
 # Ignore PO/POT backups
 *.po.bak

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -65,7 +65,7 @@ class User < ApplicationRecord
   #   :token_authenticatable, :confirmable,
   #   :lockable, :timeoutable and :omniauthable
   devise :invitable, :database_authenticatable, :registerable, :recoverable,
-         :rememberable, :trackable, :validatable, :omniauthable,
+         :rememberable, :trackable, :validatable, :omniauthable, :confirmable,
          omniauth_providers: %i[shibboleth orcid openid_connect]
 
   ##

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -3,5 +3,5 @@
 
 	<p><%= _("Thank you for registering. Please confirm your email address") %>:</p>
 
-	<p><%= link_to _("Click here to confirm your account"),  new_user_confirmation_url(@resource, :confirmation_token => @token) %> (<%= _("or copy") %> <%= confirmation_url(@resource, :confirmation_token => @token) %> <%= _("into your browser") %>).</p>
+	<p><%= link_to _("Click here to confirm your account"),  confirmation_url(@resource, :confirmation_token => @token) %> (<%= _("or copy") %> <%= confirmation_url(@resource, :confirmation_token => @token) %> <%= _("into your browser") %>).</p>
 <% end %>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -3,5 +3,5 @@
 
 	<p><%= _("Thank you for registering. Please confirm your email address") %>:</p>
 
-	<p><%= link_to _("Click here to confirm your account"),  confirmation_url(@resource, :confirmation_token => @token) %> (<%= _("or copy") %> <%= confirmation_url(@resource, :confirmation_token => @token) %> <%= _("into your browser") %>).</p>
+	<p><%= link_to _("Click here to confirm your account"),  new_user_confirmation_url(@resource, :confirmation_token => @token) %> (<%= _("or copy") %> <%= confirmation_url(@resource, :confirmation_token => @token) %> <%= _("into your browser") %>).</p>
 <% end %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -145,7 +145,7 @@ Devise.setup do |config|
   # initial account confirmation) to be applied. Requires additional unconfirmed_email
   # db field (see migrations). Until confirmed new email is stored in
   # unconfirmed email column, and copied to email column on successful confirmation.
-  config.reconfirmable = false
+  config.reconfirmable = true
 
   # Defines which key will be used when confirming an account
   # config.confirmation_keys = [ :email ]

--- a/db/migrate/20240919191444_add_unconfirmed_email_to_users.rb
+++ b/db/migrate/20240919191444_add_unconfirmed_email_to_users.rb
@@ -1,0 +1,5 @@
+class AddUnconfirmedEmailToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :unconfirmed_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_08_20_190548) do
+ActiveRecord::Schema.define(version: 2024_09_19_191444) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -824,6 +824,7 @@ ActiveRecord::Schema.define(version: 2024_08_20_190548) do
     t.boolean "active", default: true
     t.integer "department_id"
     t.datetime "last_api_access"
+    t.string "unconfirmed_email"
     t.index ["department_id"], name: "fk_rails_f29bf9cdf2"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["language_id"], name: "fk_rails_45f4f12508"


### PR DESCRIPTION
This is the first attempt at adding email confirmation to user accounts.
    
    Right now this change adds:
    
    + User receives email upon system user creation to confirm email
    + User receives flash notice when trying to log in through the system
    stopping them from using it until email is confirmed
    + User account is confirmed after accessing confirmation token url
    + User account goes to resend token view if token expires
    
    What we need to add:
    
    + Confirm email for SSO accounts
    + Find a way to reset confirmation values for all existing accounts
    + Confirm the translations are present and working in web site and email confirmation
    + More ?