### PR TITLE
Add CephFS sealed secrets for locales and uploads and update prod configuration

### DIFF
--- a/deployments/prod/sealed-secrets/cephfs-locales-sealed-secret.yaml
+++ b/deployments/prod/sealed-secrets/cephfs-locales-sealed-secret.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: cephfs-locales-key
+  namespace: dmp-roadmap-prod
+spec:
+  encryptedData:
+    key: AgDnoRqTsXrXKSBuoYcAkc/zOSCR1m1vdMyIUMIM27pPI7IR35hZV4gSXc8UkMtr0yXHanXg/LbiDgZLEvz3bHwNMn4Y6NuwM0HUPHASkqNlcN6jTmRgCdwX04ybq3sX2HjXlbGbX5pZ5boCszSf0sCCdsDbTC71kgFiHIzkEo2WMpSim+oIV4l40DG6TmFfHfj/O+npB4qoYkoOQKWRlmcudFbOMz17vCoNWP5A4BerMD1AbJxdeguxBKsQrIP4kFRS9dhbrhHWsuP1n4A4MMzBbPa+MooklivAJfJeiHzwYsBai18N7qTbSXnBW8qFAtVMbAQRyv8eUyUwdp1tnpiiqT9OUe1JZv6yZIpkQ5oQ68+ugYNSji1VYbcd6/rMQJ973yGJj2KQeT98b+xG5zTC87QwJJDM+z9xH7IzFSyYwFVG6kdon5QnO/P5FHKw3VxmeB3JEeBmCuMjJsxzA6ArEEOMLzfK+37jJU+vtQQO6+YEMSHjQT144Pq8O9jm4EbchbGllBbMlkaDlHGyNn1Ao1pIiAhpB17O0H+aoFCqhMybHbVTbcLHD1LXZ48sIF2/Ez6vrLdlCuW+teQdWzfw3uM79a9k7HaWN4lpCGOgmKhGzUnn2cPiaMrwmQqlZgWyQXLZbkVGwvpukp83RGk2kKmoMzVhHfF4XsScftUfmQLniRxhzmCrY4VxiiQwKcT2Kor174Dw0um5utD74vjAgGEcK94gazZA0WH60W6Ogoqn9wFo9Yc3
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        cephfs-mount-user: dmp-roadmap-locales-user
+      name: cephfs-locales-key
+      namespace: dmp-roadmap-prod
+    type: Opaque

--- a/deployments/prod/sealed-secrets/cephfs-uploads-sealed-secret.yaml
+++ b/deployments/prod/sealed-secrets/cephfs-uploads-sealed-secret.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: cephfs-uploads-key
+  namespace: dmp-roadmap-prod
+spec:
+  encryptedData:
+    key: AgBV0fz2iGzausE3x7XQRyhJ/rml14qRkvKXDt4LmTQ8cTAH8soNm9ZPWZWcNT9iRGFW/2tRxGhcW3YeVveAjI5LiUQH2VFlyVW1/480mrw1G+81BBW5IgWTrGy8uY815mhYrKc5eSi29ozkcPfG16gU9OS6yy6d8kjxHIinjV6SWpgbQpf+r0UuI1fcqPbkKiuH0CmzfFAhTd0tT9p+5x/3W5X85QKEfVX9TJVf4HI/cs9eCPNa52mpikJP4PZG2JdI6V0KPpEjcqkbTK8yZVds2uzRtvrG0eWCNthdDztEapuEQLHSItucriOhrwV8Wis2DttjFqngYnO9P4qTiRegqxT2nvMrMNyBmmEVJ2SALcRkAY5Er82hDd8fhR+NIVna/g0Ul13kBPQnebMnKcuj+DyMPqmlyBjXDAqZPq+bElwBVblAj8p02NR4R7OadN71ct+7YULNt6PxLUcDJ35cGZnpvVtUod9bbOXUYXP8bhubvRj5FPPej6VnFrAhWQ+yHkwX5H/duQ836BRFQ9MOjPZlOVFN0B3J4jEX1kpKQ6DuNMUh2dVOPfvRz+YzRLvTsHz06CeQ7fK4AtmyzazujDDur9xOf4yoCbT/x0xEpCJsYFJJObvh7W1DhE02ax6yaMXvaGy4SQCXqnX6d+vTXma2exqyLHTC6tveC5YAIqBJzWTky6G3mjULEmfQ+QDgAfkMXjhAgwswGXl9thCicUncuj0/e3rdp3udsPxL0mRBPkTI7Go0
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        cephfs-mount-user: dmp-roadmap-uploads-user
+      name: cephfs-uploads-key
+      namespace: dmp-roadmap-prod
+    type: Opaque

--- a/deployments/prod/values.yaml
+++ b/deployments/prod/values.yaml
@@ -1,0 +1,13 @@
+app:
+  image:
+    tag: "4.3.0-app"
+assets:
+  image:
+    tag: "4.3.0-assets"
+storage:
+  cephfs:
+    volumes:
+      locales:
+        path: "/volumes/_nogroup/12cec31d-96a5-464d-b475-8a2fc67c5eb2"
+      uploads:
+        path: "/volumes/_nogroup/a620def1-58f7-4b0f-95e2-f666728a45d6"


### PR DESCRIPTION
## Changes
- Added sealed secrets for CephFS mounts:
  - `cephfs-locales-key` for locales storage
  - `cephfs-uploads-key` for uploads storage
- Updated prod values.yaml with:
  - App image tag: 4.3.0-app
  - Assets image tag: 4.3.0-assets
  - CephFS volume paths:
    - Locales: /volumes/_nogroup/12cec31d-96a5-464d-b475-8a2fc67c5eb2
    - Uploads: /volumes/_nogroup/a620def1-58f7-4b0f-95e2-f666728a45d6

## Testing
- [x] Verify sealed secrets can be decrypted in prod environment
- [x] Confirm CephFS paths are accessible
- [x] Validate app and assets images are available in registry
