### PR TITLE
Add Functionality Allowing Super Admins to Confirm/Unconfirm User Emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
  - Refactor: Implement Host-Based Routing and Remove Subpath URL Configuration [#1038](https://github.com/portagenetwork/roadmap/pull/1038)
 
+### Added
+
+ - Add Functionality Allowing Super Admins to Confirm/Unconfirm User Emails [#1009](https://github.com/portagenetwork/roadmap/pull/1009)
+
 ### Changed
 
  - Bump net-imap from 0.4.19 to 0.4.20 [#1037](https://github.com/portagenetwork/roadmap/pull/1037)

--- a/app/controllers/super_admin/users_controller.rb
+++ b/app/controllers/super_admin/users_controller.rb
@@ -142,8 +142,8 @@ module SuperAdmin
       # if an unconfirmed email is now being confirmed
       if !@user.confirmed? && attrs[:confirmed_at] == '1'
         attrs[:confirmed_at] = Time.current
-      # elsif a confirmed email is now being unconfirmed
-      elsif @user.confirmed? && attrs[:confirmed_at] == '0'
+      # elsif a confirmed email is now being unconfirmed and the user is not a super admin
+      elsif @user.confirmed? && attrs[:confirmed_at] == '0' && !@user.can_super_admin?
         attrs[:confirmed_at] = nil
       else
         # else delete the param

--- a/app/controllers/super_admin/users_controller.rb
+++ b/app/controllers/super_admin/users_controller.rb
@@ -139,6 +139,11 @@ module SuperAdmin
     end
 
     def handle_confirmed_at_param(attrs)
+      # NOTE: The :confirmed_at param is controlled by a check_box in the form
+      # `app/views/super_admin/users/_email_confirmation_status.html.erb`.
+      # When the checkbox is checked, Rails submits the string '1' (indicating "confirmed").
+      # When unchecked, it submits the string '0' (indicating "unconfirmed").
+
       # if an unconfirmed email is now being confirmed
       if !@user.confirmed? && attrs[:confirmed_at] == '1'
         attrs[:confirmed_at] = Time.current

--- a/app/controllers/super_admin/users_controller.rb
+++ b/app/controllers/super_admin/users_controller.rb
@@ -38,6 +38,7 @@ module SuperAdmin
 
       # Remove the extraneous Org Selector hidden fields
       attrs = remove_org_selection_params(params_in: attrs)
+      attrs = handle_confirmed_at_param(attrs)
 
       if @user.update(attrs)
         # If its a new Org create it
@@ -124,7 +125,8 @@ module SuperAdmin
                                    :org_id, :org_name, :org_crosswalk,
                                    :department_id,
                                    :language_id,
-                                   :other_organisation)
+                                   :other_organisation,
+                                   :confirmed_at)
     end
 
     def merge_accounts
@@ -134,6 +136,21 @@ module SuperAdmin
       else
         flash.now[:alert] = failure_message(@user, _('merge'))
       end
+    end
+
+    def handle_confirmed_at_param(attrs)
+      # if an unconfirmed email is now being confirmed
+      if !@user.confirmed? && attrs[:confirmed_at] == '1'
+        attrs[:confirmed_at] = Time.current
+      # elsif a confirmed email is now being unconfirmed
+      elsif @user.confirmed? && attrs[:confirmed_at] == '0'
+        attrs[:confirmed_at] = nil
+      else
+        # else delete the param
+        # (keeps value nil for unconfirmed user and maintains previous Time value for confirmed user)
+        attrs.delete(:confirmed_at)
+      end
+      attrs
     end
   end
 end

--- a/app/views/super_admin/users/_email_confirmation_status.html.erb
+++ b/app/views/super_admin/users/_email_confirmation_status.html.erb
@@ -1,11 +1,12 @@
 <div class="form-group col-xs-12">
-    <%= f.label(:confirmed_at, _('Email Confirmation Status'), class: 'control-label') %>
+    <%= f.label(:confirmed_at, _('Email status: '), class: 'control-label') %>
+    <%= @user.confirmed? ? _("Confirmed.") : _("Unconfirmed.") %>
     <br>
     <% is_checkbox_disabled = @user.can_super_admin? && @user.confirmed_at.present? %>
     <%= f.check_box(:confirmed_at, { checked: @user.confirmed?,
                                      disabled: is_checkbox_disabled,             
                                      style: 'vertical-align: middle;
                                              margin-top: -2px;' }) %>
-    <%= @user.confirmed? ? _("Confirmed.") : _("Unconfirmed.") %>
-    <%= content_tag(:small, _("(Use checkbox to change status.)")) unless is_checkbox_disabled %>
+    <% checkbox_helper_text = @user.confirmed? ? _('(Uncheck to unconfirm email)') : _('(Check to confirm email)') %>
+    <%= content_tag(:small, checkbox_helper_text) unless is_checkbox_disabled %>
 </div>

--- a/app/views/super_admin/users/_email_confirmation_status.html.erb
+++ b/app/views/super_admin/users/_email_confirmation_status.html.erb
@@ -1,9 +1,11 @@
 <div class="form-group col-xs-12">
     <%= f.label(:confirmed_at, _('Email Confirmation Status'), class: 'control-label') %>
     <br>
-    <%= f.check_box(:confirmed_at, { checked: @user.confirmed?, 
+    <% is_checkbox_disabled = @user.can_super_admin? && @user.confirmed_at.present? %>
+    <%= f.check_box(:confirmed_at, { checked: @user.confirmed?,
+                                     disabled: is_checkbox_disabled,             
                                      style: 'vertical-align: middle;
                                              margin-top: -2px;' }) %>
     <%= @user.confirmed? ? _("Confirmed.") : _("Unconfirmed.") %>
-    <small><%= _("(Use checkbox to change status.)") %></small>
+    <%= content_tag(:small, _("(Use checkbox to change status.)")) unless is_checkbox_disabled %>
 </div>

--- a/app/views/super_admin/users/_email_confirmation_status.html.erb
+++ b/app/views/super_admin/users/_email_confirmation_status.html.erb
@@ -1,7 +1,9 @@
 <div class="form-group col-xs-12">
     <%= f.label(:confirmed_at, _('Email Confirmation Status'), class: 'control-label') %>
     <br>
-    <%= f.check_box(:confirmed_at, checked: @user.confirmed? ) %>
+    <%= f.check_box(:confirmed_at, { checked: @user.confirmed?, 
+                                     style: 'vertical-align: middle;
+                                             margin-top: -2px;' }) %>
     <%= @user.confirmed? ? _("Confirmed.") : _("Unconfirmed.") %>
     <small><%= _("(Use checkbox to change status.)") %></small>
 </div>

--- a/app/views/super_admin/users/_email_confirmation_status.html.erb
+++ b/app/views/super_admin/users/_email_confirmation_status.html.erb
@@ -1,0 +1,7 @@
+<div class="form-group col-xs-12">
+    <%= f.label(:confirmed_at, _('Email Confirmation Status'), class: 'control-label') %>
+    <br>
+    <%= f.check_box(:confirmed_at, checked: @user.confirmed? ) %>
+    <%= @user.confirmed? ? _("Confirmed.") : _("Unconfirmed.") %>
+    <small><%= _("(Use checkbox to change status.)") %></small>
+</div>

--- a/app/views/super_admin/users/edit.html.erb
+++ b/app/views/super_admin/users/edit.html.erb
@@ -57,6 +57,8 @@
         </div>
       <% end %>
 
+      <%= render 'email_confirmation_status', f: f %>
+
       <div class="form-group col-xs-12">
         <%= f.button(_('Save'), class: 'btn btn-default', type: "submit", id: "personal_details_registration_form_submit") %>
 

--- a/spec/controllers/super_admin/users_controller_spec.rb
+++ b/spec/controllers/super_admin/users_controller_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SuperAdmin::UsersController, type: :controller do
+  let(:super_admin) { create(:user, :super_admin) }
+  let(:user) { create(:user, confirmed_at: nil) }
+
+  before do
+    sign_in super_admin
+  end
+
+  describe 'PUT #update' do
+    context 'when confirming an unconfirmed user' do
+      it 'sets confirmed_at to the current time' do
+        put :update, params: { id: user.id, user: { confirmed_at: '1' } }
+        user.reload
+        expect(user.confirmed_at).to be_a(Time)
+      end
+    end
+
+    context 'when unconfirming a confirmed user' do
+      before do
+        user.update(confirmed_at: Time.current)
+      end
+
+      it 'sets confirmed_at to nil' do
+        put :update, params: { id: user.id, user: { confirmed_at: '0' } }
+        user.reload
+        expect(user.confirmed_at).to be_nil
+      end
+    end
+
+    context 'when update will not affect confirmation status' do
+      it 'does not update confirmed_at value for an already confirmed user' do
+        # (usec: 0) removes mircoseconds to better enable comparison
+        user.update(confirmed_at: Time.current.change(usec: 0))
+        original_confirmed_at = user.confirmed_at
+        patch :update, params: { id: user.id, user: { firstname: 'NewName', confirmed_at: '1' } }
+        user.reload
+        expect(user.confirmed_at).to eq(original_confirmed_at)
+      end
+    end
+  end
+end

--- a/spec/controllers/super_admin/users_controller_spec.rb
+++ b/spec/controllers/super_admin/users_controller_spec.rb
@@ -36,9 +36,17 @@ RSpec.describe SuperAdmin::UsersController, type: :controller do
         # (usec: 0) removes mircoseconds to better enable comparison
         user.update(confirmed_at: Time.current.change(usec: 0))
         original_confirmed_at = user.confirmed_at
-        patch :update, params: { id: user.id, user: { firstname: 'NewName', confirmed_at: '1' } }
+        put :update, params: { id: user.id, user: { firstname: 'NewName', confirmed_at: '1' } }
         user.reload
         expect(user.confirmed_at).to eq(original_confirmed_at)
+      end
+    end
+
+    context 'when attempting to set a super_admin to unconfirmed' do
+      it 'does not update confirmed_at value to nil' do
+        put :update, params: { id: super_admin.id, user: { confirmed_at: '0' } }
+        super_admin.reload
+        expect(super_admin.confirmed_at).not_to be_nil
       end
     end
   end


### PR DESCRIPTION
Fixes #1006

Changes proposed in this PR:
- Include email confirmation status as an editable attribute on the `/super_admin/users/:id` path.
  ![Screenshot from 2025-02-10 12-19-02](https://github.com/user-attachments/assets/d58ff379-9f9c-4263-829f-1d32f23f1e76)
  - The added logic includes special handling for superadmins. Specifically, it prevents the un-confirming of any already confirmed super admin email.
- This added feature helps address an encountered issue (https://github.com/portagenetwork/roadmap/issues/1005) where some institutions were blocking emails from `@portagenetwork.ca`, and as a result, preventing users from receiving email confirmation instructions.