### PR TITLE
Fix User Lookup Via SSO Email: Make Query Case-Insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+ - Fix User Lookup Via SSO Email: Make Query Case-Insensitive [#924](https://github.com/portagenetwork/roadmap/pull/924)
+
 ## [4.1.1+portage-4.2.2] - 2024-09-18
 
 ### Changed

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -192,9 +192,8 @@ class User < ApplicationRecord
     return unless user.new_record?
 
     user.update!(
-      firstname: provider_data.info&.first_name.present? ? provider_data.info.first_name : _('First name'),
-      surname: provider_data.info&.last_name.present? ? provider_data.info.last_name : _('Last name'),
-      email: email,
+      firstname: provider_data.info&.first_name.presence || _('First name'),
+      surname: provider_data.info&.last_name.presence || _('Last name'),
       # We don't know which organization to setup so we will use other
       org: Org.find_by(is_other: true),
       accept_terms: true,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -186,8 +186,7 @@ class User < ApplicationRecord
   # Handle user creation from provider
   # rubocop:disable Metrics/AbcSize
   def self.create_from_provider_data(provider_data)
-    email = provider_data.info.email.downcase
-    user = User.find_or_initialize_by(email: email)
+    user = User.find_or_initialize_by(email: provider_data.info.email.downcase)
 
     return unless user.new_record?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -186,14 +186,15 @@ class User < ApplicationRecord
   # Handle user creation from provider
   # rubocop:disable Metrics/AbcSize
   def self.create_from_provider_data(provider_data)
-    user = User.find_or_initialize_by(email: provider_data.info.email)
+    email = provider_data.info.email.downcase
+    user = User.find_or_initialize_by(email: email)
 
     return unless user.new_record?
 
     user.update!(
       firstname: provider_data.info&.first_name.present? ? provider_data.info.first_name : _('First name'),
       surname: provider_data.info&.last_name.present? ? provider_data.info.last_name : _('Last name'),
-      email: provider_data.info.email,
+      email: email,
       # We don't know which organization to setup so we will use other
       org: Org.find_by(is_other: true),
       accept_terms: true,


### PR DESCRIPTION
Fixes #900

Changes proposed in this PR:
- Applied .downcase to the SSO email for case-insensitive user lookup:
  ```ruby
  email = provider_data.info.email.downcase
  user = User.find_or_initialize_by(email: email)
   ```
  - Given that all user emails in the database are stored in lowercase, this change ensures `User.find_or_initialize_by(email: email)` is case-insensitive (where `email` is the email provided by SSO/CILogon).
  - Analysis of the `identifiers` table (where `provider.info.email` values are stored) shows that some emails contain capital letters, whereas no capitalised emails exist within the `users` table. Without applying `.downcase`, the code was susceptible to the bug illustrated in the following comment: https://github.com/portagenetwork/roadmap/issues/900#issuecomment-2405659038

- Some factoring has also been done: ade11897923b3d854fb452107dee45c18de39be0