### PR TITLE
Add ENTRYPOINT to `Dockerfile.production` / Sync and Render New Translations at Runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@
 
  - Update CSS / Improve Accessibility For Hyperlinks and `.sign-in` Tabs [#811](https://github.com/portagenetwork/roadmap/pull/811)
 
+ - Add ENTRYPOINT to `Dockerfile.production` / Sync and Render New Translations at Runtime [#1075](https://github.com/portagenetwork/roadmap/pull/1075)
+
 ## [4.1.1+portage-4.3.0]
 
 ### Added

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -109,13 +109,13 @@ WORKDIR $INSTALL_PATH
 
 # Copy wkhtmltopdf binary
 COPY --from=wkhtmltopdf /bin/wkhtmltopdf /usr/bin/wkhtmltopdf
-# Copy data for timezone and mime types
+# Copy data for timezone and mime types from builder stage
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 COPY --from=builder /usr/share/mime /usr/share/mime
-# Copy application code and dependencies from builder stage
+# Copy application code from builder stage
 COPY --from=builder --chown=dmpuser:dmpgroup $INSTALL_PATH $INSTALL_PATH
 
-# Create required directories with correct ownerships & permissions
+# Create required dirs, set ownerships, move + chmod entrypoint.sh
 RUN mkdir -p ${INSTALL_PATH}/tmp/cache \
         ${INSTALL_PATH}/tmp/pids \
         ${INSTALL_PATH}/tmp/sockets \
@@ -130,7 +130,11 @@ RUN mkdir -p ${INSTALL_PATH}/tmp/cache \
     chmod -R 755 \
         ${INSTALL_PATH}/tmp \
         ${INSTALL_PATH}/public \
-        ${INSTALL_PATH}/config/locale
+        ${INSTALL_PATH}/config/locale && \
+        # Move entrypoint.sh to /usr/bin/ (already copied from builder stage)
+        mv ${INSTALL_PATH}/entrypoint.sh /usr/bin/entrypoint.sh && \
+        # Make /usr/bin/entrypoint.sh executable
+        chmod +x /usr/bin/entrypoint.sh
 
 USER dmpuser
 
@@ -139,7 +143,7 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
     CMD wget -qO- ${BASE_URL}/api/v1/heartbeat || exit 1
 
-CMD ["bundle", "exec", "rails", "s"]
+ENTRYPOINT ["/usr/bin/entrypoint.sh"]
 
 # nginx stage to serve static assets
 FROM nginx:$NGINX_VERSION AS assets

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,19 +2,11 @@
 set -e
 
 echo "==> Checking database readiness..."
-
-MAX_RETRIES=20
-RETRY_INTERVAL=3
-TRIES=0
-
-while ! bundle exec rails db:version > /dev/null 2>&1; do
-  TRIES=$((TRIES + 1))
-  if [ "$TRIES" -ge "$MAX_RETRIES" ]; then
-    echo "Database not ready after $((MAX_RETRIES * RETRY_INTERVAL)) seconds. Exiting."
-    exit 1
-  fi
-  echo "Attempted $TRIES/$MAX_RETRIES: Waiting for DB..."
-  sleep "$RETRY_INTERVAL"
+# Although this loop may run indefinitely, Kubernetes readiness probes
+# will detect when the app isn't ready and handle pod restarts if needed.
+until bundle exec rails db:version; do
+  echo "Waiting for DB connection..."
+  sleep 3
 done
 
 echo "Database is ready."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,30 @@
 #!/bin/sh
 set -e
 
+echo "==> Checking database readiness..."
+
+MAX_RETRIES=20
+RETRY_INTERVAL=3
+TRIES=0
+
+while ! bundle exec rails db:version > /dev/null 2>&1; do
+  TRIES=$((TRIES + 1))
+  if [ "$TRIES" -ge "$MAX_RETRIES" ]; then
+    echo "Database not ready after $((MAX_RETRIES * RETRY_INTERVAL)) seconds. Exiting."
+    exit 1
+  fi
+  echo "Attempted $TRIES/$MAX_RETRIES: Waiting for DB..."
+  sleep "$RETRY_INTERVAL"
+done
+
+echo "Database is ready."
+
+
 echo "==> Executing translation:sync..."
-bundle exec rake translation:sync
+if ! bundle exec rake translation:sync; then
+  echo "ERROR: translation:sync failed, continuing anyway."
+fi
+
 
 echo "==> Starting Rails server..."
 exec bundle exec rails s

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+echo "==> Executing translation:sync..."
+bundle exec rake translation:sync
+
+echo "==> Starting Rails server..."
+exec bundle exec rails s


### PR DESCRIPTION
Changes proposed in this PR:
- Replace `CMD ["bundle", "exec", "rails", "s"]` with `ENTRYPOINT ["/usr/bin/entrypoint.sh"]` in `Dockerfile.production`
- Created `entrypoint.sh`, which performs the following:
  1. Perform a database readiness check
     - Specifically, it executes `bundle exec rails db:version` to verify the DB connection. It retries every 3 seconds, up to a maximum of 20 attempts (60 seconds total). If the database is still unreachable after this time, the script exits with an error (`exit 1`).
  2. Execute `bundle exec translation:sync`
      - Our customised version of the translation gem relies on a DB connection, thus 1. is necessary
      - If this step fails,  the error is logged, but the app continues to start.
  3. Start the app via `bundle exec rails s`