### PR TITLE
feat(cronjobs): add stat:build cronjob to dmp-roadmap chart

### DIFF
--- a/charts/dmp-roadmap/README.md
+++ b/charts/dmp-roadmap/README.md
@@ -83,13 +83,13 @@ Helm chart for DMP Roadmap - A Data Management Planning tool that helps research
 | assets.tolerations | list | `[]` | Tolerations for the assets deployment |
 | assets.volumeMounts | list | `[]` | Additional volume mounts for the assets deployment |
 | assets.volumes | list | `[]` | Additional volumes for the assets deployment |
-| config | object | `{"application":{"dmproadmapHost":"","httpProxy":"","httpProxyPort":"","onSandbox":"false"},"environment":{"assetHost":"","baseUrl":"","bundlePath":"vendor/bundle","bundleWithout":"development:test:mysql:aws:sandbox:ci:wkhtmltopdf","defaultFunderId":8,"englishOrgId":"","frenchOrgId":"","funderOrgId":"","locale":"en_CA.UTF-8","nodeEnv":"production","omniauthFullHost":"","orcidClientMember":"false","railsEnv":"production","railsLogToStdout":"true","railsServeStaticFiles":"false","railsSkipAssetCompilation":"true","rakeEnv":"production","rollbarEnv":"arbutus-test","tmpDir":"/usr/src/app/tmp","wickedPdfPath":"/usr/bin/wkhtmltopdf","wickedPdfProxy":""},"mailer":{"defaultHost":"","from":"support@portagenetwork.ca","smtpAddress":"smtp.gmail.com","smtpAuthentication":"plain","smtpDomain":"portagenetwork.ca","smtpPort":587,"to":"support@portagenetwork.ca"}}` | Configuration values for the application |
+| config | object | `{"application":{"dmproadmapHost":"","httpProxy":"","httpProxyPort":"","onSandbox":"false"},"environment":{"assetHost":"","baseUrl":"","bundlePath":"vendor/bundle","bundleWithout":"development:test:mysql:aws:sandbox:ci:wkhtmltopdf","defaultFunderId":8,"englishOrgId":"","frenchOrgId":"","funderOrgId":"","locale":"en_CA.UTF-8","nodeEnv":"production","omniauthFullHost":"","orcidClientMember":"false","railsEnv":"production","railsLogToStdout":"true","railsServeStaticFiles":"false","railsSkipAssetCompilation":"true","rakeEnv":"production","rollbarEnv":"arbutus","tmpDir":"/usr/src/app/tmp","wickedPdfPath":"/usr/bin/wkhtmltopdf","wickedPdfProxy":""},"mailer":{"defaultHost":"","from":"support@portagenetwork.ca","smtpAddress":"smtp.gmail.com","smtpAuthentication":"plain","smtpDomain":"portagenetwork.ca","smtpPort":587,"to":"support@portagenetwork.ca"}}` | Configuration values for the application |
 | config.application | object | `{"dmproadmapHost":"","httpProxy":"","httpProxyPort":"","onSandbox":"false"}` | Application and host settings |
 | config.application.dmproadmapHost | string | global.domain.name | Main hostname for the application |
 | config.application.httpProxy | string | `""` | HTTP proxy if needed |
 | config.application.httpProxyPort | string | `""` | HTTP proxy port if needed |
 | config.application.onSandbox | string | `"false"` | Set to true for sandbox mode |
