### PR TITLE
Fix Test / Update SSO button Name Within Test 

### DIFF
--- a/spec/integration/openid_connect_sso_spec.rb
+++ b/spec/integration/openid_connect_sso_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Openid_connection SSO', type: :feature do
                                        surname: 'DMP Lastname')
       expect(user.identifiers.count).to eql(0)
       visit root_path
-      click_link 'Sign in with CILogon'
+      click_link 'Sign in with institutional or social ID'
       error_message = 'That email appears to be associated with an existing account'
       expect(page).to have_content(error_message)
       expect(user.identifiers.count).to eql(0)


### PR DESCRIPTION
Changes proposed in this PR:
- Fix `./spec/integration/openid_connect_sso_spec.rb:42` test
  - This test was failing because the SSO button name within the test was outdated. In order to pass, the test's button name must match the actual button name specified within `app/views/shared/_sign_in_form.html.erb`
