### PR TITLE
Update CephFS user naming convention and credentials

### DIFF
--- a/charts/dmp-roadmap/templates/storage/cephfs-pv.yaml
+++ b/charts/dmp-roadmap/templates/storage/cephfs-pv.yaml
@@ -15,7 +15,7 @@ spec:
     {{- toYaml $.Values.storage.cephfs.accessModes | nindent 4 }}
   cephfs:
     path: {{ $volume.path }}
-    user: dmp-roadmap-{{ $name }}-user
+    user: dmp-roadmap-{{ $.Values.global.domain.prefix }}-{{ $name }}-user
     secretRef:
       name: {{ $volume.secretRef }}
     monitors:

--- a/deployments/dev/sealed-secrets/cephfs-locales-sealed-secret.yaml
+++ b/deployments/dev/sealed-secrets/cephfs-locales-sealed-secret.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: cephfs-locales-key
+  namespace: dmp-roadmap-dev
+spec:
+  encryptedData:
+    key: AgDteGdAR1mKb1+m9U19BzY0WpivPJTttjDUM6yxZ2lJwzjoAvG7dHcKeMYSwkKlOrNs0ss331gY1nkHY+UDtek9g4/5KgBKiBgu0uh7JlrBmvgWvacemA4YFCm58aLmDkWu8nqp9t7nn8ngqn9n0ORjEvHT5galmjaidKWqWrZ6XuqFEeo0gs+G8mIUIGumOaWNK/uykcdrN1pNrygrGfgb/F8wW6LoS1Vz/dLyFP7TcNVSWmldKumDCJuMTjwbNtOqe4pUtNhbaHWj2sm8/xPsFKHwaJDlQ2s8HxkSR9Y7VG12pywTKZNQ4LeYqR2jBOzUpO7h1cUuEP3DnWgMd38+tC3vjbDYTS/a42at/fFdDsx8Nwtgk18pyaOH8VRteWTqnZkqJdjS4+eNVoIwJ/VMFv0f6nyit4byWO6+pjBL+mA81V4wpJTL0d/uqQ6AhIZltztgq4U61l9pNOXHdFZPbOABtH4rjgvec2kqlWEa1l2HeTkf6wr+iO8dDHiYYqFkWW2OKbJmR7E/b1ULz8eTXoot+8y1Uuo8Px1WLY32ptrvT8NRZcs+elkfi6khJ++EHj8j04eScSCud63BcXCM084WEwR8CjqZnEJngTBsjTMqvyRsN77Tyv09Ina2X3VZFFYqe+i1tw2lnQTQ47OGS/dY0RIjvcEj+TZ+5XrreYvCETBrSLP+dS30XHOhMqjJzYCEDvTHeDKnl2k1lphpNL4/Tgz6qNvyocKq16oaSN8ucvPyW57f
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/part-of: argocd
+        cephfs-mount-user: dmp-roadmap-dev-locales-user
+      name: cephfs-locales-key
+      namespace: dmp-roadmap-dev
+    type: Opaque

--- a/deployments/dev/sealed-secrets/cephfs-uploads-sealed-secret.yaml
+++ b/deployments/dev/sealed-secrets/cephfs-uploads-sealed-secret.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: cephfs-uploads-key
+  namespace: dmp-roadmap-dev
+spec:
+  encryptedData:
+    key: AgCRqeOV/1GT8LF0tqkDGN7ihm4WR2vAjIUdmyEyi7SFxYWZ/aOa3ESWZMIO+kfTbx8kMMJytua/LcbVfM1rfseGBy+58NHJnGUz+iZR0o0q61jHfVyhDvRlTclDk6wI08c+vVidFtoXhDXtDCwbiJ/gnXKLGmLbnBNQxnqH8G+dA3m4pCX9BH6Kjn5xc1OXoLusg+iuOzOIXK4MHMzSyVYZu6ZiBstWRskSaxM6mMwPRhMsXm2QZwOmhNIHGVTF9PVnhcP5o1zAehQHc0Jrrr7bcGnIRGUMZbhqEdfdOY3kuT4JY+W78ULY29PLpRTkBlBiVoVkmTG0uIPoE17Hl+bIgnp3mNCuzZiCUkBlCc269BvzOhRLle4+g4/g5A1UoPaGMTqvfoWibp6ZSek6S0JlRt9V+Vp4KgbeZxtlQSyR9lOcLmGaQrduCQfwBBvnCJEJm8Xqjs2rwUH6ODybOjABioO00CsTZm7HjPGG5gHMXAFvyHOdG7ziu1Q66aZzMr4c+L1D40KBh/1xv5vCHgaXkM8+0sPvv2iy8ip3EsV/kqRD5mt3kbjuUXWqFc/44eU2KXNTpkLC7l8gFuMbGpsYIVSZnC9gF9LuRDfKB+d05+DQjJ68oiSTsKq2T3Z6+bm+KLUohcWcc1iOBublk/Q5+8KGXxsjGq3cS55lAG5Vd+qpQ8SlaoqHjpECoyHZeibbocCjiauDvu3MksC1NhAlVt22Xk3xMB9LI2di+S9+yGIUk8Z2UndC
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/part-of: argocd
+        cephfs-mount-user: dmp-roadmap-dev-uploads-user
+      name: cephfs-uploads-key
+      namespace: dmp-roadmap-dev
+    type: Opaque