-| config.environment | object | `{"assetHost":"","baseUrl":"","bundlePath":"vendor/bundle","bundleWithout":"development:test:mysql:aws:sandbox:ci:wkhtmltopdf","defaultFunderId":8,"englishOrgId":"","frenchOrgId":"","funderOrgId":"","locale":"en_CA.UTF-8","nodeEnv":"production","omniauthFullHost":"","orcidClientMember":"false","railsEnv":"production","railsLogToStdout":"true","railsServeStaticFiles":"false","railsSkipAssetCompilation":"true","rakeEnv":"production","rollbarEnv":"arbutus-test","tmpDir":"/usr/src/app/tmp","wickedPdfPath":"/usr/bin/wkhtmltopdf","wickedPdfProxy":""}` | Environment-specific settings |
+| config.environment | object | `{"assetHost":"","baseUrl":"","bundlePath":"vendor/bundle","bundleWithout":"development:test:mysql:aws:sandbox:ci:wkhtmltopdf","defaultFunderId":8,"englishOrgId":"","frenchOrgId":"","funderOrgId":"","locale":"en_CA.UTF-8","nodeEnv":"production","omniauthFullHost":"","orcidClientMember":"false","railsEnv":"production","railsLogToStdout":"true","railsServeStaticFiles":"false","railsSkipAssetCompilation":"true","rakeEnv":"production","rollbarEnv":"arbutus","tmpDir":"/usr/src/app/tmp","wickedPdfPath":"/usr/bin/wkhtmltopdf","wickedPdfProxy":""}` | Environment-specific settings |
 | config.environment.assetHost | string | https://global.domain.name | Asset host |
 | config.environment.baseUrl | string | https://global.domain.name/global.domain.path | Base URL |
 | config.environment.bundlePath | string | `"vendor/bundle"` | Bundle path |
@@ -107,7 +107,7 @@ Helm chart for DMP Roadmap - A Data Management Planning tool that helps research
 | config.environment.railsServeStaticFiles | string | `"false"` | Rails serve static files |
 | config.environment.railsSkipAssetCompilation | string | `"true"` | Rails skip asset compilation |
 | config.environment.rakeEnv | string | `"production"` | Rake environment |
-| config.environment.rollbarEnv | string | `"arbutus-test"` | Rollbar environment |
+| config.environment.rollbarEnv | string | `"arbutus"` | Rollbar environment |
 | config.environment.tmpDir | string | `"/usr/src/app/tmp"` | Tmp directory |
 | config.environment.wickedPdfPath | string | `"/usr/bin/wkhtmltopdf"` | Path to wkhtmltopdf binary |
 | config.environment.wickedPdfProxy | string | `""` | Proxy for wkhtmltopdf if needed |
@@ -119,7 +119,7 @@ Helm chart for DMP Roadmap - A Data Management Planning tool that helps research
 | config.mailer.smtpDomain | string | `"portagenetwork.ca"` | SMTP domain |
 | config.mailer.smtpPort | int | `587` | SMTP port |
 | config.mailer.to | string | `"support@portagenetwork.ca"` | To address for system emails |
