### PR TITLE
Fixes to CILogon / `openid_connect` Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
  - Fix User Lookup Via SSO Email: Make Query Case-Insensitive [#924](https://github.com/portagenetwork/roadmap/pull/924)
 
+ - Fixes to CILogon / `openid_connect` Tests [#922](https://github.com/portagenetwork/roadmap/pull/922)
+
 ## [4.1.1+portage-4.2.2] - 2024-09-18
 
 ### Changed

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -19,7 +19,6 @@ test:
   mailer_default_host: <%= ENV['MAILER_DEFAULT_HOST'] || Socket.gethostname %>
   mailer_from: <%= ENV['MAILER_FROM'] %>
   mailer_to: <%= ENV['MAILER_TO'] %>
-  omniauth_full_host: <%= ENV['OMNIAUTH_FULL_HOST'] %>
   orcid_client_id: <%= ENV['ORCID_CLIENT_ID'] %>
   orcid_client_member: <%= ENV['ORCID_CLIENT_MEMBER'] %>
   orcid_client_secret: <%= ENV['ORCID_CLIENT_SECRET'] %>

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -15,19 +15,17 @@ RSpec.describe Users::OmniauthCallbacksController, type: :controller do
                                 identifier_prefix: 'https://www.cilogon.org/')
 
     # Mock OmniAuth data for OpenID Connect with necessary info
-    OmniAuth.config.mock_auth[:openid_connect] = OmniAuth::AuthHash.new({
-                                                                          provider: 'openid_connect',
-                                                                          uid: '12345',
-                                                                          info: {
-                                                                            email: 'user@organization.ca',
-                                                                            first_name: 'Test',
-                                                                            last_name: 'User',
-                                                                            name: 'Test User'
-                                                                          }
-                                                                        })
-
     # Assign the mocked authentication hash to the request environment
-    @request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:openid_connect]
+    @request.env['omniauth.auth'] = OmniAuth::AuthHash.new({
+                                                             provider: 'openid_connect',
+                                                             uid: '12345',
+                                                             info: {
+                                                               email: 'user@organization.ca',
+                                                               first_name: 'Test',
+                                                               last_name: 'User',
+                                                               name: 'Test User'
+                                                             }
+                                                           })
   end
 
   after do
@@ -44,8 +42,7 @@ RSpec.describe Users::OmniauthCallbacksController, type: :controller do
     context 'when the email is missing and the user does not exist' do
       before do
         # Simulate missing email
-        OmniAuth.config.mock_auth[:openid_connect].info.email = nil
-        @request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:openid_connect]
+        @request.env['omniauth.auth'].info.email = nil
       end
 
       it 'redirects to the registration page with a flash message' do

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -10,11 +10,7 @@ RSpec.describe Users::OmniauthCallbacksController, type: :controller do
     @request.env['devise.mapping'] = Devise.mappings[:user]
     create(:org, managed: false, is_other: true)
     @org = create(:org, managed: true)
-    @identifier_scheme = create(:identifier_scheme,
-                                name: 'openid_connect',
-                                description: 'CILogon',
-                                active: true,
-                                identifier_prefix: 'https://www.cilogon.org/')
+    @identifier_scheme = create(:identifier_scheme, :openid_connect)
 
     # Mock OmniAuth data for OpenID Connect with necessary info
     # Assign the mocked authentication hash to the request environment
@@ -37,7 +33,6 @@ RSpec.describe Users::OmniauthCallbacksController, type: :controller do
 
   describe 'POST #openid_connect' do
     let(:auth) { request.env['omniauth.auth'] }
-    let!(:identifier_scheme) { IdentifierScheme.create(name: auth.provider) }
 
     context 'when the email is missing and the user does not exist' do
       before do

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 
 RSpec.describe Users::OmniauthCallbacksController, type: :controller do
   before do
+    # Capture User.from_omniauth before redefining it
+    @from_omniauth_method = User.method(:from_omniauth)
     # Setup Devise mapping
     @request.env['devise.mapping'] = Devise.mappings[:user]
     create(:org, managed: false, is_other: true)