--- a/deployments/dev/values.yaml
+++ b/deployments/dev/values.yaml
@@ -1,0 +1,22 @@
+global:
+  domain:
+    prefix: dev
+app:
+  image:
+    tag: "4.3.0-rc.1-app"
+assets:
+  image:
+    tag: "4.3.0-rc.1-assets"
+ingress:
+  annotations:
+    cert-manager.io/issuer: letsencrypt-staging-cloudflare
+storage:
+  cephfs:
+    volumes:
+      locales:
+        path: "/volumes/_nogroup/a2b85f14-843e-40fe-a6b0-8c4d895312f2"
+      uploads:
+        path: "/volumes/_nogroup/b2f2d190-3db0-4ada-96db-e05d000e4af0"
+config:
+  environment:
+    rollbarEnv: arbutus-dev

--- a/deployments/prod/sealed-secrets/cephfs-locales-sealed-secret.yaml
+++ b/deployments/prod/sealed-secrets/cephfs-locales-sealed-secret.yaml
@@ -7,13 +7,13 @@ metadata:
   namespace: dmp-roadmap-prod
 spec:
   encryptedData:
-    key: AgCi2/Ls0hYYu0BGGtptxwDR83tJJ5xxY5Cc7ZV42B+PKwcDTVSczAtSFo63yZG4uF3W6xQ0F7OdezmK0Q0JhH8/W4HSPXD95JZ9PMA6tyW/+WFN6jkjphepCijwbBkBm5kq88oRyJAEm6fJbaR1W3k2uep59fKvPsTWuFpOEqsSFBZ4O7M/GbyiGqeT7hktDWGSsG3PV+NOu3WUAcDPLKOpTDXnadbSnCPxVNGFCAgxnZ978OOcwW3VOpjB4mYfPUaVOHT5UJQpem6YYg97cLK5zETIVvGUlA6R9s46V+cl9gbhmG/VG2HmWLC49qLYXmHmdBqGI5OTv9bJvLcYA0oCXl59HNGgD5QwoyzVsC6m6fKhauhxkRNDOaohzkbMBhk3votD47uTtslIbfJILodhtagdjxlebe0xazJxOwLXgHIv9LxjXlHAiXo2wdZyHfzqNsnvMAUL9qRx5QmJEqQN80vHHhZq2a5b0gSD2IfuM6knTK53zk3ijQr4xoIYCueGBHGzLzJeFB7/iEwt1Eiz4coxo20waQ8Dq1kSfFh7VexyS6Lpi7VBaEbeeOo26ffVkAC2BLi/+Awf7yxxpL0J7UhBps7xsmNVJFPZnzFThNt1o77wyAGJOg783gBFtpT2mUznEHFuxJFNp9Ld2kbyB8WLp3kKVYPJrWdD/vOopzivKhEbwiQckMPkJYWDYPoLS8ZvvO64FJ5HF8JNVGiL+TRtHJ7Ji+9bsDYeAxlfA67gD4I98VSd
+    key: AgBl8p/PI60GRaql+1w7UnvDicJ2FH9o1KYiDCajaomFaxFwLonhr2HQ/MGxd9SpZL+aHhDTgUGqPeGMik2P/x313pK5lVSBjNsvOuXc0Ytz4+9GqamVqbqHfKLv3oHmePjz1MamxH+5GMZKZ6Sw2Z6KgHqVxYswoQByL/QtMXcSAo4BKY23BL3aLqcQI/pHrwb9OgaF/Q0dfQbZA+feM8FXEcxMAzGK4nLLfbCTGMnyDikSfqWUeCa2ELjFTf8y8vZLz6WPhb+SEzDQxHxTL8wJaJCBvNGGlSl1AeaSVeykzv2OPMqMQq7Ri4DnrzTsL12Cvf+KUnzf5qHt4buh9ga74Q2ZgXC984968eOyNOGGvqtoePFt7h+01zSF4Iq7QPuvttSJriuHbGRFGR8FXFAvldgSIcuC9osW4rKsrehmBtSX5weKIcE6049+lyANVAv3IWV2xvJZvmHLkq6lHSm7oVL1+yBY5wHD/mu0Sp5D6qzhPgQBnx1Docu3gHGWe5QY2mmL9wOcLdgF50htBBFOSCPdzgDnElhmDTIZZiDAOjXelzFARBprI11du9HH4xkyUXI+4bqUYrkQb9KP7roPX6ItzbKeMSq7wDgU2DppRxfoshofkwbGXi1XfxBJGZpIYf/zASs4VFDQdysXwoTeS7ISU4zGtzn4TeppR8oy2xb9Pi2mQreSnycG/fpBQzAnQxyhx+f7nYaFzxkXJsozTTPXyKBG5rLKw9QQdOPjFeJgfOqFVra8
   template:
     metadata:
       creationTimestamp: null
       labels:
         app.kubernetes.io/part-of: argocd
