### PR TITLE
Modify CSV Separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 
 ### Changed
 
- -  Add `autocomplete` attribute for some fields [#1089](https://github.com/portagenetwork/roadmap/pull/1089)
+ - Add `autocomplete` attribute for some fields [#1089](https://github.com/portagenetwork/roadmap/pull/1089)
 
  - Set 'noreply@dmp-pgd.ca' as envelope sender for all outgoing emails [#1088](https://github.com/portagenetwork/roadmap/pull/1088)
 
@@ -59,6 +59,8 @@
  - Update CSS / Improve Accessibility For Hyperlinks and `.sign-in` Tabs [#811](https://github.com/portagenetwork/roadmap/pull/811)
 
  - Add ENTRYPOINT to `Dockerfile.production` / Sync and Render New Translations at Runtime [#1075](https://github.com/portagenetwork/roadmap/pull/1075)
+
+ - Modify CSV separator parameter [#1095](https://github.com/portagenetwork/roadmap/pull/1095)
 
 ## [4.1.1+portage-4.3.0]
 

--- a/app/controllers/usage_controller.rb
+++ b/app/controllers/usage_controller.rb
@@ -188,9 +188,14 @@ class UsageController < ApplicationController
     params[:filtered].present? && params[:filtered] == 'true'
   end
 
-  # set the csv separator or default to comma
+  # This sets the csv separator
+  # Ensures separator is either a comma or a safe separator
   def sep_param
-    params['sep'] || ','
+    safe_csv_separators = Rails.configuration.x.application.csv_separators
+    sep = params['sep'].to_s
+    return sep if safe_csv_separators.include?(sep)
+
+    ','
   end
 
   def min_max_dates(args:)


### PR DESCRIPTION
Changes proposed in this PR:
- Refactor the sep_param method in `usage_controller` to validate that the provided CSV field separator is a safe, predefined character.
