### PR TITLE
Edit Contents of Confirmation Instructions Email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Changed
 
- - Email Confirmation Changes [#923](https://github.com/portagenetwork/roadmap/pull/923)
+ - Email Confirmation Changes [#923](https://github.com/portagenetwork/roadmap/pull/923), [#952](https://github.com/portagenetwork/roadmap/pull/952)
 
  - Disable Updating of User Emails [#917](https://github.com/portagenetwork/roadmap/pull/917)
 

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,7 +1,7 @@
 <% I18n.with_locale I18n.locale do %>
 	<p><%= _("Welcome to %{application_name}") % {application_name: ApplicationService.application_name} %>, <%= @email %>!</p>
 
-	<p><%= _("Thank you for registering. Please confirm your email address") %>:</p>
+	<p><%= _("Please confirm your email address") %>:</p>
 
 	<p><%= link_to _("Click here to confirm your account"),  confirmation_url(@resource, :confirmation_token => @token) %> (<%= _("or copy") %> <%= confirmation_url(@resource, :confirmation_token => @token) %> <%= _("into your browser") %>).</p>
 <% end %>


### PR DESCRIPTION
Changes proposed in this PR:
- The upcoming `4.1.1+portage-4.2.3` release will require all existing users to confirm their emails. This commit edits the contents of that confirmation email. "Thank you for registering." makes sense for users that just created an account, but doesn't sound right when read by users with existing accounts. Thus, we are removing the sentence.