### PR TITLE
Enable Translations On `/users/confirmation/new` Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+ - Enable Translations On `/users/confirmation/new` Page [#953](https://github.com/portagenetwork/roadmap/pull/953)
+
  - Email Confirmation Changes [#923](https://github.com/portagenetwork/roadmap/pull/923), [#952](https://github.com/portagenetwork/roadmap/pull/952)
 
  - Disable Updating of User Emails [#917](https://github.com/portagenetwork/roadmap/pull/917)

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend confirmation instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend confirmation instructions" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,15 +1,15 @@
-<h2>Resend confirmation instructions</h2>
+<h2><%= _('Resend confirmation instructions') %></h2>
 
 <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
-    <%= f.label :email %><br />
+    <%= f.label :email, _('Email') %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
   </div>
 
   <div class="actions">
-    <%= f.submit "Resend confirmation instructions" %>
+    <%= f.submit _('Resend confirmation instructions') %>
   </div>
 <% end %>
 


### PR DESCRIPTION
Changes proposed in this PR:
- Copy Devise's default `app/views/devise/confirmations/new.html.erb` to codebase (executed `rails generate devise:views`)
- Enable translations within `app/views/devise/confirmations/new.html.erb` 