@@ -29,10 +31,8 @@ RSpec.describe Users::OmniauthCallbacksController, type: :controller do
   end
 
   after do
-    # Reset the `from_omniauth` method after each test
-    User.define_singleton_method(:from_omniauth) do |auth|
-      User.find_by(email: auth.info.email)
-    end
+    # Restore the actual User.from_omniauth method
+    User.define_singleton_method(:from_omniauth, @from_omniauth_method)
   end
 
   describe 'POST #openid_connect' do

--- a/spec/factories/identifier_schemes.rb
+++ b/spec/factories/identifier_schemes.rb
@@ -32,5 +32,11 @@ FactoryBot.define do
         identifier_scheme.update("#{identifier_scheme.all_context[idx]}": true)
       end
     end
+
+    trait :openid_connect do
+      name { 'openid_connect' }
+      description { 'CILogon' }
+      identifier_prefix { 'https://www.cilogon.org/' }
+    end
   end
 end

--- a/spec/integration/openid_connect_sso_spec.rb
+++ b/spec/integration/openid_connect_sso_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Openid_connection SSO', type: :feature do
       Rails.application.env_config['omniauth.auth'] = OmniAuth.config.mock_auth[:openid_connect]
     end
 
-    it 'creates account from external credentials' do
+    it 'creates account from external credentials', :js do
       visit root_path
       click_link 'Sign in with institutional or social ID'
 
@@ -51,7 +51,7 @@ RSpec.describe 'Openid_connection SSO', type: :feature do
       expect(user.identifiers.count).to eql(0)
     end
 
-    xit 'links account from external credentails' do
+    it 'links account from external credentails', :js do
       # Create existing user
       user = create(:user, :org_admin, org: @org, email: 'user@organization.ca', firstname: 'DMP Name',
                                        surname: 'DMP Lastname')

--- a/spec/integration/openid_connect_sso_spec.rb
+++ b/spec/integration/openid_connect_sso_spec.rb
@@ -7,11 +7,7 @@ RSpec.describe 'Openid_connection SSO', type: :feature do
     before do
       create(:org, managed: false, is_other: true)
       @org = create(:org, managed: true)
-      @identifier_scheme = create(:identifier_scheme,
-                                  name: 'openid_connect',
-                                  description: 'CILogon',
-                                  active: true,
-                                  identifier_prefix: 'https://www.cilogon.org/')
+      @identifier_scheme = create(:identifier_scheme, :openid_connect)
 
       # Adding this identifier scheme as it is needed in view but we are not testing for it
       create(:identifier_scheme,


### PR DESCRIPTION
Fixes #921

Changes proposed in this PR:
- Fix flaky tests due to overriding of `OmniAuth.config.mock_auth[:openid_connect]` [648d6d8](https://github.com/portagenetwork/roadmap/pull/922/commits/648d6d848832b31ddbca4fa7420070e4aaef219b)
  - Prior to this PR, whenever `OmniAuth.config.mock_auth[:openid_connect]` was being overridden in this file, the value was always subsequently assigned to `@request.env['omniauth.auth']`. These changes simply bypass `OmniAuth.config.mock_auth[:openid_connect]` and directly assign `OmniAuth::AuthHash.new(...)` to `@request.env['omniauth.auth']` instead.

- Update and re-enable openid_connect features tests [4fd0f55](https://github.com/portagenetwork/roadmap/pull/922/commits/4fd0f55d5a0faa73ab979aef7f58b709f84659c6)
  - config/secrets.yml
    - `Rails.application.secrets.omniauth_full_host` does not appear to be necessary in test mode. In fact, if a value exists for `ENV['OMNIAUTH_FULL_HOST']` (e.g. the value set for development) then it results in the tests failing (By default, `Capybara.server_port` is set to a random value, so hardcoding a secret isn't completely straightforward.)
  - spec/integration/openid_connect_sso_spec.rb
    - Here we are re-enabling the "links account from external credentails" test, which was failing due to the aforementioned issue with `config/secrets.yml`.
    - We are also adding `:js`, which if desired, makes it simpler to execute these tests in non-headless mode.