### PR TITLE
Add `upgrade_customization?` Check When Determining Default Template (Funder vs Org Customization) For Dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
  - Add Functionality Allowing Super Admins to Confirm/Unconfirm User Emails [#1009](https://github.com/portagenetwork/roadmap/pull/1009)
 
+### Fixed
+ 
+ - Add `upgrade_customization?` Check When Determining Default Template (Funder vs Org Customization) For Dropdown [#1014](https://github.com/portagenetwork/roadmap/pull/1014)
+
 ### Changed
 
  - Delete Auto-Generated and Unused `tinymce/skins` Contents and Add to `.gitignore` [#1060](https://github.com/portagenetwork/roadmap/pull/1060)

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -60,7 +60,10 @@ class TemplateOptionsController < ApplicationController
     # @templates << funder_templates = Template.latest_customizable
     # Always use the default template
     if Template.default.present? && org.present?
+      # Fetch the org’s latest customization of the default template
       customization = Template.published.latest_customized_version(Template.default.family_id, org.id).first
+      # In short: check if `customization` is based on `Template.default`
+      # If so, use `customization`; otherwise, fall back to `Template.default`
       customization = Template.default unless customization.present? && !customization.upgrade_customization?
       @templates.select! { |t| t.id != Template.default.id && t.id != customization.id }
       # We want the default template to appear at the beggining of the list

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -61,7 +61,7 @@ class TemplateOptionsController < ApplicationController
     # Always use the default template
     if Template.default.present? && org.present?
       customization = Template.published.latest_customized_version(Template.default.family_id, org.id).first
-      customization ||= Template.default
+      customization = Template.default unless customization.present? && !customization.upgrade_customization?
       @templates.select! { |t| t.id != Template.default.id && t.id != customization.id }
       # We want the default template to appear at the beggining of the list
       @templates.unshift(customization)


### PR DESCRIPTION
Fixes #1013

Changes proposed in this PR:
- Adds the `!customization.upgrade_customization?` check when determining whether to populate the "Create a new plan" template dropdown with the default funder's default template vs an org's customization of it.
  - Before this change, `!customization.upgrade_customization?` was applied to all templates populating the dropdown, with the exception of the default template. As a result, if an org had customised and published an older version of the default template, but not the newest version, the default funder's newest version would not be chosen to populate the template dropdown.