### PR TITLE
Fix Email Translation

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -20,7 +20,11 @@ class UserMailer < ActionMailer::Base
     @contact_us     = Rails.application.config.x.organisation.contact_us_url || contact_us_url
     @helpdesk_email = helpdesk_email(org: @user.org)
 
-    I18n.with_locale I18n.locale do
+    # @user.language&.abbreviation = abbreviation of user's language (en or fr)'
+    # I18n.default_locale = app's default locale
+    # This temporarily sets the I18n locale to user's preferred language (if available)
+    # defaults to app's default locale
+    I18n.with_locale(@user.language&.abbreviation || I18n.default_locale) do
       mail(to: @user.email,
            subject: format(_('Welcome to %{tool_name}'), tool_name: tool_name))
     end
@@ -41,14 +45,16 @@ class UserMailer < ActionMailer::Base
     @answer_text    = @options_string.to_s
     @helpdesk_email = helpdesk_email(org: @user.org)
 
-    I18n.with_locale I18n.locale do
+    # This temporarily sets the I18n locale to user's preferred language (if available)
+    # defaults to app's default locale
+    I18n.with_locale(@user.language&.abbreviation || I18n.default_locale) do
       mail(to: data['email'],
            subject: data['subject'])
     end
   end
   # rubocop:enable Metrics/AbcSize
 
-  def sharing_notification(role, user, inviter:)
+  def sharing_notification(role, user, inviter:) # rubocop:disable Metrics/AbcSize
     @role       = role
     @user       = user
     @user_email = @user.email
@@ -57,14 +63,16 @@ class UserMailer < ActionMailer::Base
     @link       = url_for(action: 'show', controller: 'plans', id: @role.plan.id)
     @helpdesk_email = helpdesk_email(org: @inviter.org)
 
-    I18n.with_locale I18n.locale do
+    # This temporarily sets the I18n locale to user's preferred language (if available)
+    # defaults to app's default locale
+    I18n.with_locale(@user.language&.abbreviation || I18n.default_locale) do
       mail(to: @role.user.email,
            subject: format(_('A Data Management Plan in %{tool_name} has been shared with you'),
                            tool_name: tool_name))
     end
   end
 
-  def permissions_change_notification(role, user)
+  def permissions_change_notification(role, user) # rubocop:disable Metrics/AbcSize
     return unless user.active?
 
     @role       = role
@@ -74,7 +82,9 @@ class UserMailer < ActionMailer::Base
     @messaging = role_text(@role)
     @helpdesk_email = helpdesk_email(org: @user.org)
 
-    I18n.with_locale I18n.locale do
+    # This temporarily sets the I18n locale to user's preferred language (if available)
+    # defaults to app's default locale
+    I18n.with_locale(@user.language&.abbreviation || I18n.default_locale) do
       mail(to: @recepient.email,
            subject: format(_('Changed permissions on a Data Management Plan in %{tool_name}'),
                            tool_name: tool_name))
@@ -89,14 +99,16 @@ class UserMailer < ActionMailer::Base
     @current_user = current_user
     @helpdesk_email = helpdesk_email(org: @plan.org)
 
-    I18n.with_locale I18n.locale do
+    # This temporarily sets the I18n locale to user's preferred language (if available)
+    # defaults to app's default locale
+    I18n.with_locale(@user.language&.abbreviation || I18n.default_locale) do
       mail(to: @user.email,
            subject: format(_('Permissions removed on a DMP in %{tool_name}'),
                            tool_name: tool_name))
     end
   end
 
-  def feedback_notification(recipient, plan, requestor)
+  def feedback_notification(recipient, plan, requestor) # rubocop:disable Metrics/AbcSize
     return unless recipient.active?
 
     @user           = requestor
@@ -107,7 +119,9 @@ class UserMailer < ActionMailer::Base
     @plan_name      = @plan.title
     @helpdesk_email = helpdesk_email(org: @plan.org)
 
-    I18n.with_locale I18n.locale do
+    # This temporarily sets the I18n locale to user's preferred language (if available)
+    # defaults to app's default locale
+    I18n.with_locale(@user.language&.abbreviation || I18n.default_locale) do
       mail(to: @recipient.email,
            subject: format(_('%{user_name} has requested feedback on a %{tool_name} plan'),
                            tool_name: tool_name, user_name: @user.name(false)))
@@ -126,7 +140,9 @@ class UserMailer < ActionMailer::Base
     @plan_name      = @plan.title
     @helpdesk_email = helpdesk_email(org: @plan.org)
 
