### PR TITLE
Fix Handling of "Only Show Admins" Filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+ - Fix Handling of "Only Show Admins" Filter [#996](https://github.com/portagenetwork/roadmap/pull/996)
+
 ### Changed
 
  - Bump jwt from 2.8.2 to 2.10.1 [#984](https://github.com/portagenetwork/roadmap/pull/984)

--- a/app/controllers/paginable/users_controller.rb
+++ b/app/controllers/paginable/users_controller.rb
@@ -25,7 +25,7 @@ module Paginable
       paginable_renderise(
         partial: 'index',
         scope: scope,
-        query_params: { sort_field: 'users.surname', sort_direction: :asc },
+        query_params: { sort_field: 'users.surname', sort_direction: :asc, filter_admin: params[:filter_admin] },
         format: :json,
         view_all: !current_user.can_super_admin?
       )


### PR DESCRIPTION
Fixes #941

Changes proposed in this PR:
- Updated the `index` action within `Paginable UsersController` to include `filter_admin` in the `query_params` for `paginable_renderise`.
- This addresses the issue where `filter_admin` was sometimes `nil` within the controller, even when it was set to '1' in the browser (https://github.com/portagenetwork/roadmap/issues/941).