-| cronjobs | object | `{"researchDataOutput":{"affinity":{},"concurrencyPolicy":"Forbid","enabled":true,"env":[],"failedJobsHistoryLimit":1,"nodeSelector":{},"podAnnotations":{},"podLabels":{},"priorityClassName":"","resources":{"limits":{"cpu":"200m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}},"restartPolicy":"OnFailure","schedule":"0 1 * * *","successfulJobsHistoryLimit":3,"suspend":false,"tolerations":[],"volumeMounts":[],"volumes":[]},"translationSync":{"affinity":{},"concurrencyPolicy":"Forbid","enabled":true,"env":[],"failedJobsHistoryLimit":1,"nodeSelector":{},"podAnnotations":{},"podLabels":{},"priorityClassName":"","resources":{"limits":{"cpu":"200m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}},"restartPolicy":"OnFailure","schedule":"0 1 * * *","successfulJobsHistoryLimit":3,"suspend":false,"tolerations":[],"volumeMounts":[],"volumes":[]}}` | Scheduled tasks for the application |
+| cronjobs | object | `{"researchDataOutput":{"affinity":{},"concurrencyPolicy":"Forbid","enabled":true,"env":[],"failedJobsHistoryLimit":1,"nodeSelector":{},"podAnnotations":{},"podLabels":{},"priorityClassName":"","resources":{"limits":{"cpu":"200m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}},"restartPolicy":"OnFailure","schedule":"0 1 * * *","successfulJobsHistoryLimit":3,"suspend":false,"tolerations":[],"volumeMounts":[],"volumes":[]},"statBuild":{"affinity":{},"concurrencyPolicy":"Forbid","enabled":true,"env":[],"failedJobsHistoryLimit":1,"nodeSelector":{},"podAnnotations":{},"podLabels":{},"priorityClassName":"","resources":{"limits":{"cpu":"200m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}},"restartPolicy":"OnFailure","schedule":"1 1 * * *","successfulJobsHistoryLimit":3,"suspend":false,"tolerations":[],"volumeMounts":[],"volumes":[]},"translationSync":{"affinity":{},"concurrencyPolicy":"Forbid","enabled":true,"env":[],"failedJobsHistoryLimit":1,"nodeSelector":{},"podAnnotations":{},"podLabels":{},"priorityClassName":"","resources":{"limits":{"cpu":"200m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}},"restartPolicy":"OnFailure","schedule":"0 1 * * *","successfulJobsHistoryLimit":3,"suspend":false,"tolerations":[],"volumeMounts":[],"volumes":[]}}` | Scheduled tasks for the application |
 | cronjobs.researchDataOutput | object | `{"affinity":{},"concurrencyPolicy":"Forbid","enabled":true,"env":[],"failedJobsHistoryLimit":1,"nodeSelector":{},"podAnnotations":{},"podLabels":{},"priorityClassName":"","resources":{"limits":{"cpu":"200m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}},"restartPolicy":"OnFailure","schedule":"0 1 * * *","successfulJobsHistoryLimit":3,"suspend":false,"tolerations":[],"volumeMounts":[],"volumes":[]}` | Research Data Output CronJob configuration |
 | cronjobs.researchDataOutput.affinity | object | app.affinity | Affinity rules for the CronJob |
 | cronjobs.researchDataOutput.concurrencyPolicy | string | `"Forbid"` | Concurrency policy for CronJob (Allow, Forbid, Replace) |
@@ -138,6 +138,24 @@ Helm chart for DMP Roadmap - A Data Management Planning tool that helps research
 | cronjobs.researchDataOutput.tolerations | list | app.tolerations | Tolerations for the CronJob |
 | cronjobs.researchDataOutput.volumeMounts | list | `[]` | Additional volume mounts for the CronJob |
 | cronjobs.researchDataOutput.volumes | list | `[]` | Additional volumes for the CronJob |
