### PR TITLE
Fix and Refactor Querying of `template.phases` and Associations Within `OrgAdmin TemplatesController`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+ - Fix and Refactor Querying of `template.phases` and Associations Within `OrgAdmin TemplatesController` [#991](https://github.com/portagenetwork/roadmap/pull/991)
+
 ### Changed
 
  - Bump wkhtmltopdf-binary from 0.12.6.7 to 0.12.6.8 [#989](https://github.com/portagenetwork/roadmap/pull/989)

--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -104,11 +104,7 @@ module OrgAdmin
       template = Template.find(params[:id])
       authorize template
       # Load the info needed for the overview section if the authorization check passes!
-      phases = template.phases
-                       .includes(sections: { questions: :question_options })
-                       .order('phases.number', 'sections.number', 'questions.number',
-                              'question_options.number')
-                       .select(:title, :description, :modifiable)
+      phases = fetch_template_phases(template)
       unless template.latest?
         # rubocop:disable Layout/LineLength
         flash[:notice] = _('You are viewing a historical version of this template. You will not be able to make changes.')
@@ -123,17 +119,11 @@ module OrgAdmin
     end
 
     # GET /org_admin/templates/:id/edit
-    # rubocop:disable Metrics/AbcSize
     def edit
       template = Template.includes(:org, :phases).find(params[:id])
       authorize template
       # Load the info needed for the overview section if the authorization check passes!
-      phases = template.phases.includes(sections: { questions: :question_options })
-                       .order('phases.number',
-                              'sections.number',
-                              'questions.number',
-                              'question_options.number')
-                       .select(:title, :description, :modifiable)
+      phases = fetch_template_phases(template)
       if template.latest?
         render 'container', locals: {
           partial_path: 'edit',
@@ -145,7 +135,6 @@ module OrgAdmin
         redirect_to org_admin_template_path(id: template.id)
       end
     end
-    # rubocop:enable Metrics/AbcSize
 
     # GET /org_admin/templates/new
     def new
@@ -357,6 +346,16 @@ module OrgAdmin
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
     private
+
+    def fetch_template_phases(template)
+      template.phases
+              .includes(sections: { questions: :question_options })
+              .order('phases.number',
+                     'sections.number',
+                     'questions.number',
+                     'question_options.number')
+              .select(:title, :description, :modifiable)
+    end
 
     def template_params
       # TODO: For some reason the sample plans and funder links are sent outside

--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -2,7 +2,6 @@
 
 module OrgAdmin
   # Controller that handles templates
-  # rubocop:disable Metrics/ClassLength
   class TemplatesController < ApplicationController
     include Paginable
     include Versionable
@@ -109,8 +108,7 @@ module OrgAdmin
                        .includes(sections: { questions: :question_options })
                        .order('phases.number', 'sections.number', 'questions.number',
                               'question_options.number')
-                       .select('phases.title', 'phases.description', 'phases.modifiable',
-                               'sections.title', 'questions.text', 'question_options.text')
+                       .select(:title, :description, :modifiable)
       unless template.latest?
         # rubocop:disable Layout/LineLength
         flash[:notice] = _('You are viewing a historical version of this template. You will not be able to make changes.')
@@ -125,7 +123,7 @@ module OrgAdmin
     end
 
     # GET /org_admin/templates/:id/edit
-    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize
     def edit
       template = Template.includes(:org, :phases).find(params[:id])
       authorize template
@@ -135,12 +133,7 @@ module OrgAdmin
                               'sections.number',
                               'questions.number',
                               'question_options.number')
-                       .select('phases.title',
-                               'phases.description',
-                               'phases.modifiable',
-                               'sections.title',
-                               'questions.text',
-                               'question_options.text')
+                       .select(:title, :description, :modifiable)
       if template.latest?
         render 'container', locals: {
           partial_path: 'edit',
@@ -152,7 +145,7 @@ module OrgAdmin
         redirect_to org_admin_template_path(id: template.id)
       end
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize
 
     # GET /org_admin/templates/new
     def new
@@ -415,5 +408,4 @@ module OrgAdmin
       end
     end
   end
-  # rubocop:enable Metrics/ClassLength
 end

--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -350,11 +350,7 @@ module OrgAdmin
     def fetch_template_phases(template)
       template.phases
               .includes(sections: { questions: :question_options })
-              .order('phases.number',
-                     'sections.number',
-                     'questions.number',
-                     'question_options.number')
-              .select(:title, :description, :modifiable)
+              .select(:id, :title, :description, :modifiable)
     end
 
     def template_params

--- a/app/views/org_admin/phases/_phase.html.erb
+++ b/app/views/org_admin/phases/_phase.html.erb
@@ -55,7 +55,7 @@
                           <%= sanitize question.text %>
                           <% if question.question_options.length > 0 %>
                             <ul>
-                              <% question.question_options.each do |option| %>
+                              <% question.question_options.by_number.each do |option| %>
                                 <li><%= option.text %></li>
                               <% end %>
                             </ul>

--- a/app/views/org_admin/phases/_phase.html.erb
+++ b/app/views/org_admin/phases/_phase.html.erb
@@ -53,7 +53,7 @@
                       <% section.questions.each do |question| %>
                         <li>
                           <%= sanitize question.text %>
-                          <% if question.question_options.length > 0 %>
+                          <% if question.question_options.any? %>
                             <ul>
                               <% question.question_options.by_number.each do |option| %>
                                 <li><%= option.text %></li>


### PR DESCRIPTION
Fixes #955

Changes proposed in this PR:
- Address ambiguity and remove one-to-many columns from `.select()` clause ca52b915253cd412e7a50372b730586965b56a98
  - Prior to this commit, both 'phases.title' and 'sections.title' were included in the `.select()` clause. Since 'sections.title' was listed after 'phases.title', `phases.first.title`, would evaluate to the `sections.title` value.
  - A phase can have multiple sections, questions, and question_options, so including columns like `sections.title` in `.select()` is not appropriate.
  - No additional handling is needed since we're already using `.includes(sections: { questions: :question_options })` to preload the associations, and `phase.sections.each` etc. handles the associations properly within the view.

- Refactor fetching of `template.phases` b18a454964e559bb73f09d78f0f314187264089c
  - There were identical `phases` queries within the `view` and `edit` actions. This refactor makes the query accessible by calling the `fetch_template_phases` method.

- Fix and refactor ordering of template associations c7921b4694e01eddc0fbb02792a09e068320f0e7
  - Removed `.order()` as it was only applied to the main phases query and did not guarantee the order of associated records (e.g., `question_options`), which are loaded in separate queries.
  - `default_scope { order(number: :asc) }` already exists for the `Phase`, `Section`, and `Question` models, ensuring the desired ordering by default.
  - The `QuestionOption` model includes `scope :by_number, -> { order(:number) }`, which is now explicitly applied when fetching the `question_options` association to enable proper ordering.
  - `.order()` must've been auto-including `:id` in the `.select()` clause. Since it is required, we are explicitly adding it now.

- Refactor/optimise check for `question_options` db92f3b0cbcc19ab86a8699dbdccc4c4b87b98be
  - Replaced `.length > 0` with `.any?` to improve readability and performance.
  - `.any?` is more efficient for checking if a collection has elements, especially for ActiveRecord associations, as it doesn't require loading the entire collection into memory.