### PR TITLE
Fix logo path within static error pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,9 @@
 
  - Delete Auto-Generated and Unused `tinymce/skins` Contents and Add to `.gitignore` [#1060](https://github.com/portagenetwork/roadmap/pull/1060)
 
- - Changed error messages in `public` to be consistent and include French translations [#1058](https://github.com/portagenetwork/roadmap/pull/1058)
+ - Changed error pages in `public/` to be consistent and include French translations
+   - [#1058](https://github.com/portagenetwork/roadmap/pull/1058)
+   - [#1083](https://github.com/portagenetwork/roadmap/pull/1083) 
 
  - Modified "Request Feedback" Default Message and Flash Behaviour [#1064](https://github.com/portagenetwork/roadmap/pull/1064)
 

--- a/public/403.html
+++ b/public/403.html
@@ -20,7 +20,7 @@
 
 <body>
   <!-- This file lives in public/403.html -->
-  <img src = "images/dmp-logo-bil-large.png" class="img"/>
+  <img src="/images/dmp-logo-bil-large.png" class="img"/>
   <div class="dialog">
     <h1>You're not authorized to view this resource. </h1>
     <h1>Vous n'&ecirc;tes pas autoris&eacute; &agrave; consulter cette ressource.</h1>

--- a/public/404.html
+++ b/public/404.html
@@ -20,7 +20,7 @@
 
 <body>
   <!-- This file lives in public/404.html -->
-  <img src = "images/dmp-logo-bil-large.png" class="img"/>
+  <img src="/images/dmp-logo-bil-large.png" class="img"/>
   <div class="dialog">
     <h1>The page you were looking for doesn't exist.</h1>
     <h1>La page que vous recherchez n'existe pas.</h1>

--- a/public/422.html
+++ b/public/422.html
@@ -20,7 +20,7 @@
 
 <body>
   <!-- This file lives in public/422.html -->
-  <img src = "images/dmp-logo-bil-large.png" class="img"/>
+  <img src="/images/dmp-logo-bil-large.png" class="img"/>
   <div class="dialog">
     <h1>The change you wanted was rejected.</h1>
     <h1>La modification souhait&eacute;e a &eacute;t&eacute; refus&eacute;e.</h1>

--- a/public/429.html
+++ b/public/429.html
@@ -20,7 +20,7 @@
 
 <body>
   <!-- This file lives in public/429.html -->
-  <img src = "images/dmp-logo-bil-large.png" class="img"/>
+  <img src="/images/dmp-logo-bil-large.png" class="img"/>
   <div class="dialog">
     <h1>Too Many Requests.</h1>
     <h1>Trop de sollicitations.</h1>

--- a/public/500.html
+++ b/public/500.html
@@ -20,7 +20,7 @@
 
 <body>
   <!-- This file lives in public/500.html -->
-  <img src = "images/dmp-logo-bil-large.png" class="img"/>
+  <img src="/images/dmp-logo-bil-large.png" class="img"/>
   <div class="dialog">
     <h1>Internal Server Error.</h1>
     <h1>Erreur de serveur interne.</h1>


### PR DESCRIPTION
Changes proposed in this PR:
- Updated <img> tag within static error pages to use an absolute path instead of a relative one.

- Previously, the logo would only render when errors occurred on the root path. Errors encountered on nested paths (e.g., /users/edit/bad_path) would result in the following error when attempting to load the image:
  
  `ActionController::RoutingError (No route matches [GET] "/users/edit/images/dmp-logo-bil-large.png")`