+| cronjobs.statBuild | object | `{"affinity":{},"concurrencyPolicy":"Forbid","enabled":true,"env":[],"failedJobsHistoryLimit":1,"nodeSelector":{},"podAnnotations":{},"podLabels":{},"priorityClassName":"","resources":{"limits":{"cpu":"200m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}},"restartPolicy":"OnFailure","schedule":"1 1 * * *","successfulJobsHistoryLimit":3,"suspend":false,"tolerations":[],"volumeMounts":[],"volumes":[]}` | Stat Build CronJob configuration |
+| cronjobs.statBuild.affinity | object | app.affinity | Affinity rules for the CronJob |
+| cronjobs.statBuild.concurrencyPolicy | string | `"Forbid"` | Concurrency policy for CronJob (Allow, Forbid, Replace) |
+| cronjobs.statBuild.enabled | bool | `true` | Enable or disable the stat build CronJob |
+| cronjobs.statBuild.env | list | `[]` | Additional environment variables for the CronJob |
+| cronjobs.statBuild.failedJobsHistoryLimit | int | `1` | Number of failed job history to keep |
+| cronjobs.statBuild.nodeSelector | object | app.nodeSelector | Node selector for the CronJob |
+| cronjobs.statBuild.podAnnotations | object | `{}` | Pod annotations for the CronJob pods |
+| cronjobs.statBuild.podLabels | object | `{}` | Pod labels for the CronJob pods |
+| cronjobs.statBuild.priorityClassName | string | app.priorityClassName or global.priorityClassName | Priority class name for the CronJob |
+| cronjobs.statBuild.resources | object | `{"limits":{"cpu":"200m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}` | Resource limits and requests for the CronJob |
+| cronjobs.statBuild.restartPolicy | string | `"OnFailure"` | Restart policy for the job pods |
+| cronjobs.statBuild.schedule | string | `"1 1 * * *"` | Schedule for the CronJob (cron format) |
+| cronjobs.statBuild.successfulJobsHistoryLimit | int | `3` | Number of successful job history to keep |
+| cronjobs.statBuild.suspend | bool | `false` | Whether to suspend the job execution |
+| cronjobs.statBuild.tolerations | list | app.tolerations | Tolerations for the CronJob |
+| cronjobs.statBuild.volumeMounts | list | `[]` | Additional volume mounts for the CronJob |
+| cronjobs.statBuild.volumes | list | `[]` | Additional volumes for the CronJob |
 | cronjobs.translationSync | object | `{"affinity":{},"concurrencyPolicy":"Forbid","enabled":true,"env":[],"failedJobsHistoryLimit":1,"nodeSelector":{},"podAnnotations":{},"podLabels":{},"priorityClassName":"","resources":{"limits":{"cpu":"200m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}},"restartPolicy":"OnFailure","schedule":"0 1 * * *","successfulJobsHistoryLimit":3,"suspend":false,"tolerations":[],"volumeMounts":[],"volumes":[]}` | Translation Sync CronJob configuration |
 | cronjobs.translationSync.affinity | object | app.affinity | Affinity rules for the CronJob |
 | cronjobs.translationSync.concurrencyPolicy | string | `"Forbid"` | Concurrency policy for CronJob (Allow, Forbid, Replace) |

