### PR TITLE
Fix WickedPdf deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 
  - Improve OmniauthCallbacksController Tests [#1074](https://github.com/portagenetwork/roadmap/pull/1074)
 
+ - Fix WickedPdf deprecation warning [#1080](https://github.com/portagenetwork/roadmap/pull/1080)
+
 ### Changed
 
  - Improve copying of third-party and static assets not served by the Rails asset pipeline [#980](https://github.com/portagenetwork/roadmap/pull/980)

--- a/config/initializers/wicked_pdf.rb
+++ b/config/initializers/wicked_pdf.rb
@@ -3,9 +3,9 @@
 module DMPRoadmap
   # wkhtmlpdf configurations
   class Application < Rails::Application
-    WickedPdf.config = {
-      exe_path: Rails.application.secrets.wicked_pdf_path || '/usr/bin/wkhtmltopdf',
-      proxy: Rails.application.secrets.wicked_pdf_proxy || ''
-    }
+    WickedPdf.configure do |config|
+      config.exe_path = Rails.application.secrets.wicked_pdf_path || '/usr/bin/wkhtmltopdf'
+      config.proxy = Rails.application.secrets.wicked_pdf_proxy || ''
+    end
   end
 end


### PR DESCRIPTION
Fixes #979

Changes proposed in this PR:
- This change resolves the following deprecation warning:
`WickedPdf.config= is deprecated and will be removed in future versions. Use WickedPdf.configure instead.`
