### PR TITLE
Fix Paginating, Sorting, and Searching Issues Within  "Research Outputs" Tab 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
  - Fixes to CILogon / `openid_connect` Tests [#922](https://github.com/portagenetwork/roadmap/pull/922)
 
+ - Fix Paginating, Sorting, and Searching Issues Within "Research Outputs" Tab [#938](https://github.com/portagenetwork/roadmap/pull/938)
+
 ## [4.1.1+portage-4.2.2] - 2024-09-18
 
 ### Changed

--- a/app/controllers/paginable/research_outputs_controller.rb
+++ b/app/controllers/paginable/research_outputs_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Paginable
+  # Controller for paginating/sorting/searching the research_outputs table
+  class ResearchOutputsController < ApplicationController
+    include Paginable
+
+    after_action :verify_authorized
+
+    # GET /paginable/plans/:plan_id/research_outputs
+    def index
+      @plan = Plan.find_by(id: params[:plan_id])
+
+      # Same @research_outputs assignment as app/controllers/research_outputs_controller.rb
+      @research_outputs = ResearchOutput.includes(:repositories).where(plan_id: @plan.id)
+      # Same authorize handling as app/controllers/research_outputs_controller.rb
+      authorize @research_outputs.first || ResearchOutput.new(plan_id: @plan.id)
+      paginable_renderise(
+        partial: 'index',
+        scope: @research_outputs,
+        query_params: { sort_field: 'research_outputs.title' },
+        format: :json
+      )
+    end
+  end
+end

--- a/app/controllers/paginable/research_outputs_controller.rb
+++ b/app/controllers/paginable/research_outputs_controller.rb
@@ -13,7 +13,9 @@ module Paginable
       # Same assignment as app/controllers/research_outputs_controller.rb
       research_outputs = ResearchOutput.includes(:repositories).where(plan_id: @plan.id)
       # Same authorize handling as app/controllers/research_outputs_controller.rb
-      authorize research_outputs.first || ResearchOutput.new(plan_id: @plan.id)
+      # `|| ResearchOutput.new(plan_id: @plan.id)` prevents Pundit::NotDefinedError when a direct
+      # GET /paginable/plans/:id/research_outputs request is made on a plan with 0 research_outputs
+      authorize(research_outputs.first || ResearchOutput.new(plan_id: @plan.id))
       paginable_renderise(
         partial: 'index',
         scope: research_outputs,

--- a/app/controllers/paginable/research_outputs_controller.rb
+++ b/app/controllers/paginable/research_outputs_controller.rb
@@ -10,13 +10,13 @@ module Paginable
     # GET /paginable/plans/:plan_id/research_outputs
     def index
       @plan = Plan.find_by(id: params[:plan_id])
-      # Same @research_outputs assignment as app/controllers/research_outputs_controller.rb
-      @research_outputs = ResearchOutput.includes(:repositories).where(plan_id: @plan.id)
+      # Same assignment as app/controllers/research_outputs_controller.rb
+      research_outputs = ResearchOutput.includes(:repositories).where(plan_id: @plan.id)
       # Same authorize handling as app/controllers/research_outputs_controller.rb
-      authorize @research_outputs.first || ResearchOutput.new(plan_id: @plan.id)
+      authorize research_outputs.first || ResearchOutput.new(plan_id: @plan.id)
       paginable_renderise(
         partial: 'index',
-        scope: @research_outputs,
+        scope: research_outputs,
         query_params: { sort_field: 'research_outputs.title' },
         format: :json
       )

--- a/app/controllers/paginable/research_outputs_controller.rb
+++ b/app/controllers/paginable/research_outputs_controller.rb
@@ -10,7 +10,6 @@ module Paginable
     # GET /paginable/plans/:plan_id/research_outputs
     def index
       @plan = Plan.find_by(id: params[:plan_id])
-
       # Same @research_outputs assignment as app/controllers/research_outputs_controller.rb
       @research_outputs = ResearchOutput.includes(:repositories).where(plan_id: @plan.id)
       # Same authorize handling as app/controllers/research_outputs_controller.rb

--- a/app/models/research_output.rb
+++ b/app/models/research_output.rb
@@ -70,6 +70,15 @@ class ResearchOutput < ApplicationRecord
   # Ensure presence of the :output_type_description if the user selected 'other'
   validates_presence_of :output_type_description, if: -> { other? }, message: PRESENCE_MESSAGE
 
+  # ==========
+  # = Scopes =
+  # ==========
+
+  scope :search, lambda { |term|
+                   search_pattern = "%#{term}%"
+                   where('lower(title) LIKE lower(?)', search_pattern)
+                 }
+
   # ====================
   # = Instance methods =
   # ====================


### PR DESCRIPTION
Fixes #935

Changes proposed in this PR:
- Add `scope :search` to `ResearchOutput` model: e289fba9b0cbe4af4699455cf08adca8f597dac1
  - Search query is performed by `research_outputs.title` (case-insensitive) 
- Create `app/controllers/paginable/research_outputs_controller.rb` 3c5a478feacc9bb9a8e69abd93579c70af29a207
  - This new controller fixes the following features on the `/plans/:plan_id/research_outputs` page:
    - The clickable pagination options (e.g. View all,1,2,Next,Last)
    - The search box (for `research_outputs.title` matches)
    - The clickable sorting arrows