### PR TITLE
Clean Up `/contact-us` Page, Fix "Contact us" Footer Link, and Update `terms_of_use_path`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
  
  - Add `upgrade_customization?` Check When Determining Default Template (Funder vs Org Customization) For Dropdown [#1014](https://github.com/portagenetwork/roadmap/pull/1014)
 
+ - Clean Up `/contact-us` Page, Fix "Contact us" Footer Link, and Update `terms_of_use_path` [#978](https://github.com/portagenetwork/roadmap/pull/978)
+
 ### Changed
 
  - Delete Auto-Generated and Unused `tinymce/skins` Contents and Add to `.gitignore` [#1060](https://github.com/portagenetwork/roadmap/pull/1060)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
  
  - Add `upgrade_customization?` Check When Determining Default Template (Funder vs Org Customization) For Dropdown [#1014](https://github.com/portagenetwork/roadmap/pull/1014)
 
- - Clean Up `/contact-us` Page, Fix "Contact us" Footer Link, and Update `terms_of_use_path` [#978](https://github.com/portagenetwork/roadmap/pull/978)
+ - Clean Up `/contact-us` Page, Fix "Contact us" Footer Link, and Update '/terms' Path Routing [#978](https://github.com/portagenetwork/roadmap/pull/978)
 
 ### Changed
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -53,15 +53,6 @@ module ApplicationHelper
     end
   end
 
-  def contact_us_path
-    if I18n.locale == :'fr-CA'
-      'https://portagenetwork.ca/fr/contactez-nous/'
-    else
-      # Handling :'en-CA' locale
-      'https://portagenetwork.ca/contact-us/'
-    end
-  end
-
   # TODO: Replace function body with the commented-out code when French version of this path is made available.
   def terms_of_use_path
     'https://dmp-pgd.ca/terms' # TEMPORARY FIX

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -53,10 +53,6 @@ module ApplicationHelper
     end
   end
 
-  def terms_of_use_path
-    '/terms'
-  end
-
   def how_to_manage_your_data_path
     if I18n.locale == :'fr-CA'
       'https://portagenetwork.ca/fr/outils-et-ressources/assistant-pgd/comment-gerer-vos-donnees/'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -53,15 +53,8 @@ module ApplicationHelper
     end
   end
 
-  # TODO: Replace function body with the commented-out code when French version of this path is made available.
   def terms_of_use_path
-    'https://dmp-pgd.ca/terms' # TEMPORARY FIX
-    # if I18n.locale == :'fr-CA'
-    #   'https://portagenetwork.ca/fr/outils-et-ressources/assistant-pgd/conditions-dutilisation-de-lassistant-pgd/'
-    # else
-    #   # Handling :'en-CA' locale
-    #   'https://assistant.portagenetwork.ca/terms'
-    # end
+    '/terms'
   end
 
   def how_to_manage_your_data_path

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -42,7 +42,7 @@
           <%= f.label(:accept_terms) do %>
             <%= f.check_box(:accept_terms, "aria-required": true, required: true) %>
             <%= _('I accept the') %>
-            <%= link_to _('terms and conditions'), terms_of_use_path %>
+            <%= link_to _('terms and conditions'), terms_path %>
           <% end %>
         </div>
       </div>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -76,7 +76,7 @@
         }, Rails.configuration.branding[:organisation][:url])%></li>
       <li>•</li>
       <li><a href="<%= contact_us %>"><%= _('Contact us') %></a></li>
-      <li><a href="<%= terms_of_use_path %>"><%= _('Terms of use') %></a></li>
+      <li><a href="<%= terms_path %>"><%= _('Terms of use') %></a></li>
       <li><a href="/privacy"><%= _('Privacy statement') %></a></li>
       <li><a href="https://github.com/portagenetwork/roadmap"><%= _('GitHub') %></a></li>
     </ul>    

--- a/app/views/shared/_create_account_form.html.erb
+++ b/app/views/shared/_create_account_form.html.erb
@@ -40,7 +40,7 @@
       <%= f.label(:accept_terms) do %>
         <%= f.check_box(:accept_terms, "aria-required": true) %>
         <%= _('I accept the') %>
-        <%= link_to _('terms and conditions'), terms_of_use_path %>
+        <%= link_to _('terms and conditions'), terms_path %>
       <% end %>
     </div>
   </div>

--- a/config/initializers/_dmproadmap.rb
+++ b/config/initializers/_dmproadmap.rb
@@ -38,7 +38,6 @@ module DMPRoadmap
     # Your organisation's telephone number - used on the contact us page
     config.x.organisation.telephone = nil
     # Your organisation's address - used on the contact us page
-    # rubocop:disable Naming/VariableNumber
     config.x.organisation.address = {
       line1: nil,
       line2: nil,
@@ -46,8 +45,6 @@ module DMPRoadmap
       line4: nil,
       country: 'Canada'
     }
-    # rubocop:enable Naming/VariableNumber
-
     # The Google maps link to your organisation's location - used to display the
     # Google map on the contact us page.
     # To find your organisation's Google maps URL, open maps.google.com, search for

--- a/config/initializers/_dmproadmap.rb
+++ b/config/initializers/_dmproadmap.rb
@@ -36,14 +36,14 @@ module DMPRoadmap
     # This email is used in email communications
     config.x.organisation.helpdesk_email = 'dmp-assistant@tech.alliancecan.ca'
     # Your organisation's telephone number - used on the contact us page
-    config.x.organisation.telephone = '+1-123-123-1234'
+    config.x.organisation.telephone = nil
     # Your organisation's address - used on the contact us page
     # rubocop:disable Naming/VariableNumber
     config.x.organisation.address = {
-      line_1: 'P.O. Box 48008',
-      line_2: 'Davisville Post Office',
-      line_3: 'Toronto, ON',
-      line_4: 'M4S 3C6',
+      line_1: nil,
+      line_2: nil,
+      line_3: nil,
+      line_4: nil,
       country: 'Canada'
     }
     # rubocop:enable Naming/VariableNumber
@@ -55,7 +55,7 @@ module DMPRoadmap
     # once the menu opens, click the 'share or embed' link and the 'embed' tab on
     # the dialog window that opens. DO NOT place the entire <iframe> tag below, just
     # the address!
-    config.x.organisation.google_maps_link = 'https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d29046286.09795864!2d-34.22768319424708!3d-63.61874004304689!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0xb57520cc078b16a9!2sPrincess%20Elisabeth%20Station!5e0!3m2!1sen!2sus!4v1587495708129!5m2!1sen!2sus'
+    config.x.organisation.google_maps_link = nil
 
     # Uncomment the following line if you want to redirect your users to an
     # organisational contact/help page instead of using the built-in contact_us form

--- a/config/initializers/_dmproadmap.rb
+++ b/config/initializers/_dmproadmap.rb
@@ -40,10 +40,10 @@ module DMPRoadmap
     # Your organisation's address - used on the contact us page
     # rubocop:disable Naming/VariableNumber
     config.x.organisation.address = {
-      line_1: nil,
-      line_2: nil,
-      line_3: nil,
-      line_4: nil,
+      line1: nil,
+      line2: nil,
+      line3: nil,
+      line4: nil,
       country: 'Canada'
     }
     # rubocop:enable Naming/VariableNumber


### PR DESCRIPTION
Fixes #961

Changes proposed in this PR:
- Prevent dummy values for "telephone", "address", and "google_maps_link" from being rendered within `/contact-us` page.
- Fix variable name typos within `config.x.organisation.address` to properly correspond with variable names within `app/views/contact_us/contacts/_new_right.html.erb`.
- Override/undo overriding of `contact_us_path`
  - `contact_us_path` now defaults to the following via the `contact_us` gem:
      ```
      3.1.4 :001 > Rails.application.routes.url_helpers.contact_us_path
      => "/contact-us"
      3.1.4 :002 > I18n.locale = :'fr-CA'
      => :"fr-CA"
      3.1.4 :003 > Rails.application.routes.url_helpers.contact_us_path
      => "/contact-us"
      ```
- Replace `def terms_of_use_path` Rails convention `terms_path`.