### PR TITLE
Update Handling For When Linking New External Credentials Without IdP email and Refactor `def openid_connect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
 
  - Bump guard from 2.18.0 to 2.19.1 [#994](https://github.com/portagenetwork/roadmap/pull/994)
 
+ - Update Handling For When Linking New External Credentials Without IdP email and Refactor `def openid_connect` [#1003](https://github.com/portagenetwork/roadmap/pull/1003)
+
 ## [4.1.1+portage-4.3.0]
 
 ### Added

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -6,7 +6,6 @@ module Users
     include EmailConfirmationHandler
 
     # This is for the OpenidConnect CILogon
-    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def openid_connect
       auth = request.env['omniauth.auth']
       user = User.from_omniauth(auth)
@@ -22,22 +21,11 @@ module Users
       # if user is not signed in (They clicked the SSO sign in button)
       if current_user.nil?
         handle_openid_connect_for_signed_out_user(user, auth, identifier_scheme)
-      elsif user.nil?
-        # we need to link
-        current_user.identifiers << Identifier.create(identifier_scheme: identifier_scheme,
-                                                      value: auth.uid,
-                                                      attrs: auth,
-                                                      identifiable: current_user)
-        flash[:notice] = _('Linked successfully')
-        redirect_to root_path
-      # elsif user is signed in and trying to link via SSO, but the auth creds are already linked to another account
-      elsif user.id != current_user.id
-        flash[:alert] = format(_('The current %{description} iD has been already linked to a user with email %{email}'),
-                               description: identifier_scheme.description, email: user.email)
-        redirect_to edit_user_registration_path
+      # else user is signed in (They clicked the SSO link account button)
+      else
+        handle_openid_connect_for_signed_in_user(user, auth, identifier_scheme)
       end
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
     def orcid
       handle_omniauth(IdentifierScheme.for_authentication.find_by(name: 'orcid'))
@@ -172,6 +160,23 @@ module Users
                                               identifiable: user)
       end
       user
+    end
+
+    def handle_openid_connect_for_signed_in_user(user, auth, identifier_scheme)
+      if user.nil?
+        # we need to link
+        current_user.identifiers << Identifier.create(identifier_scheme: identifier_scheme,
+                                                      value: auth.uid,
+                                                      attrs: auth,
+                                                      identifiable: current_user)
+        flash[:notice] = _('Linked successfully')
+        redirect_to root_path
+      # elsif user is signed in and trying to link via SSO, but the auth creds are already linked to another account
+      elsif user.id != current_user.id
+        flash[:alert] = format(_('The current %{description} iD has been already linked to a user with email %{email}'),
+                               description: identifier_scheme.description, email: user.email)
+        redirect_to edit_user_registration_path
+      end
     end
   end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -8,21 +8,19 @@ module Users
     # This is for the OpenidConnect CILogon
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def openid_connect
-      # First or create
       auth = request.env['omniauth.auth']
       user = User.from_omniauth(auth)
 
+      # if email missing from IdP and no user with these auth creds exists in DB
       if auth.info.email.nil? && user.nil?
-        # If email is missing we need to request the user to register with DMP.
-        # User email can be missing if the usFFvate or trusted clients only we won't get the value.
-        # User email id is one of the mandatory field which is must required.
         handle_missing_email_for_new_sso_entry
         return
       end
 
       identifier_scheme = IdentifierScheme.find_by(name: auth.provider)
 
-      if current_user.nil? # if user is not signed in (They clicked the SSO sign in button)
+      # if user is not signed in (They clicked the SSO sign in button)
+      if current_user.nil?
         handle_openid_connect_for_signed_out_user(user, auth, identifier_scheme)
       elsif user.nil?
         # we need to link
@@ -30,13 +28,10 @@ module Users
                                                       value: auth.uid,
                                                       attrs: auth,
                                                       identifiable: current_user)
-
         flash[:notice] = _('Linked successfully')
-
         redirect_to root_path
+      # elsif user is signed in and trying to link via SSO, but the auth creds are already linked to another account
       elsif user.id != current_user.id
-        # If a user was found but does NOT match the current user then the identifier has
-        # already been attached to another account (likely the user has 2 accounts)
         flash[:alert] = format(_('The current %{description} iD has been already linked to a user with email %{email}'),
                                description: identifier_scheme.description, email: user.email)
         redirect_to edit_user_registration_path
@@ -137,14 +132,14 @@ module Users
 
     def generate_flash_message_for_missing_email
       url = 'https://cilogon.org/testidp/'
-      # if user tried to sign in via SSO
+      # if user is signed out and tried to sign in via SSO
       if current_user.nil?
         format(
           _('Unable to sign in with the selected identity provider. Please visit %{url} to verify ' \
             'that all required fields are provided, or try signing in with another identity provider.'),
           url: view_context.link_to(nil, url)
         )
-      # user is signed in and attempted to link a new SSO account
+      # else user is signed in and attempted to link a new SSO account
       else
         format(
           _('Unable to link with the selected identity provider. Please visit %{url} to verify ' \

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -164,19 +164,27 @@ module Users
 
     def handle_openid_connect_for_signed_in_user(user, auth, identifier_scheme)
       if user.nil?
-        # we need to link
-        current_user.identifiers << Identifier.create(identifier_scheme: identifier_scheme,
-                                                      value: auth.uid,
-                                                      attrs: auth,
-                                                      identifiable: current_user)
-        flash[:notice] = _('Linked successfully')
-        redirect_to root_path
+        # We need to link the new auth creds
+        handle_new_sso_email_for_signed_in_user(auth, identifier_scheme)
       # elsif user is signed in and trying to link via SSO, but the auth creds are already linked to another account
       elsif user.id != current_user.id
-        flash[:alert] = format(_('The current %{description} iD has been already linked to a user with email %{email}'),
-                               description: identifier_scheme.description, email: user.email)
-        redirect_to edit_user_registration_path
+        handle_conflicting_sso_email_for_signed_in_user(identifier_scheme, user)
       end
+    end
+
+    def handle_new_sso_email_for_signed_in_user(auth, identifier_scheme)
+      current_user.identifiers << Identifier.create(identifier_scheme: identifier_scheme,
+                                                    value: auth.uid,
+                                                    attrs: auth,
+                                                    identifiable: current_user)
+      flash[:notice] = _('Linked successfully')
+      redirect_to root_path
+    end
+
+    def handle_conflicting_sso_email_for_signed_in_user(identifier_scheme, user)
+      flash[:alert] = format(_('The current %{description} iD has been already linked to a user with email %{email}'),
+                             description: identifier_scheme.description, email: user.email)
+      redirect_to edit_user_registration_path
     end
   end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -121,23 +121,22 @@ module Users
     def generate_flash_message_for_missing_email
       testidp_url = 'https://cilogon.org/testidp/'
       helpdesk_email = Rails.configuration.x.organisation.helpdesk_email
-      # if user is signed out and attempted to sign in via SSO
-      if current_user.nil?
-        format(
+      msg_template =
+        if current_user.nil? # if user is signed out and attempted to sign in via SSO
           _('Unable to sign in with the selected identity provider. Consider using an alternative sign in method, ' \
             'like social sign on. You can verify your email is being provided here <%{url}> and contact us at the ' \
-            'help desk for further assistance. Help desk email: %{helpdesk_email}'),
-          url: view_context.link_to(nil, testidp_url), helpdesk_email: view_context.mail_to(helpdesk_email)
-        )
-      # else user is signed in and attempted to link a new SSO account
-      else
-        format(
+            'help desk for further assistance. Help desk email: %{helpdesk_email}')
+        else # else user is signed in and attempted to link a new SSO account
           _('Unable to link with the selected identity provider. Consider using an alternative sign in method, ' \
             'like social sign on. You can verify your email is being provided here <%{url}> and contact us at the ' \
-            'help desk for further assistance. Help desk email: %{helpdesk_email}'),
-          url: view_context.link_to(nil, testidp_url), helpdesk_email: view_context.mail_to(helpdesk_email)
-        )
-      end
+            'help desk for further assistance. Help desk email: %{helpdesk_email}')
+        end
+
+      format(
+        msg_template,
+        url: view_context.link_to(nil, testidp_url),
+        helpdesk_email: view_context.mail_to(helpdesk_email)
+      )
     end
 
     def handle_openid_connect_for_signed_out_user(user, auth, identifier_scheme)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -16,8 +16,7 @@ module Users
         # If email is missing we need to request the user to register with DMP.
         # User email can be missing if the usFFvate or trusted clients only we won't get the value.
         # User email id is one of the mandatory field which is must required.
-        flash[:notice] = _('Something went wrong, Please try signing up here.')
-        redirect_to new_user_registration_path
+        handle_missing_email_for_new_sso_entry
         return
       end
 
@@ -127,6 +126,33 @@ module Users
     end
 
     private
+
+    def handle_missing_email_for_new_sso_entry
+      flash[:alert] = generate_flash_message_for_missing_email
+      # Signed out user stays on 'Sign in' page
+      # Signed in user stays on 'Edit profile' page
+      path = current_user.nil? ? root_path : edit_user_registration_path
+      redirect_to path
+    end
+
+    def generate_flash_message_for_missing_email
+      url = 'https://cilogon.org/testidp/'
+      # if user tried to sign in via SSO
+      if current_user.nil?
+        format(
+          _('Unable to sign in with the selected identity provider. Please visit %{url} to verify ' \
+            'that all required fields are provided, or try signing in with another identity provider.'),
+          url: view_context.link_to(nil, url)
+        )
+      # user is signed in and attempted to link a new SSO account
+      else
+        format(
+          _('Unable to link with the selected identity provider. Please visit %{url} to verify ' \
+            'that all required fields are provided, or try linking with another identity provider.'),
+          url: view_context.link_to(nil, url)
+        )
+      end
+    end
 
     def handle_openid_connect_for_signed_out_user(user, auth, identifier_scheme)
       # user.nil? is true if the chosen CILogon email is not currently linked to an existing user account

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -119,20 +119,23 @@ module Users
     end
 
     def generate_flash_message_for_missing_email
-      url = 'https://cilogon.org/testidp/'
-      # if user is signed out and tried to sign in via SSO
+      testidp_url = 'https://cilogon.org/testidp/'
+      helpdesk_email = Rails.configuration.x.organisation.helpdesk_email
+      # if user is signed out and attempted to sign in via SSO
       if current_user.nil?
         format(
-          _('Unable to sign in with the selected identity provider. Please visit %{url} to verify ' \
-            'that all required fields are provided, or try signing in with another identity provider.'),
-          url: view_context.link_to(nil, url)
+          _('Unable to sign in with the selected identity provider. Consider using an alternative sign in method, ' \
+            'like social sign on. You can verify your email is being provided here <%{url}> and contact us at the ' \
+            'help desk for further assistance. Help desk email: %{helpdesk_email}'),
+          url: view_context.link_to(nil, testidp_url), helpdesk_email: view_context.mail_to(helpdesk_email)
         )
       # else user is signed in and attempted to link a new SSO account
       else
         format(
-          _('Unable to link with the selected identity provider. Please visit %{url} to verify ' \
-            'that all required fields are provided, or try linking with another identity provider.'),
-          url: view_context.link_to(nil, url)
+          _('Unable to link with the selected identity provider. Consider using an alternative sign in method, ' \
+            'like social sign on. You can verify your email is being provided here <%{url}> and contact us at the ' \
+            'help desk for further assistance. Help desk email: %{helpdesk_email}'),
+          url: view_context.link_to(nil, testidp_url), helpdesk_email: view_context.mail_to(helpdesk_email)
         )
       end
     end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -178,7 +178,7 @@ module Users
                                                     attrs: auth,
                                                     identifiable: current_user)
       flash[:notice] = _('Linked successfully')
-      redirect_to root_path
+      redirect_to edit_user_registration_path
     end
 
     def handle_conflicting_sso_email_for_signed_in_user(identifier_scheme, user)

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -30,9 +30,12 @@ RSpec.describe Users::OmniauthCallbacksController, type: :controller do
       it 'Redirects signed out user to root path and renders correct flash message' do
         post :openid_connect
         expect(response).to redirect_to(root_path)
-        msg = 'Unable to sign in with the selected identity provider. Please visit ' \
-              '<a href="https://cilogon.org/testidp/">https://cilogon.org/testidp/</a> to verify ' \
-              'that all required fields are provided, or try signing in with another identity provider.'
+        msg = 'Unable to sign in with the selected identity provider. ' \
+              'Consider using an alternative sign in method, like social sign on. ' \
+              'You can verify your email is being provided here ' \
+              '<<a href="https://cilogon.org/testidp/">https://cilogon.org/testidp/</a>> ' \
+              'and contact us at the help desk for further assistance. Help desk email: ' \
+              '<a href="mailto:dmp-assistant@tech.alliancecan.ca">dmp-assistant@tech.alliancecan.ca</a>'
         expect(flash[:alert]).to eq(msg)
       end
 
@@ -40,9 +43,12 @@ RSpec.describe Users::OmniauthCallbacksController, type: :controller do
         sign_in current_user
         post :openid_connect
         expect(response).to redirect_to(edit_user_registration_path)
-        msg = 'Unable to link with the selected identity provider. Please visit ' \
-              '<a href="https://cilogon.org/testidp/">https://cilogon.org/testidp/</a> to verify ' \
-              'that all required fields are provided, or try linking with another identity provider.'
+        msg = 'Unable to link with the selected identity provider. ' \
+              'Consider using an alternative sign in method, like social sign on. ' \
+              'You can verify your email is being provided here ' \
+              '<<a href="https://cilogon.org/testidp/">https://cilogon.org/testidp/</a>> ' \
+              'and contact us at the help desk for further assistance. Help desk email: ' \
+              '<a href="mailto:dmp-assistant@tech.alliancecan.ca">dmp-assistant@tech.alliancecan.ca</a>'
         expect(flash[:alert]).to eq(msg)
       end
     end

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -26,11 +26,13 @@ RSpec.describe Users::OmniauthCallbacksController, type: :controller do
         @request.env['omniauth.auth'].info.email = nil
       end
 
-      it 'redirects to the registration page with a flash message' do
+      it 'Redirects signed out user to root path and renders correct flash message' do
         post :openid_connect
-
-        expect(response).to redirect_to(new_user_registration_path)
-        expect(flash[:notice]).to eq('Something went wrong, Please try signing up here.')
+        expect(response).to redirect_to(root_path)
+        msg = 'Unable to sign in with the selected identity provider. Please visit ' \
+              '<a href="https://cilogon.org/testidp/">https://cilogon.org/testidp/</a> to verify ' \
+              'that all required fields are provided, or try signing in with another identity provider.'
+        expect(flash[:alert]).to eq(msg)
       end
     end
 

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe Users::OmniauthCallbacksController, type: :controller do
   end
 
   describe 'POST #openid_connect' do
-    context 'when the email is missing and the user does not exist' do
+    context 'email is missing from IdP and no user with these auth creds exists in DB' do
+      let(:current_user) { create(:user) }
       before do
         # Simulate missing email
         @request.env['omniauth.auth'].info.email = nil
@@ -32,6 +33,16 @@ RSpec.describe Users::OmniauthCallbacksController, type: :controller do
         msg = 'Unable to sign in with the selected identity provider. Please visit ' \
               '<a href="https://cilogon.org/testidp/">https://cilogon.org/testidp/</a> to verify ' \
               'that all required fields are provided, or try signing in with another identity provider.'
+        expect(flash[:alert]).to eq(msg)
+      end
+
+      it 'Redirects signed in user to Edit Profile path and renders correct flash message' do
+        sign_in current_user
+        post :openid_connect
+        expect(response).to redirect_to(edit_user_registration_path)
+        msg = 'Unable to link with the selected identity provider. Please visit ' \
+              '<a href="https://cilogon.org/testidp/">https://cilogon.org/testidp/</a> to verify ' \
+              'that all required fields are provided, or try linking with another identity provider.'
         expect(flash[:alert]).to eq(msg)
       end
     end

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Users::OmniauthCallbacksController, type: :controller do
         end.to change(current_user.identifiers, :count).by(1)
 
         expect(flash[:notice]).to eq('Linked successfully')
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(edit_user_registration_path)
       end
     end
 


### PR DESCRIPTION
Fixes #966

Changes proposed in this PR:
- Updates handling for when `if auth.info.email.nil? && user.nil?`
 - Previously, when this condition was true, the following code was executed:
     ```ruby
     flash[:notice] = _('Something went wrong, Please try signing up here.')
     redirect_to new_user_registration_path
     ```
  - Now, the executed code is contingent on whether or not the user is signed into the app (see `def handle_missing_email_for_new_sso_entry`).

- Keep user on /users/edit page after linking creds e8bfb5678256f7ef32fdc38243e48933381fc8f4
  - This redirect seems to make more sense than the prior redirect to `root_path`

- In addition, this pull request addresses the outstanding `Metrics/AbcSize` and `Metrics/MethodLength` rubocop offenses that existed within `def openid_connect`.