### PR TITLE
OmniauthCallbacksController Changes: Handle Additional User Scenarios and Improve Underlyling Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
  - Added Arbutus Cloud and UVic logos to footer and added institutional sign in explanation [#1063](https://github.com/portagenetwork/roadmap/pull/1063)
 
+ - Add handling For Additional User Scenarios in OmniauthCallbacksController [#1074](https://github.com/portagenetwork/roadmap/pull/1074)
+   - 1) Render flash message for users signing in with a "generic name"
+   - 2) Handle attempts to re-link already linked external credentials
+
 ### Fixed
 
  - Fix handling of attrs[:managed] on Org updates [#1062](https://github.com/portagenetwork/roadmap/pull/1062)
@@ -17,6 +21,8 @@
  - Add `upgrade_customization?` Check When Determining Default Template (Funder vs Org Customization) For Dropdown [#1014](https://github.com/portagenetwork/roadmap/pull/1014)
 
  - Clean Up `/contact-us` Page, Fix "Contact us" Footer Link, and Update '/terms' Path Routing [#978](https://github.com/portagenetwork/roadmap/pull/978)
+
+ - Improve OmniauthCallbacksController Tests [#1074](https://github.com/portagenetwork/roadmap/pull/1074)
 
 ### Changed
 

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -139,12 +139,26 @@ module Users
       )
     end
 
+    def generate_flash_message_for_openid_connect_sign_in(user)
+      if user.generic_name?
+        flash[:alert] =
+          format(
+            _('Some information is missing from your profile. ' \
+              '<a href="%{link}">Click here to complete your profile</a>.'),
+            link: edit_user_registration_path
+          )
+      else
+        flash[:notice] = _('Signed in successfully.')
+      end
+    end
+
     def handle_openid_connect_for_signed_out_user(user, auth, identifier_scheme)
       # user.nil? is true if the chosen CILogon email is not currently linked to an existing user account
       user = handle_new_sso_email_for_signed_out_user(auth, identifier_scheme) if user.nil?
       # See app/controllers/concerns/email_confirmation_handler.rb
       return if confirmation_instructions_missing_and_handled?(user)
 
+      generate_flash_message_for_openid_connect_sign_in(user)
       sign_in_and_redirect user, event: :authentication
     end
 

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -182,9 +182,12 @@ module Users
       if user.nil?
         # We need to link the new auth creds
         handle_new_sso_email_for_signed_in_user(auth, identifier_scheme)
-      # elsif user is signed in and trying to link via SSO, but the auth creds are already linked to another account
       elsif user.id != current_user.id
+        # `auth` is already linked to a different user
         handle_conflicting_sso_email_for_signed_in_user(identifier_scheme, user)
+      else # (user.id == current_user.id)
+        # `auth` is already linked to this user.
+        handle_already_linked_credentials
       end
     end
 
@@ -200,6 +203,13 @@ module Users
     def handle_conflicting_sso_email_for_signed_in_user(identifier_scheme, user)
       flash[:alert] = format(_('The current %{description} iD has been already linked to a user with email %{email}'),
                              description: identifier_scheme.description, email: user.email)
+      redirect_to edit_user_registration_path
+    end
+
+    def handle_already_linked_credentials
+      # NOTE: This scenario is not possible through normal UI interaction,
+      # but a user could trigger it by manipulating the frontend.
+      flash[:alert] = _('These credentials are already linked to your account.')
       redirect_to edit_user_registration_path
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,6 +59,15 @@ class User < ApplicationRecord
 
   extend UniqueRandom
 
+  # =============
+  # = Constants =
+  # =============
+
+  GENERIC_USER_NAME_VALUES = {
+    firstname: 'First name',
+    surname: 'Last name'
+  }.freeze
+
   ##
   # Devise
   #   Include default devise modules. Others available are:
@@ -191,8 +200,8 @@ class User < ApplicationRecord
     return user unless user.new_record?
 
     user.update!(
-      firstname: provider_data.info&.first_name.presence || _('First name'),
-      surname: provider_data.info&.last_name.presence || _('Last name'),
+      firstname: provider_data.info&.first_name.presence || _(GENERIC_USER_NAME_VALUES[:firstname]),
+      surname: provider_data.info&.last_name.presence || _(GENERIC_USER_NAME_VALUES[:surname]),
       # We don't know which organization to setup so we will use other
       org: Org.find_by(is_other: true),
       accept_terms: true,
@@ -211,6 +220,14 @@ class User < ApplicationRecord
   # ===========================
   # = Public instance methods =
   # ===========================
+
+  # Evaluates whether self.firstname and self.surname are both generic values
+  # (The user's name is compared against all translations of the generic firstname and surname)
+  def generic_name?
+    firstname_list = LocaleService.translations_for_all_locales(GENERIC_USER_NAME_VALUES[:firstname])
+    surname_list = LocaleService.translations_for_all_locales(GENERIC_USER_NAME_VALUES[:surname])
+    firstname_list.include?(firstname) && surname_list.include?(surname)
+  end
 
   # This method uses Devise's built-in handling for inactive users
   #

--- a/app/services/locale_service.rb
+++ b/app/services/locale_service.rb
@@ -33,6 +33,11 @@ class LocaleService
       convert(string: locale, join_char: join_char)
     end
 
+    # Returns an array containing all available translations for the provided string arg
+    def translations_for_all_locales(string)
+      I18n.available_locales.map { |locale| I18n.with_locale(locale) { _(string) } }
+    end
+
     private
 
     def convert(string:, join_char: Rails.configuration.x.locales.gettext_join_character)

--- a/app/services/locale_service.rb
+++ b/app/services/locale_service.rb
@@ -33,9 +33,14 @@ class LocaleService
       convert(string: locale, join_char: join_char)
     end
 
-    # Returns an array containing all available translations for the provided string arg
-    def translations_for_all_locales(string)
-      I18n.available_locales.map { |locale| I18n.with_locale(locale) { _(string) } }
+    # Returns an array of string elements
+    # The elements are all of the available translations of `text` across all available locales
+    def translations_for_all_locales(text)
+      return [] unless text.present?
+
+      arr = I18n.available_locales.map { |locale| I18n.with_locale(locale) { _(text) } }
+      # Remove duplicates (occurs when a locale falls back to the default translation)
+      arr.uniq
     end
 
     private

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -2,131 +2,193 @@
 
 require 'rails_helper'
 
+FLASH_MESSAGES = {
+  notice: {
+    linked: 'Linked successfully',
+    signed_in: 'Signed in successfully.'
+  },
+  alert: {
+    missing_profile: 'Some information is missing from your profile. ' \
+                     '<a href="/users/edit">Click here to complete your profile</a>.',
+    missing_email_sign_in: 'Unable to sign in with the selected identity provider. ' \
+                           'Consider using an alternative sign in method, like social sign on. ' \
+                           'You can verify your email is being provided here ' \
+                           '<<a href="https://cilogon.org/testidp/">https://cilogon.org/testidp/</a>> ' \
+                           'and contact us at the help desk for further assistance. Help desk email: ' \
+                           '<a href="mailto:dmp-assistant@tech.alliancecan.ca">dmp-assistant@tech.alliancecan.ca</a>'
+  }
+}.freeze
+FLASH_MESSAGES[:alert][:missing_email_link] = FLASH_MESSAGES[:alert][:missing_email_sign_in].sub('sign in', 'link')
+
 RSpec.describe Users::OmniauthCallbacksController, type: :controller do
   before do
-    # Capture User.from_omniauth before redefining it
-    @from_omniauth_method = User.method(:from_omniauth)
     # Setup Devise mapping
     @request.env['devise.mapping'] = Devise.mappings[:user]
     create(:org, managed: false, is_other: true)
-    @org = create(:org, managed: true)
     @identifier_scheme = create(:identifier_scheme, :openid_connect)
     @request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:openid_connect].dup
   end
 
-  after do
-    # Restore the actual User.from_omniauth method
-    User.define_singleton_method(:from_omniauth, @from_omniauth_method)
-  end
-
   describe 'POST #openid_connect' do
-    context 'email is missing from IdP and no user with these auth creds exists in DB' do
-      let(:current_user) { create(:user) }
+    context 'A user attempts to sign in using valid external credentials.' do
+      context 'The credentials are linked to an existing account' do
+        let!(:user) { create(:user) }
+
+        before do
+          create_user_identifier_from_auth(user)
+        end
+        it 'Signs the user in successfully' do
+          expect(User.count).to eq(1)
+          expect(Identifier.count).to eq(1)
+          expectations_for_openid_connect_sign_in
+        end
+      end
+
+      context 'The credentials are not yet linked to an existing account' do
+        context 'Generic case.' do
+          it 'Signs in the user successfully' do
+            expect(User.count).to eq(0)
+            expect(Identifier.count).to eq(0)
+            expectations_for_openid_connect_sign_in
+            user = User.first
+            # The attribute values correspond with User.find_or_create_from_provider_data(provider_data)
+            expect(user.email).to eq(@request.env['omniauth.auth'].info.email)
+            expect(user.firstname).to eq(@request.env['omniauth.auth'].info.first_name)
+            expect(user.surname).to eq(@request.env['omniauth.auth'].info.last_name)
+            expect(user.org).to eq(Org.find_by(is_other: true))
+            expect(user.accept_terms).to eq(true)
+          end
+        end
+
+        context 'The auth email matches an existing user email' do
+          # Set user email to match auth email
+          let!(:user) { create(:user, email: @request.env['omniauth.auth'].info.email) }
+          it 'Signs in the user successfully' do
+            expect(User.count).to eq(1)
+            expect(Identifier.count).to eq(0)
+            expectations_for_openid_connect_sign_in
+            # The newly-created Identifier belongs to the existing User with the same email
+            expect(User.first.identifiers.count).to eq(1)
+          end
+        end
+
+        context '`first_name` and `last_name` are absent from the auth data.' do
+          before do
+            # Set the auth data's first_name and last_name to nil
+            @request.env['omniauth.auth'].info.first_name = nil
+            @request.env['omniauth.auth'].info.last_name = nil
+          end
+          it 'Signs in the user and renders a flash alert to update their profile' do
+            expect(User.count).to eq(0)
+            expect(Identifier.count).to eq(0)
+            expectations_for_openid_connect_sign_in_with_generic_name
+          end
+        end
+      end
+    end
+
+    context 'A user is signed in and attempts to link their external credentials.' do
+      context 'Generic case.' do
+        let!(:user) { create(:user) }
+
+        before do
+          sign_in user
+        end
+
+        it 'Successfully links their credentials.' do
+          expect do
+            post :openid_connect
+            user.reload
+          end.to change(user.identifiers, :count).by(1)
+          expect(User.count).to eq(1)
+          expect(Identifier.count).to eq(1)
+          expect(flash[:notice]).to eq(FLASH_MESSAGES[:notice][:linked])
+          expect(response).to redirect_to(edit_user_registration_path)
+        end
+      end
+
+      context 'The external credentials are already linked to another user' do
+        let!(:user) { create(:user) }
+        let!(:other_user) { create(:user) }
+
+        before do
+          # Link the mocked auth data to `other_user`
+          create_user_identifier_from_auth(other_user)
+          sign_in user
+        end
+
+        it 'Does not link their credentials' do
+          post :openid_connect
+
+          expect(flash[:alert]).to eq(
+            "The current #{@identifier_scheme.description} iD has been already linked " \
+            "to a user with email #{other_user.email}"
+          )
+          expect(response).to redirect_to(edit_user_registration_path)
+          expect(User.count).to eq(2)
+          expect(Identifier.count).to eq(1)
+        end
+      end
+    end
+
+    context 'The credentials are not yet linked to an existing account and the email is nil.' do
+      let!(:user) { create(:user) }
       before do
         # Simulate missing email
         @request.env['omniauth.auth'].info.email = nil
       end
-
-      it 'Redirects signed out user to root path and renders correct flash message' do
-        post :openid_connect
-        expect(response).to redirect_to(root_path)
-        msg = 'Unable to sign in with the selected identity provider. ' \
-              'Consider using an alternative sign in method, like social sign on. ' \
-              'You can verify your email is being provided here ' \
-              '<<a href="https://cilogon.org/testidp/">https://cilogon.org/testidp/</a>> ' \
-              'and contact us at the help desk for further assistance. Help desk email: ' \
-              '<a href="mailto:dmp-assistant@tech.alliancecan.ca">dmp-assistant@tech.alliancecan.ca</a>'
-        expect(flash[:alert]).to eq(msg)
-      end
-
-      it 'Redirects signed in user to Edit Profile path and renders correct flash message' do
-        sign_in current_user
-        post :openid_connect
-        expect(response).to redirect_to(edit_user_registration_path)
-        msg = 'Unable to link with the selected identity provider. ' \
-              'Consider using an alternative sign in method, like social sign on. ' \
-              'You can verify your email is being provided here ' \
-              '<<a href="https://cilogon.org/testidp/">https://cilogon.org/testidp/</a>> ' \
-              'and contact us at the help desk for further assistance. Help desk email: ' \
-              '<a href="mailto:dmp-assistant@tech.alliancecan.ca">dmp-assistant@tech.alliancecan.ca</a>'
-        expect(flash[:alert]).to eq(msg)
-      end
-    end
-
-    context 'when the user is not signed in but already exists' do
-      let!(:user) { User.create(email: 'user@organization.ca', firstname: 'John', surname: 'Doe', org: @org) }
-
-      before do
-        def User.from_omniauth(_auth)
-          User.find_by(email: 'user@organization.ca')
-        end
-      end
-
-      it 'signs in the existing user' do
-        post :openid_connect
-        expect(response).to redirect_to(root_path)
-        expect(flash[:notice]).to eq('Signed in successfully.')
-      end
-    end
-
-    context 'when the user is signed in and needs to link their OpenID Connect account' do
-      let!(:user) { User.create(email: 'user@organization.ca', firstname: 'John', surname: 'Doe', org: @org) }
-      let(:current_user) { create(:user) }
-
-      before do
-        sign_in current_user
-      end
-
-      it 'links identifier to current user, sets flash notice, and redirects to root path' do
-        expect do
+      context 'The user is attempting to sign in with the external credentials.' do
+        it 'Does not link the credentials, renders a flash alert, and redirects the user to the root path.' do
           post :openid_connect
-          current_user.reload # Ensure we have the latest state of the user
-        end.to change(current_user.identifiers, :count).by(1)
-
-        expect(flash[:notice]).to eq('Linked successfully')
-        expect(response).to redirect_to(edit_user_registration_path)
-      end
-    end
-
-    context 'when the user found via omniauth is different from the current_user' do
-      let(:current_user) { create(:user) }
-      # Ensure different_user is created before test runs
-      let!(:different_user) do
-        create(:user, email: 'different_user@example.com')
-      end
-      before do
-        sign_in current_user
-
-        # Mocking the from_omniauth method to return a different user
-        # We use `let!` to ensure `different_user` is accessible here
-        User.define_singleton_method(:from_omniauth) do |_auth|
-          User.find_by(email: 'different_user@example.com')
+          expect(response).to redirect_to(root_path)
+          expect(flash[:alert]).to eq(FLASH_MESSAGES[:alert][:missing_email_sign_in])
+          expect(User.count).to eq(1)
+          expect(Identifier.count).to eq(0)
         end
       end
 
-      it 'sets flash alert and redirects to edit user registration path' do
-        post :openid_connect
-
-        expect(flash[:alert]).to eq(
-          "The current #{@identifier_scheme.description} iD has been already linked " \
-          "to a user with email #{different_user.email}"
-        )
-        expect(response).to redirect_to(edit_user_registration_path)
-      end
-    end
-
-    context 'when an unknown error occurs' do
-      before do
-        def User.from_omniauth(_auth)
-          raise StandardError, 'Unexpected error'
-        end
-      end
-
-      it 'handles the error and raises an exception' do
-        expect do
+      context 'The user is signed in and attempting to link the external credentials.' do
+        it 'Does not link the credentials, renders a flash alert, and redirects the user to the Edit Profile page.' do
+          sign_in user
           post :openid_connect
-        end.to raise_error(StandardError, 'Unexpected error')
+          expect(response).to redirect_to(edit_user_registration_path)
+          expect(flash[:alert]).to eq(FLASH_MESSAGES[:alert][:missing_email_link])
+          expect(User.count).to eq(1)
+          expect(Identifier.count).to eq(0)
+        end
       end
     end
+
+    private
+
+    def create_user_identifier_from_auth(user)
+      Identifier.create(identifier_scheme: @identifier_scheme,
+                        value: request.env['omniauth.auth'].uid,
+                        attrs: request.env['omniauth.auth'],
+                        identifiable: user)
+    end
+
+    # rubocop:disable Metrics/AbcSize
+    def expectations_for_openid_connect_sign_in
+      post :openid_connect
+      expect(response).to redirect_to(root_path)
+      expect(flash[:notice]).to eq(FLASH_MESSAGES[:notice][:signed_in])
+      expect(User.count).to eq(1)
+      expect(Identifier.count).to eq(1)
+    end
+    # rubocop:enable Metrics/AbcSize
+
+    # rubocop:disable Metrics/AbcSize
+    def expectations_for_openid_connect_sign_in_with_generic_name
+      post :openid_connect
+      expect(response).to redirect_to(root_path)
+      expect(flash[:alert]).to eq(FLASH_MESSAGES[:alert][:missing_profile])
+      expect(User.count).to eq(1)
+      expect(Identifier.count).to eq(1)
+      user = User.first
+      expect(user.firstname).to eq(User::GENERIC_USER_NAME_VALUES[:firstname])
+      expect(user.surname).to eq(User::GENERIC_USER_NAME_VALUES[:surname])
+    end
+    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -64,9 +64,8 @@ RSpec.describe Users::OmniauthCallbacksController, type: :controller do
 
       it 'signs in the existing user' do
         post :openid_connect
-        # expect(subject.current_user).to eq(user)
         expect(response).to redirect_to(root_path)
-        expect(flash[:notice]).to be_nil
+        expect(flash[:notice]).to eq('Signed in successfully.')
       end
     end
 

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Users::OmniauthCallbacksController, type: :controller do
             expect(user.email).to eq(@request.env['omniauth.auth'].info.email)
             expect(user.firstname).to eq(@request.env['omniauth.auth'].info.first_name)
             expect(user.surname).to eq(@request.env['omniauth.auth'].info.last_name)
-            expect(user.org).to eq(Org.find_by(is_other: true))
+            expect(user.org).to eq(Org.find_by!(is_other: true))
             expect(user.accept_terms).to eq(true)
           end
         end
@@ -162,10 +162,10 @@ RSpec.describe Users::OmniauthCallbacksController, type: :controller do
     private
 
     def create_user_identifier_from_auth(user)
-      Identifier.create(identifier_scheme: @identifier_scheme,
-                        value: request.env['omniauth.auth'].uid,
-                        attrs: request.env['omniauth.auth'],
-                        identifiable: user)
+      Identifier.create!(identifier_scheme: @identifier_scheme,
+                         value: request.env['omniauth.auth'].uid,
+                         attrs: request.env['omniauth.auth'],
+                         identifiable: user)
     end
 
     # rubocop:disable Metrics/AbcSize

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -15,7 +15,8 @@ FLASH_MESSAGES = {
                            'You can verify your email is being provided here ' \
                            '<<a href="https://cilogon.org/testidp/">https://cilogon.org/testidp/</a>> ' \
                            'and contact us at the help desk for further assistance. Help desk email: ' \
-                           '<a href="mailto:dmp-assistant@tech.alliancecan.ca">dmp-assistant@tech.alliancecan.ca</a>'
+                           '<a href="mailto:dmp-assistant@tech.alliancecan.ca">dmp-assistant@tech.alliancecan.ca</a>',
+    already_linked: 'These credentials are already linked to your account.'
   }
 }.freeze
 FLASH_MESSAGES[:alert][:missing_email_link] = FLASH_MESSAGES[:alert][:missing_email_sign_in].sub('sign in', 'link')
@@ -104,6 +105,29 @@ RSpec.describe Users::OmniauthCallbacksController, type: :controller do
           expect(Identifier.count).to eq(1)
           expect(flash[:notice]).to eq(FLASH_MESSAGES[:notice][:linked])
           expect(response).to redirect_to(edit_user_registration_path)
+        end
+      end
+
+      context 'Edge Case: The external credentials are already linked to the user.' do
+        # NOTE: This scenario is not possible through normal UI interaction,
+        # but a user could trigger it by manipulating the frontend.
+        let!(:user) { create(:user) }
+        before do
+          create_user_identifier_from_auth(user)
+          sign_in user
+        end
+        it 'Does not link the already linked credentials a second time.' do
+          expect(User.count).to eq(1)
+          expect(Identifier.count).to eq(1)
+          expect(user.identifiers.count).to eq(1)
+          # Attempt to link the already linked credentials
+          post :openid_connect
+          user.reload
+          expect(flash[:alert]).to eq(FLASH_MESSAGES[:alert][:already_linked])
+          expect(response).to redirect_to(edit_user_registration_path)
+          expect(User.count).to eq(1)
+          expect(Identifier.count).to eq(1)
+          expect(user.identifiers.count).to eq(1)
         end
       end
 

--- a/spec/services/locale_service_spec.rb
+++ b/spec/services/locale_service_spec.rb
@@ -57,6 +57,28 @@ RSpec.describe LocaleService do
     end
   end
 
+  describe '#translations_for_all_locales(string)' do
+    before do
+      # Override `I18n.available_locales` value to match DMP Assistant
+      # (LocaleService.translations_for_all_locales calls I18n.available_locales, NOT LocaleService.available_locales)
+      # TODO: Consider configuring the test locales to match those used within the actual app.
+      I18n.available_locales = %i[en-CA fr-CA]
+    end
+    it 'returns an array containing all translations of a string, across all available locales' do
+      # Use a string that has an existing translation in `config/locale/fr_CA/LC_MESSAGES/app.mo`
+      string = 'Create plans'
+      expect(described_class.translations_for_all_locales(string)).to eql(['Create plans', 'Créer des plans'])
+    end
+    it 'Handles edge cases' do
+      # When a string with no available translations is provided
+      expect(described_class.translations_for_all_locales('RANDOM XYZ123 STRING')).to eql(['RANDOM XYZ123 STRING'])
+      # When an empty string is provided
+      expect(described_class.translations_for_all_locales('')).to eql([])
+      # When a nil value is provided
+      expect(described_class.translations_for_all_locales(nil)).to eql([])
+    end
+  end
+
   context 'private methods' do
     describe '#convert(string:, join_char:)' do
       it 'handles a 2 character locale (e.g. `en`)' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -126,7 +126,7 @@ OmniAuth.config.test_mode = true
 OmniAuth.config.mock_auth[:openid_connect] = OmniAuth::AuthHash.new(
   {
     provider: 'openid_connect',
-    uid: '12345',
+    uid: 'https://www.cilogon.org/12345',
     info: {
       email: 'user@organization.ca',
       first_name: 'John',


### PR DESCRIPTION
Fixes # Not a fix, but this PR helps address https://github.com/portagenetwork/roadmap/issues/1067

# Changes proposed in this PR:
## Handle Additional User Scenarios
- Add flash message for users signing in via CILogon
  - If the user's name is 'generic' (i.e. it matches the fallback values used for accounts created via SSO), then a flash warning is rendered, informing the user to update their profile. Otherwise, a 'Signed in successfully.' flash notice is rendered.
- Handle attempts to re-link already linked external credentials
  - This scenario is not possible through normal UI interaction, but a user could trigger it by manipulating the frontend.

## Improve Underlyling Tests
- Perform a complete rework of the corresponding OmniauthCallbacksController test file
  - Add additional test scenarios, including those corresponding to the aforementioned additional user scenarios.