--- a/charts/dmp-roadmap/templates/cronjobs/stat-build.yaml
+++ b/charts/dmp-roadmap/templates/cronjobs/stat-build.yaml
@@ -1,0 +1,91 @@
+{{- if .Values.cronjobs.statBuild.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "dmp-roadmap.fullname" . }}-stat-build
+  labels:
+    {{- $_ := set . "component" "cronjob-stat-build" }}
+    {{- include "dmp-roadmap.labels" . | nindent 4 }}
+spec:
+  schedule: "{{ .Values.cronjobs.statBuild.schedule }}"
+  concurrencyPolicy: {{ .Values.cronjobs.statBuild.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.cronjobs.statBuild.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.cronjobs.statBuild.failedJobsHistoryLimit }}
+  suspend: {{ .Values.cronjobs.statBuild.suspend }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          {{- with .Values.cronjobs.statBuild.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          labels:
+            {{- $_ := set . "component" "cronjob-stat-build" }}
+            {{- include "dmp-roadmap.labels" . | nindent 12 }}
+            app.kubernetes.io/part-of: cronjob
+            {{- with .Values.cronjobs.statBuild.podLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        spec:
+          {{- with .Values.app.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.cronjobs.statBuild.priorityClassName | default .Values.app.priorityClassName | default .Values.global.priorityClassName }}
+          priorityClassName: {{ . }}
+          {{- end }}
+          serviceAccountName: {{ include "dmp-roadmap.serviceAccountName" . }}
+          securityContext:
+            {{- toYaml .Values.app.podSecurityContext | nindent 12 }}
+          restartPolicy: {{ .Values.cronjobs.statBuild.restartPolicy }}
+          containers:
+            - name: {{ .Chart.Name }}-stat-build
+              image: "{{ .Values.app.image.repository | default .Values.global.image.repository }}:{{ .Values.app.image.tag | default .Chart.AppVersion }}"
+              imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.app.image.imagePullPolicy }}
+              env:
+                {{- with (concat .Values.global.env .Values.app.env .Values.cronjobs.statBuild.env) }}
+                  {{- toYaml . | nindent 16 }}
+                {{- end }}
+              envFrom:
+                - configMapRef:
+                    name: {{ include "dmp-roadmap.fullname" . }}-app-config
+                {{- with .Values.app.envFrom }}
+                {{- toYaml . | nindent 16 }}
+                {{- end }}
+              securityContext:
+                {{- toYaml .Values.app.securityContext | nindent 16 }}
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  time bundle exec rake stat:build
+              resources:
+                {{- toYaml .Values.cronjobs.statBuild.resources | nindent 16 }}
+              volumeMounts:
+                # Required tmp directories for Rails
+                - name: rails-tmp
+                  mountPath: /usr/src/app/tmp
+                {{- with .Values.cronjobs.statBuild.volumeMounts }}
+                {{- toYaml . | nindent 16 }}
+                {{- end }}
+          volumes:
+            # Tmp directories required for Rails
+            - name: rails-tmp
+              emptyDir: {}
+            {{- with .Values.cronjobs.statBuild.volumes }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.cronjobs.statBuild.nodeSelector | default .Values.app.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.cronjobs.statBuild.affinity | default .Values.app.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.cronjobs.statBuild.tolerations | default .Values.app.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/charts/dmp-roadmap/values.yaml
+++ b/charts/dmp-roadmap/values.yaml
@@ -560,6 +560,54 @@ cronjobs:
     # -- Tolerations for the CronJob
     # @default -- app.tolerations
     tolerations: []
+
+  # -- Stat Build CronJob configuration
+  statBuild:
+    # -- Enable or disable the stat build CronJob
+    enabled: true
+    # -- Schedule for the CronJob (cron format)
+    schedule: '1 1 * * *'
+    # -- Concurrency policy for CronJob (Allow, Forbid, Replace)
+    concurrencyPolicy: Forbid
+    # -- Number of successful job history to keep
+    successfulJobsHistoryLimit: 3
+    # -- Number of failed job history to keep
+    failedJobsHistoryLimit: 1
+    # -- Whether to suspend the job execution
+    suspend: false
+    # -- Restart policy for the job pods
+    restartPolicy: OnFailure
+    # -- Pod annotations for the CronJob pods
+    podAnnotations: {}
+    # -- Pod labels for the CronJob pods
+    podLabels: {}
+    # -- Priority class name for the CronJob
+    # @default -- app.priorityClassName or global.priorityClassName
+    priorityClassName: ''
+    # -- Additional environment variables for the CronJob
+    env: []
+    # -- Additional volume mounts for the CronJob
+    volumeMounts: []
+    # -- Additional volumes for the CronJob
+    volumes: []
+    # -- Resource limits and requests for the CronJob
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 200m
+        memory: 512Mi
+    # -- Node selector for the CronJob
+    # @default -- app.nodeSelector
+    nodeSelector: {}
+    # -- Affinity rules for the CronJob
+    # @default -- app.affinity
+    affinity: {}
+    # -- Tolerations for the CronJob
+    # @default -- app.tolerations
+    tolerations: []
+
 # -- Extra Kubernetes objects to deploy
 extraObjects: []
 ## Network Policies


### PR DESCRIPTION
  ## Summary
  - Add new `stat:build` cronjob following the same pattern as existing cronjobs
  - Schedule: `1 1 * * *` (daily at 1:01 AM)
  - Executes `bundle exec rake stat:build` command

  ## Changes
  - **Added**: `charts/dmp-roadmap/templates/cronjobs/stat-build.yaml` - New cronjob template
  - **Updated**: `charts/dmp-roadmap/values.yaml` - Added `statBuild` configuration section
  - **Updated**: `charts/dmp-roadmap/README.md` - Documentation updated via helm-docs

  ## Test plan
  - [x] Verify cronjob template renders correctly with `helm template`
  - [ ] Deploy to development environment and confirm cronjob is created
  - [ ] Verify cronjob executes successfully on schedule