### PR TITLE
 Add `autocomplete` attribute for some fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 
 ### Changed
 
+ -  Add `autocomplete` attribute for some fields [#1089](https://github.com/portagenetwork/roadmap/pull/1089)
+
  - Set 'noreply@dmp-pgd.ca' as envelope sender for all outgoing emails [#1088](https://github.com/portagenetwork/roadmap/pull/1088)
 
  - Improve copying of third-party and static assets not served by the Rails asset pipeline [#980](https://github.com/portagenetwork/roadmap/pull/980)

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -13,11 +13,11 @@
       <%= f.hidden_field :invitation_token %>
       <div class="form-group">
         <%= f.label(:password, _('New password'), class: 'control-label') %>
-        <%= f.password_field(:password, class: 'form-control', "aria-required": true) %>
+        <%= f.password_field(:password, class: 'form-control', "aria-required": true, autocomplete: "new-password") %>
       </div>
       <div class="form-group">
         <%= f.label(:password_confirmation, _('Password confirmation'), class: 'control-label') %>
-        <%= f.password_field(:password_confirmation, class: 'form-control', "aria-required": true) %>
+        <%= f.password_field(:password_confirmation, class: 'form-control', "aria-required": true, autocomplete: "new-password") %>
       </div>
       <div class="form-group">
         <%= f.label(:firstname, _('First name'), class: 'control-label') %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -13,11 +13,11 @@
 
       <div class="form-group">
         <%= f.label(:password, _('New password'), class: 'control-label') %>
-        <%= f.password_field(:password, class: 'form-control', "aria-required": true) %>
+        <%= f.password_field(:password, class: 'form-control', "aria-required": true, autocomplete: "new-password") %>
       </div>
       <div class="form-group">
         <%= f.label(:password_confirmation, _('Password confirmation'), class: 'control-label') %>
-        <%= f.password_field(:password_confirmation, class: 'form-control', "aria-required": true) %>
+        <%= f.password_field(:password_confirmation, class: 'form-control', "aria-required": true, autocomplete: "new-password") %>
       </div>
       <div class="checkbox">
         <label>

--- a/app/views/devise/registrations/_password_details.html.erb
+++ b/app/views/devise/registrations/_password_details.html.erb
@@ -11,12 +11,12 @@
 
   <div class="form-group col-xs-8">
     <%= f.label(:password, _('New password'),  class: 'control-label') %> 
-    <%= f.password_field(:password,  class: "form-control", "aria-required": true , id: 'user_new_password') %>
+    <%= f.password_field(:password,  class: "form-control", "aria-required": true , id: 'user_new_password', autocomplete: "new-password") %>
   </div>
 
   <div class="form-group col-xs-8">
     <%= f.label(:password_confirmation, _('Password confirmation'),  class: 'control-label') %>
-    <%= f.password_field(:password_confirmation, class: "form-control", "aria-required": true,  ) %>
+    <%= f.password_field(:password_confirmation, class: "form-control", "aria-required": true, autocomplete: "new-password") %>
   </div>
 
   <div class="form-group col-xs-8">

--- a/app/views/shared/_create_account_form.html.erb
+++ b/app/views/shared/_create_account_form.html.erb
@@ -25,7 +25,7 @@
   </div>
   <div class="form-group">
     <%= f.label(:password, _('Password'), class: "control-label") %>
-    <%= f.password_field(:password, class: "form-control", "aria-required": true) %>
+    <%= f.password_field(:password, class: "form-control", "aria-required": true, autocomplete: "new-password") %>
   </div>
   <div class="form-group">
     <div class="checkbox">

--- a/app/views/shared/_sign_in_form.html.erb
+++ b/app/views/shared/_sign_in_form.html.erb
@@ -5,7 +5,7 @@
   </div>
   <div class="form-group">
     <%= f.label(:password, _('Password'), class: 'control-label') %>
-    <%= f.password_field(:password, class: 'form-control', "aria-required": true) %>
+    <%= f.password_field(:password, class: 'form-control', "aria-required": true, autocomplete: "current-password") %>
   </div>
   <% unless FeatureFlagHelper.enabled?(:on_sandbox) %>
     <div>


### PR DESCRIPTION
## Changes proposed in this PR:
These changes align with the what is recommended in MDN web docs: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/password#allowing_autocomplete

NOTE:  `autocomplete: "current-password"` has intentionally NOT been added to`app/views/devise/registrations/_password_details.html.erb`. This should make the browser's autofill behavior less aggressive and encourage more deliberate user input when changing their password.

NOTE: `app/views/devise/registrations/_password_confirmation.html.erb` has not been edited, mainly because we currently do not allow users to update their email within the app.
