### PR TITLE
Bump `runs-on:` to `ubuntu-22.04` Within all `.github/workflows` Files

### DIFF
--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   brakeman:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   danger:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/docker-push-image.yml
+++ b/.github/workflows/docker-push-image.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3

--- a/.github/workflows/docker-push-uat-image.yml
+++ b/.github/workflows/docker-push-uat-image.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   push_to_registry:
     name: Push Docker UAT image to Docker Hub
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   eslint:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   mysql:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     # Define environment variables for MySQL and Rails
     env:

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   postgresql:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     services:
       # Postgres installation

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   rubocop:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     services:
       # Postgres installation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+ - Bump `runs-on:` to `ubuntu-22.04` Within all `.github/workflows` Files [#1017](https://github.com/portagenetwork/roadmap/pull/1017)
+
  - Bump jwt from 2.8.2 to 2.10.1 [#984](https://github.com/portagenetwork/roadmap/pull/984)
 
  - Bump dragonfly from 1.4.0 to 1.4.1 [#988](https://github.com/portagenetwork/roadmap/pull/988)


### PR DESCRIPTION
Fixes #1016

Changes proposed in this PR:
- Updates from `runs-on: ubuntu-20.04` to `runs-on: ubuntu-22.04` within all `.github/workflows` files
  - This change addresses the following deprecation/brownout warning: https://github.com/actions/runner-images/issues/11101