### PR TITLE
Bug Fix:  Address Delivery of Duplicate "contact-us" Emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Fixed
 
+ - Bug Fix: Address Delivery of Duplicate "contact-us" Emails [#1097](https://github.com/portagenetwork/roadmap/pull/1097)
+
  - Fix handling of attrs[:managed] on Org updates [#1062](https://github.com/portagenetwork/roadmap/pull/1062)
  
  - Add `upgrade_customization?` Check When Determining Default Template (Funder vs Org Customization) For Dropdown [#1014](https://github.com/portagenetwork/roadmap/pull/1014)

--- a/app/controllers/contact_us/contacts_controller.rb
+++ b/app/controllers/contact_us/contacts_controller.rb
@@ -4,12 +4,11 @@ module ContactUs
   # Controller for the Contact Us gem
   class ContactsController < ApplicationController
     # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     def create
       @contact = ContactUs::Contact.new(params[:contact_us_contact])
 
       if !user_signed_in? && Rails.configuration.x.recaptcha.enabled &&
-         !(verify_recaptcha(model: @contact) && @contact.save)
+         !verify_recaptcha(model: @contact)
         flash[:alert] = _('Captcha verification failed, please retry.')
         render_new_page and return
       end
@@ -22,7 +21,6 @@ module ContactUs
       end
     end
     # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
     def new
       @contact = ContactUs::Contact.new


### PR DESCRIPTION
Fixes # https://github.com/DMPRoadmap/roadmap/issues/3543

Changes proposed in this PR:
- These changes address the following upstream issue: https://github.com/DMPRoadmap/roadmap/issues/3543
  - Specifically, prior to this change, if a user was signed out, and recaptcha was enabled, and the recaptcha verification was successful, then `@contact.save` was executed and a "contact-us" email was delivered.
  - However, even though the email was delivered, the following if check would evaluate to false:
    ```ruby  
    if !user_signed_in? && Rails.configuration.x.recaptcha.enabled &&
        !(verify_recaptcha(model: @contact) && @contact.save)
    ```
  - Thus, `if @contact.save` would also be executed, resulting in the delivery of 2 "contact-us" emails.
  - Removing the first `@contact.save` statement remedies this bug by ensuring that the first if check only evaluates the recaptcha verification, and prevents duplicate "contact-us" emails from being delivered.