### PR TITLE
Lower Ruby GitHub Action Chrome Version to Address Breaking Changes Between Latest Chrome Version (134) and `/features` Tests

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -79,6 +79,18 @@ jobs:
     - name: 'Yarn Install'
       run: |
         yarn install
+    
+    # TEMPORARY WORKAROUND FOR THE FOLLOWING ISSUE: https://github.com/portagenetwork/roadmap/issues/1032
+    # Remove this once our tests are compatible with the new version of Chrome
+    # Source: https://github.com/teamcapybara/capybara/issues/2800#issuecomment-2731100953
+    - name: Remove image-bundled Chrome
+      run: sudo apt-get purge google-chrome-stable
+    - name: Setup stable Chrome
+      uses: browser-actions/setup-chrome@v1
+      with:
+        chrome-version: 128
+        install-chromedriver: true
+        install-dependencies: true
 
     - name: 'Setup Test DB'
       run: bin/rails db:setup RAILS_ENV=test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Changed
 
+ - Lower Ruby GitHub Action Chrome Version to Address Breaking Changes Between Latest Chrome Version (134) and `/features` Tests [#1041](https://github.com/portagenetwork/roadmap/pull/1041)
+
  - Lower PostgreSQL GitHub Action Chrome Version to Address Breaking Changes Between Latest Chrome Version (134) and `/features` Tests [#1033](https://github.com/portagenetwork/roadmap/pull/1033)
 
  - Bump nokogiri from 1.16.8 to 1.18.3 [#1012](https://github.com/portagenetwork/roadmap/pull/1012)


### PR DESCRIPTION
Fixes # (Only a temporary fix for #1032)

Changes proposed in this PR:
- Replace image-bundled Chrome version with Chrome version 128
  - This change addresses the breaking changes encountered between Chrome version 134 and our `/features` tests
  - NOTE: This change should be reverted once are `/features` tests are working with the latest Chrome version