### PR TITLE
Disable Updating of User Emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+ - Disable Updating of User Emails [#917](https://github.com/portagenetwork/roadmap/pull/917)
+
 ## [4.1.1+portage-4.2.2] - 2024-09-18
 
 ### Changed

--- a/app/controllers/super_admin/users_controller.rb
+++ b/app/controllers/super_admin/users_controller.rb
@@ -119,8 +119,7 @@ module SuperAdmin
     private
 
     def user_params
-      params.require(:user).permit(:email,
-                                   :firstname,
+      params.require(:user).permit(:firstname,
                                    :surname,
                                    :org_id, :org_name, :org_crosswalk,
                                    :department_id,

--- a/app/views/devise/registrations/_personal_details.html.erb
+++ b/app/views/devise/registrations/_personal_details.html.erb
@@ -8,7 +8,7 @@
 
   <div class="form-group col-xs-8">
     <%= f.label(:email, _('Email'), class: 'control-label') %>
-    <%= f.email_field(:email, class: "form-control", "aria-required": true, value: @user.email) %>
+    <%= f.email_field(:email, class: "form-control", "aria-required": true, value: @user.email, "disabled": true) %>
     <%= hidden_field_tag :original_email, @user.email %>
   </div>
 

--- a/app/views/devise/registrations/_personal_details.html.erb
+++ b/app/views/devise/registrations/_personal_details.html.erb
@@ -1,16 +1,16 @@
 <%= form_for(resource, namespace: current_user.id, as: resource_name, url: registration_path(resource_name), html: {method: :put, id: 'personal_details_registration_form' }) do |f| %>
-  <p class="form-control-static">
-    <%= sanitize _("Please note that your email address is used as your username. If you change this, remember to use your new email address on sign in.") %>
-  </p>
-
-  <p class="form-control-static"><%= _('You can edit any of the details below.') %></p>
-  <%= hidden_field_tag :unlink_flag, "false", id: 'unlink_flag' %>
 
   <div class="form-group col-xs-8">
     <%= f.label(:email, _('Email'), class: 'control-label') %>
     <%= f.email_field(:email, class: "form-control", "aria-required": true, value: @user.email, "disabled": true) %>
     <%= hidden_field_tag :original_email, @user.email %>
   </div>
+
+  <div class="form-group col-xs-12">
+    <p class="form-control-static"><%= _('You can edit any of the details below.') %></p>
+  </div>
+
+  <%= hidden_field_tag :unlink_flag, "false", id: 'unlink_flag' %>
 
   <div class="form-group col-xs-8">
     <%= f.label(:firstname, _('First name'), class: 'control-label') %>

--- a/app/views/super_admin/users/edit.html.erb
+++ b/app/views/super_admin/users/edit.html.erb
@@ -13,7 +13,7 @@
     <%= form_for(@user, namespace: :superadmin, as: :user, url: super_admin_user_path(@user), html: {method: :put, id: 'super_admin_user_edit' }) do |f| %>
       <div class="form-group col-xs-12">
         <%= f.label(:email, _('Email'), class: 'control-label') %>
-        <%= f.email_field(:email, class: "form-control", "aria-required": true) %>
+        <%= f.email_field(:email, class: "form-control", "aria-required": true, "disabled": true) %>
       </div>
 
       <div class="form-group col-xs-12">


### PR DESCRIPTION
Fixes #916

Changes proposed in this PR:
- Set `"disabled": true` within `f.email_field` for all forms (the same approach is already used in `app/views/org_admin/users/edit.html.erb`)
- For added security, remove `:email` from the .permit() update params of the controllers corresponding to the forms
- Update layout of "Edit Profile" contents to correspond with the aforementioned changes

Notes regarding changes to `app/controllers/registrations_controller.rb`:
- Because `:email` was removed from the .permit() params, all of the `update_params[:email]` - related code needed to be addressed/removed (lines 161, 174, and 200)
- The removal of `:email` from `update_params` enabled the removal of a lot of other code in the file.
  - The `if require_password` check in the `do_update` method is no longer needed. The comment on 197 stated `# user is changing email or password`. However, line 204-206 pointed out how this case is never actually reached for password changes (`def do_update_password` is executed instead). Since we are no longer allowing for the email to be changed either, it follows that `require_password` should always evaluate to false.
  - As result, we only need the code that corresponded to the `else` statement for `if require_password` (previously lines 225-228, now 185-188)
  - Also, because `require_password` is now always false, it follows that we can remove both the `require_password` arg from `def do_update` as well as the entirety of `def needs_password?`