### PR TITLE
Add rake task for `openid_connect` / CILogon cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+ - Add rake task for openid_connect / CILogon cleanup [#944](https://github.com/portagenetwork/roadmap/pull/944)
+
 ### Changed
 
  - Email Confirmation Changes [#923](https://github.com/portagenetwork/roadmap/pull/923)

--- a/lib/tasks/dmp_assistant_upgrade.rake
+++ b/lib/tasks/dmp_assistant_upgrade.rake
@@ -12,7 +12,12 @@ namespace :dmp_assistant_upgrade do
     p '------------------------------------------------------------------------'
     handle_email_confirmations_for_existing_users
     p 'Task completed: Handle email confirmations for existing users'
-    p 'All tasks completed successfully'
+    p 'Beginning task: Update `openid_connect` IdentifierScheme and its identifers'
+    p '------------------------------------------------------------------------'
+    if openid_scheme_and_its_identifiers_updated?
+      p 'Task completed: Update `openid_connect` IdentifierScheme and its identifers'
+      p 'All tasks completed successfully'
+    end
   end
   # rubocop:enable Naming/VariableNumber
 
@@ -52,5 +57,41 @@ namespace :dmp_assistant_upgrade do
   # i.e. `can_add_orgs? || can_grant_api_to_orgs? || can_change_org?` )
   def super_admin_perm_ids
     [Perm.add_orgs.id, Perm.grant_api.id, Perm.change_affiliation.id]
+  end
+
+  # Returns a boolean indicating whether the task was executed successfully
+  def openid_scheme_and_its_identifiers_updated?
+    identifier_scheme = IdentifierScheme.includes(:identifiers)
+                                        .find_by!(name: 'openid_connect')
+    old_prefix = identifier_scheme.identifier_prefix
+    p "Updating identifier_prefix to '' for openid_connect IdentifierScheme"
+    p '------------------------------------------------------------------------'
+    begin
+      ensure_correct_identifier_prefix(old_prefix)
+    rescue StandardError => e
+      p "Error updating IdentifierScheme: #{e.message}"
+      return false
+    end
+
+    # Update identifier_prefix to '' for openid_connect
+    identifier_scheme.update!(identifier_prefix: '')
+    p "identifier_prefix updated from #{old_prefix} to '' for #{identifier_scheme.name} IdentifierScheme"
+    p "Updating prefixed value for identifiers with multiple occurences of 'cilogon'"
+    p '------------------------------------------------------------------------'
+    # Find all identifiers having multiple occurences of 'cilogon' in their value
+    identifiers = identifier_scheme.identifiers.where('value ~* ?', "#{old_prefix}.+cilogon.+")
+    count = identifiers.count
+    p "(Found #{count} such identifiers)"
+    # identifier_scheme.identifier_prefix was used to prefix identifier.value
+    # Update the affected identifier values from `old_prefix` to ''
+    identifiers.each { |identifier| identifier.update!(value: identifier.value.delete_prefix(old_prefix)) }
+    p "Updated prefixed value from #{old_prefix} to '' for #{count} identifiers"
+    true
+  end
+
+  def ensure_correct_identifier_prefix(prefix)
+    expected_prefix = 'http://cilogon.org/serverE/users/'
+    error_msg = "Unexpected identifier_prefix! Expected #{expected_prefix} but got #{prefix}."
+    raise error_msg unless prefix == expected_prefix
   end
 end


### PR DESCRIPTION
Fixes #912

Changes proposed in this PR:
- Adds a task to `rake dmp_assistant_upgrade:4_2_3`
  - Updates `.identifier_prefix`  from `'http://cilogon.org/serverE/users/'` to `''` for the `openid_connect` `IdentifierScheme`
  - Updates the prefixed value of `.value` from  `'http://cilogon.org/serverE/users/'` to `''` for some existing `openid_connect`-related identifiers
    - Specifically, the following identifiers are updated:
      ```ruby
      old_prefix = 'http://cilogon.org/serverE/users/'
      identifier_scheme = IdentifierScheme.find_by!(name: 'openid_connect')
      identifiers = identifier_scheme.identifiers.where('value ~* ?', "#{old_prefix}.+cilogon.+")
      ```
- NOTE: This PR is largely based off of the following PR: https://github.com/portagenetwork/roadmap/pull/915