-        cephfs-mount-user: prod-dmp-roadmap-locales-user
+        cephfs-mount-user: dmp-roadmap-prod-locales-user
       name: cephfs-locales-key
       namespace: dmp-roadmap-prod
     type: Opaque

--- a/deployments/prod/sealed-secrets/cephfs-uploads-sealed-secret.yaml
+++ b/deployments/prod/sealed-secrets/cephfs-uploads-sealed-secret.yaml
@@ -7,13 +7,13 @@ metadata:
   namespace: dmp-roadmap-prod
 spec:
   encryptedData:
-    key: AgDVKeZeaMcL/Ev7KUDt1I09D4YnU8XKEwwcwzNa8LknzRIJQYHlSoKL+14DWi3bv0tbbuKYtw1IXYSu8414IiqoBn3Qyf29CANwd3bYSkVmGS/TrhnOhhVA3tl6E5MncYXIYEblWu5ZyOJjAb7qGVcS3Dcl/dvl+ROIcnSmaUA1Bc/O2V9zP2bYqIbl1aRtbx+OIZzcFi0ZQtQGpf7d6GSuKAV61JijiC84xYxRxAQF6A4zxE25tqpOXIf2dgRkjCrSBvVUKVAKvmGEHPcuDFkR6kBE3bNBFg2xpQHcPEGEs1+926MMxGcrlqPXnkBWYAWrq+8+O7R9wR2J2u3Pi/LaUbqtATbQ3SV+pPHzG90xzJpf/80YtnsJkblG78pYhCRiSYjlUqboRQ6BkGFzS3zrgtwoWdcFAyOP+3+pj5WE0zwwe22My2WDta6QUQtFz1nUP8b9L5BBgjXAhsS/OXu6yGPWM0EVZb6kYKRGH4kycefTcVP0pjl+LBilh7aTigVqVBWHuM9S/7Iqvt6UX6vwifhkht3Dt3ZsUJMUizgIOF35Mzbvtc7vLF8oRCqHoKhOM8plvUsSAKgG0N4omY96M85awby+xjZp8Joa9MgtUX1MGhJse+1i0UHVMHrjLxXt9TS+cs+EeDOaxB+y3UY4YE4Caq7uf6/DnN+5A2g800aJNDazOfoI20vlfByJ+RBbOvUFThvc1AQSEtfWLarTuoCPrsqbwqONdzmPVi6CNJXSsSoAChpB
+    key: AgBJb+cP2/mq1VV1ilA6QzPE8f8L14ivr1wrUVerME2hAiRMOvSjqXWbx1vtV+6dhwvolVQiIyCkLgM9iHtVgP+dCrrz4/Acv3wacQ5GTx0sKR3XkLkDhtsBlFg9nnV1dNAF4DoDm9BVfNnw1TvWFULRubi5IeFx0ChJJvJ+FGarli0jGxVvISFv9adh8/6SzdeObZRAowVj3EHo5NxzjB8ssrYYXtEH/v5sH4u3vm+I4ZOAy3iNcTEr9SgwIWpn0NvJone5+D30Za/uReJk0tUioQgHw3QvYjygNqVjw+I23WYQrMCMuFSqnTmy6ZIzTgJrGUrVIK+ztfvEuhk74GqfCrHjWH9GAPClF4CE6PTXiWg/phBtH3gV6f6YBStexjIxKmw/gUq1U/r+cDoee+B+iYlAkaV+FG2o57FF4ljUME9xiDFPnALXgs+X+27FhCx4hY+G1ERlGNL0xwRKgDmR6C/6Yz34OziVkZ4F6HLgXu9eRvAFpLY6kBqzjHjlfDp5MFIkSah7gpgyBE6oXA8HkVoV0Y2u3IuZWEOWiiqCXeM+DICD2Q58mMEpy+JA3txm9Cu1RaV6/3a5nFYzG6nSraMJlEAEAgN+nA3nFpauoR5OxCPIVfX6l3HTuW17gNVmhIfzjqOO/ICjbVOBk4DHqqqGBKmDQTtt3T+3S0Z3J+CUJiigWbZGk9a/LSHA7mRrluxHjhmkKdvws5pGXc7kL7xaTXgzoU12n39qn0wR6eIBhS1lM8U3
   template:
     metadata:
       creationTimestamp: null
       labels:
         app.kubernetes.io/part-of: argocd
-        cephfs-mount-user: prod-dmp-roadmap-uploads-user
+        cephfs-mount-user: dmp-roadmap-prod-uploads-user
       name: cephfs-uploads-key
       namespace: dmp-roadmap-prod
     type: Opaque


### PR DESCRIPTION
This MR updates the CephFS configuration to use a consistent user naming convention and updates the corresponding credentials.

Changes:
- Modifies CephFS PV template to use simplified user naming convention (removes domain prefix)
- Updates sealed secrets for CephFS credentials in production environment
- Adds CephFS dev environment files 
- Updates user labels in sealed secrets to match new naming convention

The changes ensure consistent naming across environments and update the necessary credentials to maintain CephFS access.

Testing:
- [ ] Validate sealed secrets are properly encrypted and accessible
