### PR TITLE
Clean/openid connect identifiers database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fix
+
+ - Clean up database entries for CILogon [portagenetwork/roadmap#912](https://github.com/portagenetwork/roadmap/issues/912)
+
 ## [4.1.1+portage-4.2.2] - 2024-09-18
 
 ### Changed

--- a/db/migrate/20240924203238_clean_identifier_scheme_cilogon_prefix_value.rb
+++ b/db/migrate/20240924203238_clean_identifier_scheme_cilogon_prefix_value.rb
@@ -1,0 +1,22 @@
+class CleanIdentifierSchemeCilogonPrefixValue < ActiveRecord::Migration[6.1]
+  def up
+    scheme = IdentifierScheme.find_by(name: 'openid_connect')
+    if scheme
+      scheme.identifier_prefix = ''
+      scheme.save!
+    end
+
+    Identifier.where("value ~* ?", 'http://cilogon.+cilogon.+').each do |identifier|
+      identifier.value.delete_prefix!('http://cilogon.org/serverE/users/')
+      identifier.save!
+    end
+  end
+
+  def down
+    scheme = IdentifierScheme.find_by(name: 'openid_connect')
+    if scheme
+      scheme.identifier_prefix = 'http://cilogon.org/serverE/users/'
+      scheme.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_08_20_190548) do
+ActiveRecord::Schema.define(version: 2024_09_24_203238) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/seeds/test.rb
+++ b/db/seeds/test.rb
@@ -72,7 +72,7 @@ identifier_schemes = [
     name: "openid_connect",
     description: "CILogon",
     active: true,
-    identifier_prefix: "https://www.cilogon.org/",
+    identifier_prefix: "",
   },
 ]
 identifier_schemes.each { |is| IdentifierScheme.create!(is) }

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe Users::OmniauthCallbacksController, type: :controller do
                                 name: 'openid_connect',
                                 description: 'CILogon',
                                 active: true,
-                                identifier_prefix: 'https://www.cilogon.org/')
+                                identifier_prefix: '')
 
     # Mock OmniAuth data for OpenID Connect with necessary info
     OmniAuth.config.mock_auth[:openid_connect] = OmniAuth::AuthHash.new({
                                                                           provider: 'openid_connect',
-                                                                          uid: '12345',
+                                                                          uid: 'https://www.cilogon.org/12345',
                                                                           info: {
                                                                             email: 'user@organization.ca',
                                                                             first_name: 'Test',

--- a/spec/integration/openid_connect_sso_spec.rb
+++ b/spec/integration/openid_connect_sso_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Openid_connection SSO', type: :feature do
                                   name: 'openid_connect',
                                   description: 'CILogon',
                                   active: true,
-                                  identifier_prefix: 'https://www.cilogon.org/')
+                                  identifier_prefix: '')
 
       # Adding this identifier scheme as it is needed in view but we are not testing for it
       create(:identifier_scheme,
@@ -45,7 +45,7 @@ RSpec.describe 'Openid_connection SSO', type: :feature do
                                        surname: 'DMP Lastname')
       expect(user.identifiers.count).to eql(0)
       visit root_path
-      click_link 'Sign in with CILogon'
+      click_link 'Sign in with institutional or social ID'
       error_message = 'That email appears to be associated with an existing account'
       expect(page).to have_content(error_message)
       expect(user.identifiers.count).to eql(0)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -126,7 +126,7 @@ OmniAuth.config.test_mode = true
 OmniAuth.config.mock_auth[:openid_connect] = OmniAuth::AuthHash.new(
   {
     provider: 'openid_connect',
-    uid: '12345',
+    uid: 'https://www.cilogon.org/12345',
     info: {
       email: 'user@organization.ca',
       first_name: 'John',


### PR DESCRIPTION
Cleanup db entries for CILogon identifiers

We were expecting the prefixes from CILogon to be consistent but they are not. This PR addresses cleans up these entries.

Fixes portagenetwork/roadmap#912