### PR TITLE
update cephfs user definition to handle missing prefix

### DIFF
--- a/charts/dmp-roadmap/templates/storage/cephfs-pv.yaml
+++ b/charts/dmp-roadmap/templates/storage/cephfs-pv.yaml
@@ -15,7 +15,7 @@ spec:
     {{- toYaml $.Values.storage.cephfs.accessModes | nindent 4 }}
   cephfs:
     path: {{ $volume.path }}
-    user: dmp-roadmap-{{ $.Values.global.domain.prefix }}-{{ $name }}-user
+    user: dmp-roadmap-{{ $.Values.global.domain.prefix | default "prod" }}-{{ $name }}-user
     secretRef:
       name: {{ $volume.secretRef }}
     monitors:


### PR DESCRIPTION
By default the user name should include the environment name, we are using the prefix for ease, but it is missing when undefined for prod environments. This ensure it is added appropriately.