### PR TITLE
Fix handling of `attrs[:managed]` on Org updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
  - Add Functionality Allowing Super Admins to Confirm/Unconfirm User Emails [#1009](https://github.com/portagenetwork/roadmap/pull/1009)
 
 ### Fixed
+
+ - Fix handling of attrs[:managed] on Org updates [#1062](https://github.com/portagenetwork/roadmap/pull/1062)
  
  - Add `upgrade_customization?` Check When Determining Default Template (Funder vs Org Customization) For Dropdown [#1014](https://github.com/portagenetwork/roadmap/pull/1014)
 

--- a/app/controllers/orgs_controller.rb
+++ b/app/controllers/orgs_controller.rb
@@ -44,7 +44,7 @@ class OrgsController < ApplicationController
     # Only allow super admins to change the org types and shib info
     if current_user.can_super_admin?
       identifiers = []
-      attrs[:managed] = attrs[:managed] == '1'
+      attrs = handle_managed_flag(attrs)
 
       # Handle Shibboleth identifier if that is enabled
       if Rails.configuration.x.shibboleth.use_filtered_discovery_service
@@ -239,6 +239,15 @@ class OrgsController < ApplicationController
 
   def search_params
     params.require(:org).permit(:name, :type)
+  end
+
+  def handle_managed_flag(attrs)
+    # NOTE: The :managed param is controlled by a check_box in the form
+    #       `app/views/orgs/_profile_form.html.erb`.
+    # NOTE: :managed is not present when a super admin updates an org
+    #       by clicking "Save" while on the "Request feedback" tab
+    attrs[:managed] = (attrs[:managed] == '1') if attrs.key?(:managed)
+    attrs
   end
 
   def shib_login_url


### PR DESCRIPTION
Fixes #1061

Changes proposed in this PR:
- This change resolves issue #1061 by preventing the updating of `@org.managed` when `attrs[:managed]` is missing. Prior to this change, the `if attrs.key?(:managed)` was not present. But it was necessary, because that key is not present when a super user clicks "Save" on the "Request Feedback" page.
- As a result, if `attrs[:managed]` was not present,  then `attrs[:managed] = (attrs[:managed] == '1')` would evaluate false, and `if @org.update(attrs)` (line 81) would subsequently update `@org.managed` to false in the db.