-    I18n.with_locale I18n.locale do
+    # This temporarily sets the I18n locale to user's preferred language (if available)
+    # defaults to app's default locale
+    I18n.with_locale(@user.language&.abbreviation || I18n.default_locale) do
       sender = Rails.configuration.x.organisation.do_not_reply_email ||
                Rails.configuration.x.organisation.email
 
@@ -138,7 +154,7 @@ class UserMailer < ActionMailer::Base
   end
   # rubocop:enable Metrics/AbcSize
 
-  def plan_visibility(user, plan)
+  def plan_visibility(user, plan) # rubocop:disable Metrics/AbcSize
     return unless user.active?
 
     @user            = user
@@ -148,7 +164,9 @@ class UserMailer < ActionMailer::Base
     @plan_visibility = Plan::VISIBILITY_MESSAGE[@plan.visibility.to_sym]
     @helpdesk_email = helpdesk_email(org: @plan.org)
 
-    I18n.with_locale I18n.locale do
+    # This temporarily sets the I18n locale to user's preferred language (if available)
+    # defaults to app's default locale
+    I18n.with_locale(@user.language&.abbreviation || I18n.default_locale) do
       mail(to: @user.email,
            subject: format(_('DMP Visibility Changed: %{plan_title}'), plan_title: @plan.title))
     end
@@ -177,7 +195,9 @@ class UserMailer < ActionMailer::Base
     @phase_link = url_for(action: 'edit', controller: 'plans', id: @plan.id, phase_id: @phase_id)
     @helpdesk_email = helpdesk_email(org: @plan.org)
 
-    I18n.with_locale I18n.locale do
+    # This temporarily sets the I18n locale to user's preferred language (if available)
+    # defaults to app's default locale
+    I18n.with_locale(@user.language&.abbreviation || I18n.default_locale) do
       mail(to: @plan.owner.email,
            subject: format(_('%{tool_name}: A new comment was added to %{plan_title}'),
                            tool_name: tool_name, plan_title: @plan.title))
@@ -193,7 +213,9 @@ class UserMailer < ActionMailer::Base
     @ul_list   = privileges_list(@user)
     @helpdesk_email = helpdesk_email(org: @user.org)
 
-    I18n.with_locale I18n.locale do
+    # This temporarily sets the I18n locale to user's preferred language (if available)
+    # defaults to app's default locale
+    I18n.with_locale(@user.language&.abbreviation || I18n.default_locale) do
       mail(to: user.email,
            subject: format(_('Administrator privileges updated in %{tool_name}'),
                            tool_name: tool_name))
@@ -211,7 +233,9 @@ class UserMailer < ActionMailer::Base
 
     @helpdesk_email = helpdesk_email(org: @api_client.org)
 
-    I18n.with_locale I18n.locale do
+    # This temporarily sets the I18n locale to user's preferred language (if available)
+    # defaults to app's default locale
+    I18n.with_locale(@user.language&.abbreviation || I18n.default_locale) do
       mail(to: @api_client.contact_email,
            subject: format(_('%{tool_name} API changes'), tool_name: tool_name))
     end

--- a/app/views/user_mailer/api_credentials.html.erb
+++ b/app/views/user_mailer/api_credentials.html.erb
@@ -26,7 +26,7 @@
 </p>
 
 <p>
-  <%= _("Do not share these credentials. They for use with the %{external_application} application. If you do share your credentials with another application we reserve the right to revoke your access to the API.") % {
+  <%= _("Do not share these credentials. They are for use with the %{external_application} application. If you do share your credentials with another application we reserve the right to revoke your access to the API.") % {
     external_application: @api_client.name.capitalize }
   %>
 </p>

--- a/app/views/user_mailer/permissions_change_notification.html.erb
+++ b/app/views/user_mailer/permissions_change_notification.html.erb
@@ -1,5 +1,5 @@
 <p>
-  <%= _('Hello %{recepientname}') %{ recepientname: @recepient.name } %>
+  <%= _('Hello %{recepientname},') %{ recepientname: @recepient.name } %>
 </p>
 <p>
   <%= _('Your permissions relating to %{plan_title} have changed. You now have %{type} access. This means you can %{placeholder1} %{placeholder2}') % {


### PR DESCRIPTION
Fixes emails not translating to French when being sent to users who have set their language to French.

Changes proposed in this PR:
- Adjust logic in `user_mailer.rb` to properly translate emails.
- Correct wording in API credentials email.
