### PR TITLE
Translate emails to recipient's preferred locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 
  - Fix WickedPdf deprecation warning [#1080](https://github.com/portagenetwork/roadmap/pull/1080)
 
+ - Enable translation of emails to recipient's preferred locale [#1100](https://github.com/portagenetwork/roadmap/pull/1100)
+
 ### Changed
 
  - Add `autocomplete` attribute for some fields [#1089](https://github.com/portagenetwork/roadmap/pull/1089)

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -4,12 +4,6 @@
 module MailerHelper
   include PermsHelper
 
-  # Returns the email recipient's preferred locale.
-  # Falls back to the current app locale.
-  def email_locale(recipient)
-    recipient&.language&.abbreviation || I18n.locale
-  end
-
   def tool_name
     @tool_name ||= ApplicationService.application_name
   end

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -4,6 +4,12 @@
 module MailerHelper
   include PermsHelper
 
+  # Returns the email recipient's preferred locale.
+  # Falls back to the current app locale.
+  def email_locale(recipient)
+    recipient.language&.abbreviation || I18n.locale
+  end
+
   def tool_name
     @tool_name ||= ApplicationService.application_name
   end

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -7,7 +7,7 @@ module MailerHelper
   # Returns the email recipient's preferred locale.
   # Falls back to the current app locale.
   def email_locale(recipient)
-    recipient.language&.abbreviation || I18n.locale
+    recipient&.language&.abbreviation || I18n.locale
   end
 
   def tool_name

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -37,7 +37,9 @@ class UserMailer < ActionMailer::Base
     @answer_text    = @options_string.to_s
     @helpdesk_email = helpdesk_email(org: @user.org)
 
-    I18n.with_locale(email_locale(@user)) do
+    locale = User.find_by(email: data['email'])
+
+    I18n.with_locale(email_locale(locale)) do
       mail(to: data['email'],
            subject: data['subject'])
     end
@@ -186,7 +188,6 @@ class UserMailer < ActionMailer::Base
 
     @user      = user
     @username  = @user.name
-    @ul_list   = privileges_list(@user)
     @helpdesk_email = helpdesk_email(org: @user.org)
 
     I18n.with_locale(email_locale(@user)) do

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -39,14 +39,14 @@ class UserMailer < ActionMailer::Base
 
     recipient = User.find_by(email: data['email'])
 
-    I18n.with_locale(email_locale(recipient)) do
+    LocaleService.with_preferred_locale(recipient) do
       mail(to: data['email'],
            subject: data['subject'])
     end
   end
   # rubocop:enable Metrics/AbcSize
 
-  def sharing_notification(role, user, inviter:) # rubocop:disable Metrics/AbcSize
+  def sharing_notification(role, user, inviter:)
     @role       = role
     @user       = user
     @user_email = @user.email
@@ -55,7 +55,7 @@ class UserMailer < ActionMailer::Base
     @link       = url_for(action: 'show', controller: 'plans', id: @role.plan.id)
     @helpdesk_email = helpdesk_email(org: @inviter.org)
 
-    I18n.with_locale(email_locale(@role.user)) do
+    LocaleService.with_preferred_locale(@role.user) do
       mail(to: @role.user.email,
            subject: format(_('A Data Management Plan in %{tool_name} has been shared with you'),
                            tool_name: tool_name))
@@ -72,7 +72,7 @@ class UserMailer < ActionMailer::Base
     @messaging = role_text(@role)
     @helpdesk_email = helpdesk_email(org: @user.org)
 
-    I18n.with_locale(email_locale(@recepient)) do
+    LocaleService.with_preferred_locale(@recepient) do
       mail(to: @recepient.email,
            subject: format(_('Changed permissions on a Data Management Plan in %{tool_name}'),
                            tool_name: tool_name))
@@ -87,7 +87,7 @@ class UserMailer < ActionMailer::Base
     @current_user = current_user
     @helpdesk_email = helpdesk_email(org: @plan.org)
 
-    I18n.with_locale(email_locale(@user)) do
+    LocaleService.with_preferred_locale(@user) do
       mail(to: @user.email,
            subject: format(_('Permissions removed on a DMP in %{tool_name}'),
                            tool_name: tool_name))
@@ -105,7 +105,7 @@ class UserMailer < ActionMailer::Base
     @plan_name      = @plan.title
     @helpdesk_email = helpdesk_email(org: @plan.org)
 
-    I18n.with_locale(email_locale(@recipient)) do
+    LocaleService.with_preferred_locale(@recipient) do
       mail(to: @recipient.email,
            subject: format(_('%{user_name} has requested feedback on a %{tool_name} plan'),
                            tool_name: tool_name, user_name: @user.name(false)))
@@ -124,7 +124,7 @@ class UserMailer < ActionMailer::Base
     @plan_name      = @plan.title
     @helpdesk_email = helpdesk_email(org: @plan.org)
 
-    I18n.with_locale(email_locale(recipient)) do
+    LocaleService.with_preferred_locale(recipient) do
       sender = Rails.configuration.x.organisation.do_not_reply_email ||
                Rails.configuration.x.organisation.email
 
@@ -146,7 +146,7 @@ class UserMailer < ActionMailer::Base
     @plan_visibility = Plan::VISIBILITY_MESSAGE[@plan.visibility.to_sym]
     @helpdesk_email = helpdesk_email(org: @plan.org)
 
-    I18n.with_locale(email_locale(@user)) do
+    LocaleService.with_preferred_locale(@user) do
       mail(to: @user.email,
            subject: format(_('DMP Visibility Changed: %{plan_title}'), plan_title: @plan.title))
     end
@@ -175,7 +175,7 @@ class UserMailer < ActionMailer::Base
     @phase_link = url_for(action: 'edit', controller: 'plans', id: @plan.id, phase_id: @phase_id)
     @helpdesk_email = helpdesk_email(org: @plan.org)
 
-    I18n.with_locale(email_locale(@plan.owner)) do
+    LocaleService.with_preferred_locale(@plan.owner) do
       mail(to: @plan.owner.email,
            subject: format(_('%{tool_name}: A new comment was added to %{plan_title}'),
                            tool_name: tool_name, plan_title: @plan.title))
@@ -190,7 +190,7 @@ class UserMailer < ActionMailer::Base
     @username  = @user.name
     @helpdesk_email = helpdesk_email(org: @user.org)
 
-    I18n.with_locale(email_locale(@user)) do
+    LocaleService.with_preferred_locale(@user) do
       mail(to: user.email,
            subject: format(_('Administrator privileges updated in %{tool_name}'),
                            tool_name: tool_name))
@@ -210,7 +210,7 @@ class UserMailer < ActionMailer::Base
 
     recipient = User.find_by(email: @api_client.contact_email) || @api_client.org
 
-    I18n.with_locale(email_locale(recipient)) do
+    LocaleService.with_preferred_locale(recipient) do
       mail(to: @api_client.contact_email,
            subject: format(_('%{tool_name} API changes'), tool_name: tool_name))
     end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -37,9 +37,9 @@ class UserMailer < ActionMailer::Base
     @answer_text    = @options_string.to_s
     @helpdesk_email = helpdesk_email(org: @user.org)
 
-    locale = User.find_by(email: data['email'])
+    recipient = User.find_by(email: data['email'])
 
-    I18n.with_locale(email_locale(locale)) do
+    I18n.with_locale(email_locale(recipient)) do
       mail(to: data['email'],
            subject: data['subject'])
     end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -10,7 +10,6 @@ class UserMailer < ActionMailer::Base
 
   default from: Rails.configuration.x.organisation.email
 
-  # rubocop:disable Metrics/AbcSize
   def welcome_notification(user)
     @user           = user
     @username       = @user.name
@@ -20,12 +19,9 @@ class UserMailer < ActionMailer::Base
     @contact_us     = Rails.application.config.x.organisation.contact_us_url || contact_us_url
     @helpdesk_email = helpdesk_email(org: @user.org)
 
-    I18n.with_locale I18n.locale do
-      mail(to: @user.email,
-           subject: format(_('Welcome to %{tool_name}'), tool_name: tool_name))
-    end
+    mail(to: @user.email,
+         subject: "Welcome to DMP Assistant / Bienvenue sur l'Assistant PGD")
   end
-  # rubocop:enable Metrics/AbcSize
 
   # rubocop:disable Metrics/AbcSize
   def question_answered(data, user, answer, _options_string)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -37,7 +37,9 @@ class UserMailer < ActionMailer::Base
     @answer_text    = @options_string.to_s
     @helpdesk_email = helpdesk_email(org: @user.org)
 
-    I18n.with_locale(email_locale(@user)) do
+    recipient = User.find_by(email: data['email'])
+
+    I18n.with_locale(email_locale(recipient)) do
       mail(to: data['email'],
            subject: data['subject'])
     end
@@ -186,7 +188,6 @@ class UserMailer < ActionMailer::Base
 
     @user      = user
     @username  = @user.name
-    @ul_list   = privileges_list(@user)
     @helpdesk_email = helpdesk_email(org: @user.org)
 
     I18n.with_locale(email_locale(@user)) do

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -41,14 +41,14 @@ class UserMailer < ActionMailer::Base
     @answer_text    = @options_string.to_s
     @helpdesk_email = helpdesk_email(org: @user.org)
 
-    I18n.with_locale I18n.locale do
+    I18n.with_locale(email_locale(@user)) do
       mail(to: data['email'],
            subject: data['subject'])
     end
   end
   # rubocop:enable Metrics/AbcSize
 
-  def sharing_notification(role, user, inviter:)
+  def sharing_notification(role, user, inviter:) # rubocop:disable Metrics/AbcSize
     @role       = role
     @user       = user
     @user_email = @user.email
@@ -57,7 +57,7 @@ class UserMailer < ActionMailer::Base
     @link       = url_for(action: 'show', controller: 'plans', id: @role.plan.id)
     @helpdesk_email = helpdesk_email(org: @inviter.org)
 
-    I18n.with_locale I18n.locale do
+    I18n.with_locale(email_locale(@role.user)) do
       mail(to: @role.user.email,
            subject: format(_('A Data Management Plan in %{tool_name} has been shared with you'),
                            tool_name: tool_name))
@@ -74,7 +74,7 @@ class UserMailer < ActionMailer::Base
     @messaging = role_text(@role)
     @helpdesk_email = helpdesk_email(org: @user.org)
 
-    I18n.with_locale I18n.locale do
+    I18n.with_locale(email_locale(@recepient)) do
       mail(to: @recepient.email,
            subject: format(_('Changed permissions on a Data Management Plan in %{tool_name}'),
                            tool_name: tool_name))
@@ -89,7 +89,7 @@ class UserMailer < ActionMailer::Base
     @current_user = current_user
     @helpdesk_email = helpdesk_email(org: @plan.org)
 
-    I18n.with_locale I18n.locale do
+    I18n.with_locale(email_locale(@user)) do
       mail(to: @user.email,
            subject: format(_('Permissions removed on a DMP in %{tool_name}'),
                            tool_name: tool_name))
@@ -107,7 +107,7 @@ class UserMailer < ActionMailer::Base
     @plan_name      = @plan.title
     @helpdesk_email = helpdesk_email(org: @plan.org)
 
-    I18n.with_locale I18n.locale do
+    I18n.with_locale(email_locale(@recipient)) do
       mail(to: @recipient.email,
            subject: format(_('%{user_name} has requested feedback on a %{tool_name} plan'),
                            tool_name: tool_name, user_name: @user.name(false)))
@@ -126,7 +126,7 @@ class UserMailer < ActionMailer::Base
     @plan_name      = @plan.title
     @helpdesk_email = helpdesk_email(org: @plan.org)
 
-    I18n.with_locale I18n.locale do
+    I18n.with_locale(email_locale(recipient)) do
       sender = Rails.configuration.x.organisation.do_not_reply_email ||
                Rails.configuration.x.organisation.email
 
@@ -148,7 +148,7 @@ class UserMailer < ActionMailer::Base
     @plan_visibility = Plan::VISIBILITY_MESSAGE[@plan.visibility.to_sym]
     @helpdesk_email = helpdesk_email(org: @plan.org)
 
-    I18n.with_locale I18n.locale do
+    I18n.with_locale(email_locale(@user)) do
       mail(to: @user.email,
            subject: format(_('DMP Visibility Changed: %{plan_title}'), plan_title: @plan.title))
     end
@@ -177,7 +177,7 @@ class UserMailer < ActionMailer::Base
     @phase_link = url_for(action: 'edit', controller: 'plans', id: @plan.id, phase_id: @phase_id)
     @helpdesk_email = helpdesk_email(org: @plan.org)
 
-    I18n.with_locale I18n.locale do
+    I18n.with_locale(email_locale(@plan.owner)) do
       mail(to: @plan.owner.email,
            subject: format(_('%{tool_name}: A new comment was added to %{plan_title}'),
                            tool_name: tool_name, plan_title: @plan.title))
@@ -193,7 +193,7 @@ class UserMailer < ActionMailer::Base
     @ul_list   = privileges_list(@user)
     @helpdesk_email = helpdesk_email(org: @user.org)
 
-    I18n.with_locale I18n.locale do
+    I18n.with_locale(email_locale(@user)) do
       mail(to: user.email,
            subject: format(_('Administrator privileges updated in %{tool_name}'),
                            tool_name: tool_name))
@@ -211,7 +211,9 @@ class UserMailer < ActionMailer::Base
 
     @helpdesk_email = helpdesk_email(org: @api_client.org)
 
-    I18n.with_locale I18n.locale do
+    recipient = User.find_by(email: @api_client.contact_email) || @api_client.org
+
+    I18n.with_locale(email_locale(recipient)) do
       mail(to: @api_client.contact_email,
            subject: format(_('%{tool_name} API changes'), tool_name: tool_name))
     end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -50,6 +50,8 @@ class UserMailer < ActionMailer::Base
     @role       = role
     @user       = user
     @user_email = @user.email
+    # TODO: Should this be `@user.name(false)`? Currently, @username is just being assigned @user.email
+    # (There are several other user.name calls in UserMailer that should be verified as well)
     @username   = @user.name
     @inviter    = inviter
     @link       = url_for(action: 'show', controller: 'plans', id: @role.plan.id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -421,9 +421,10 @@ class User < ApplicationRecord
 
   # Override devise_invitable email title
   def deliver_invitation(options = {})
-    super(options.merge(subject: "A Data Management Plan in DMP Assistant has been shared with you ' \
-                                          '/ Un plan de gestion des données dans l'Assistant PGD a été partagé ' \
-                                          'avec vous")
+    bilingual_subject = 'A Data Management Plan in DMP Assistant has been shared with you / ' \
+                        "Un plan de gestion des données dans l'Assistant PGD a été partagé avec vous"
+
+    super(options.merge(subject: bilingual_subject)
     )
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -420,7 +420,7 @@ class User < ApplicationRecord
   # rubocop:enable Metrics/AbcSize
 
   # Override devise_invitable email title
- def deliver_invitation(options = {})
+  def deliver_invitation(options = {})
     super(options.merge(subject: format(_('A Data Management Plan in %{application_name} has been shared with you ' \
                                           '/ Un plan de gestion des données dans %{application_name} a été partagé ' \
                                           'avec vous'),

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -420,8 +420,10 @@ class User < ApplicationRecord
   # rubocop:enable Metrics/AbcSize
 
   # Override devise_invitable email title
-  def deliver_invitation(options = {})
-    super(options.merge(subject: format(_('A Data Management Plan in %{application_name} has been shared with you'),
+ def deliver_invitation(options = {})
+    super(options.merge(subject: format(_('A Data Management Plan in %{application_name} has been shared with you ' \
+                                          '/ Un plan de gestion des données dans %{application_name} a été partagé ' \
+                                          'avec vous'),
                                         application_name: ApplicationService.application_name))
     )
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -421,10 +421,9 @@ class User < ApplicationRecord
 
   # Override devise_invitable email title
   def deliver_invitation(options = {})
-    super(options.merge(subject: format(_('A Data Management Plan in %{application_name} has been shared with you ' \
-                                          '/ Un plan de gestion des données dans %{application_name} a été partagé ' \
-                                          'avec vous'),
-                                        application_name: ApplicationService.application_name))
+    super(options.merge(subject: "A Data Management Plan in DMP Assistant has been shared with you ' \
+                                          '/ Un plan de gestion des données dans l'Assistant PGD a été partagé ' \
+                                          'avec vous")
     )
   end
 

--- a/app/services/locale_service.rb
+++ b/app/services/locale_service.rb
@@ -33,6 +33,14 @@ class LocaleService
       convert(string: locale, join_char: join_char)
     end
 
+    # Localizes the given block to the recipient's preferred locale.
+    # recipient may be an instance of User or Org (is able to respond to language&.abbreviation)
+    def with_preferred_locale(recipient, &)
+      # Fallback to the current locale, if necessary
+      locale = recipient&.language&.abbreviation || I18n.locale
+      I18n.with_locale(locale, &)
+    end
+
     # Returns an array of string elements
     # The elements are all of the available translations of `text` across all available locales
     def translations_for_all_locales(text)

--- a/app/services/locale_service.rb
+++ b/app/services/locale_service.rb
@@ -41,6 +41,14 @@ class LocaleService
       I18n.with_locale(locale, &)
     end
 
+    # Iterates over each available locale, switching to that locale,
+    # and yields the locale to the given block for translation and processing.
+    def with_each_available_locale
+      I18n.available_locales.each do |locale|
+        I18n.with_locale(locale) { yield(locale) }
+      end
+    end
+
     # Returns an array of string elements
     # The elements are all of the available translations of `text` across all available locales
     def translations_for_all_locales(text)

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,7 +1,12 @@
-<% I18n.with_locale I18n.locale do %>
-	<p><%= _("Welcome to %{application_name}") % {application_name: ApplicationService.application_name} %>, <%= @email %>!</p>
+<% I18n.available_locales.each do |locale| %>
+	<% I18n.with_locale(locale) do %>
+		<p><%= _("Welcome to %{application_name}") % {application_name: _(ApplicationService.application_name) } %>, <%= @email %>!</p>
 
-	<p><%= _("Please confirm your email address") %>:</p>
+		<p><%= _("Please confirm your email address") %>:</p>
 
-	<p><%= link_to _("Click here to confirm your account"),  confirmation_url(@resource, :confirmation_token => @token) %> (<%= _("or copy") %> <%= confirmation_url(@resource, :confirmation_token => @token) %> <%= _("into your browser") %>).</p>
+		<p><%= link_to _("Click here to confirm your account"),  confirmation_url(@resource, :confirmation_token => @token) %> (<%= _("or copy") %> <%= confirmation_url(@resource, :confirmation_token => @token) %> <%= _("into your browser") %>).</p>
+		<% unless locale == I18n.available_locales.last %>
+      		<hr>
+    	<% end %>
+	<% end %>
 <% end %>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,12 +1,10 @@
-<% I18n.available_locales.each do |locale| %>
-	<% I18n.with_locale(locale) do %>
-		<p><%= _("Welcome to %{application_name}") % {application_name: _(ApplicationService.application_name) } %>, <%= @email %>!</p>
+<% LocaleService.with_each_available_locale do |locale| %>
+	<p><%= _("Welcome to %{application_name}") % {application_name: _(ApplicationService.application_name) } %>, <%= @email %>!</p>
 
-		<p><%= _("Please confirm your email address") %>:</p>
+	<p><%= _("Please confirm your email address") %>:</p>
 
-		<p><%= link_to _("Click here to confirm your account"),  confirmation_url(@resource, :confirmation_token => @token) %> (<%= _("or copy") %> <%= confirmation_url(@resource, :confirmation_token => @token) %> <%= _("into your browser") %>).</p>
-		<% unless locale == I18n.available_locales.last %>
-      		<hr>
-    	<% end %>
+	<p><%= link_to _("Click here to confirm your account"),  confirmation_url(@resource, :confirmation_token => @token) %> (<%= _("or copy") %> <%= confirmation_url(@resource, :confirmation_token => @token) %> <%= _("into your browser") %>).</p>
+	<% unless locale == I18n.available_locales.last %>
+		<hr>
 	<% end %>
 <% end %>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,10 +1,11 @@
+<% last_locale = I18n.available_locales.last %>
+
 <% LocaleService.with_each_available_locale do |locale| %>
 	<p><%= _("Welcome to %{application_name}") % {application_name: _(ApplicationService.application_name) } %>, <%= @email %>!</p>
 
 	<p><%= _("Please confirm your email address") %>:</p>
 
 	<p><%= link_to _("Click here to confirm your account"),  confirmation_url(@resource, :confirmation_token => @token) %> (<%= _("or copy") %> <%= confirmation_url(@resource, :confirmation_token => @token) %> <%= _("into your browser") %>).</p>
-	<% unless locale == I18n.available_locales.last %>
-		<hr>
-	<% end %>
+
+	<% concat(tag.hr) unless locale == last_locale %>
 <% end %>

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -1,45 +1,54 @@
 <%
-  tool_name = ApplicationService.application_name
   link = accept_invitation_url(@resource, :invitation_token => @token)
   contact_us = (Rails.configuration.x.organisation.contact_us_url || contact_us_url)
-  email_subject = _('Query or feedback related to %{tool_name}') %{ :tool_name => tool_name }
   user_name = User.find_by(email: @resource.email).nil? ?  @resource.email : User.find_by(email: @resource.email).name(false)
   inviter =  @resource.invited_by
   inviter_name = inviter.name
   helpdesk_email = inviter.org&.helpdesk_email ||
                    Rails.configuration.x.organisation.helpdesk_email
 %>
-<% I18n.with_locale I18n.locale do %>
-<p>
+
+<% I18n.available_locales.each do |locale| %>
+  <% I18n.with_locale(locale) do %>
+    <%
+      tool_name = _(ApplicationService.application_name)
+      email_subject = _('Query or feedback related to %{tool_name}') %{ :tool_name => tool_name }
+    %>
+    <p>
 
 
-</p>
-  <p>
-    <%= _("Hello %{user_name}") %{ :user_name => user_name } %>
-  </p>
-  <p>
-    <%= _("Your colleague %{inviter_name} has invited you to contribute to "\
-            " their Data Management Plan in %{tool_name}") % {
-      tool_name: tool_name,
-      inviter_name: inviter_name
-    } %>
-  </p>
-  <p>
-    <%= sanitize(_('%{click_here} to accept the invitation, (or copy %{link} into your browser). If you don\'t want to accept the invitation, please ignore this email.') % {
-      click_here: link_to(_('Click here'), link), link: link
-    }) %>
-  </p>
-  <p>
-    <%= _('All the best') %>
-    <br />
-    <%= _('The %{tool_name} team') %{:tool_name => tool_name} %>
-  </p>
-  <p>
-    <%= _('Please do not reply to this email.') %>&nbsp;
-    <%= sanitize(_('If you have any questions or need help, please contact us at %{helpdesk_email} or visit %{contact_us_url}') % {
-      helpdesk_email: mail_to(helpdesk_email, helpdesk_email,
-      subject: email_subject),
-      contact_us_url: link_to(contact_us, contact_us)
-    }) %>
-  </p>
+    </p>
+      <p>
+        <%= _("Hello %{user_name}") %{ :user_name => user_name } %>
+      </p>
+      <p>
+        <%= _("Your colleague %{inviter_name} has invited you to contribute to "\
+                " their Data Management Plan in %{tool_name}") % {
+          tool_name: tool_name,
+          inviter_name: inviter_name
+        } %>
+      </p>
+      <p>
+        <%= sanitize(_('%{click_here} to accept the invitation, (or copy %{link} into your browser). If you don\'t want to accept the invitation, please ignore this email.') % {
+          click_here: link_to(_('Click here'), link), link: link
+        }) %>
+      </p>
+      <p>
+        <%= _('All the best') %>
+        <br />
+        <%= _('The %{tool_name} team') %{:tool_name => tool_name} %>
+      </p>
+      <p>
+        <%= _('Please do not reply to this email.') %>&nbsp;
+        <%= sanitize(_('If you have any questions or need help, please contact us at %{helpdesk_email} or visit %{contact_us_url}') % {
+          helpdesk_email: mail_to(helpdesk_email, helpdesk_email,
+          subject: email_subject),
+          contact_us_url: link_to(contact_us, contact_us)
+        }) %>
+      </p>
+
+    <% unless locale == I18n.available_locales.last %>
+      <hr>
+    <% end %>
+  <% end %>
 <% end %>

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -6,6 +6,7 @@
   inviter_name = inviter.name
   helpdesk_email = inviter.org&.helpdesk_email ||
                    Rails.configuration.x.organisation.helpdesk_email
+  last_locale = I18n.available_locales.last
 %>
 
 <% LocaleService.with_each_available_locale do |locale| %>
@@ -46,7 +47,5 @@
       }) %>
     </p>
 
-  <% unless locale == I18n.available_locales.last %>
-    <hr>
-  <% end %>
+  <% concat(tag.hr) unless locale == last_locale %>
 <% end %>

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -8,47 +8,45 @@
                    Rails.configuration.x.organisation.helpdesk_email
 %>
 
-<% I18n.available_locales.each do |locale| %>
-  <% I18n.with_locale(locale) do %>
-    <%
-      tool_name = _(ApplicationService.application_name)
-      email_subject = _('Query or feedback related to %{tool_name}') %{ :tool_name => tool_name }
-    %>
+<% LocaleService.with_each_available_locale do |locale| %>
+  <%
+    tool_name = _(ApplicationService.application_name)
+    email_subject = _('Query or feedback related to %{tool_name}') %{ :tool_name => tool_name }
+  %>
+  <p>
+
+
+  </p>
     <p>
-
-
+      <%= _("Hello %{user_name}") %{ :user_name => user_name } %>
     </p>
-      <p>
-        <%= _("Hello %{user_name}") %{ :user_name => user_name } %>
-      </p>
-      <p>
-        <%= _("Your colleague %{inviter_name} has invited you to contribute to "\
-                " their Data Management Plan in %{tool_name}") % {
-          tool_name: tool_name,
-          inviter_name: inviter_name
-        } %>
-      </p>
-      <p>
-        <%= sanitize(_('%{click_here} to accept the invitation, (or copy %{link} into your browser). If you don\'t want to accept the invitation, please ignore this email.') % {
-          click_here: link_to(_('Click here'), link), link: link
-        }) %>
-      </p>
-      <p>
-        <%= _('All the best') %>
-        <br />
-        <%= _('The %{tool_name} team') %{:tool_name => tool_name} %>
-      </p>
-      <p>
-        <%= _('Please do not reply to this email.') %>&nbsp;
-        <%= sanitize(_('If you have any questions or need help, please contact us at %{helpdesk_email} or visit %{contact_us_url}') % {
-          helpdesk_email: mail_to(helpdesk_email, helpdesk_email,
-          subject: email_subject),
-          contact_us_url: link_to(contact_us, contact_us)
-        }) %>
-      </p>
+    <p>
+      <%= _("Your colleague %{inviter_name} has invited you to contribute to "\
+              " their Data Management Plan in %{tool_name}") % {
+        tool_name: tool_name,
+        inviter_name: inviter_name
+      } %>
+    </p>
+    <p>
+      <%= sanitize(_('%{click_here} to accept the invitation, (or copy %{link} into your browser). If you don\'t want to accept the invitation, please ignore this email.') % {
+        click_here: link_to(_('Click here'), link), link: link
+      }) %>
+    </p>
+    <p>
+      <%= _('All the best') %>
+      <br />
+      <%= _('The %{tool_name} team') %{:tool_name => tool_name} %>
+    </p>
+    <p>
+      <%= _('Please do not reply to this email.') %>&nbsp;
+      <%= sanitize(_('If you have any questions or need help, please contact us at %{helpdesk_email} or visit %{contact_us_url}') % {
+        helpdesk_email: mail_to(helpdesk_email, helpdesk_email,
+        subject: email_subject),
+        contact_us_url: link_to(contact_us, contact_us)
+      }) %>
+    </p>
 
-    <% unless locale == I18n.available_locales.last %>
-      <hr>
-    <% end %>
+  <% unless locale == I18n.available_locales.last %>
+    <hr>
   <% end %>
 <% end %>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,13 +1,15 @@
 <%
-  tool_name = ApplicationService.application_name
   helpdesk_email = Rails.configuration.x.organisation.helpdesk_email
   contact_us = Rails.configuration.x.organisation.contact_us_url || contact_us_url
-  email_subject = _('Query or feedback related to %{tool_name}') %{ :tool_name => tool_name }
   user = User.find_by(email: @resource.email)
   helpdesk_email = user.org&.helpdesk_email ||
                    Rails.configuration.x.organisation.helpdesk_email
 %>
-<% I18n.with_locale I18n.locale do %>
+<% I18n.with_locale(user.language&.abbreviation || I18n.locale) do %>
+  <%
+    tool_name = _(ApplicationService.application_name)
+    email_subject = _('Query or feedback related to %{tool_name}') %{ :tool_name => tool_name }
+  %>
   <p>
     <%= _('Hello %{user_email}') %{ :user_email => @resource.email } %>
   </p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -5,7 +5,7 @@
   helpdesk_email = user.org&.helpdesk_email ||
                    Rails.configuration.x.organisation.helpdesk_email
 %>
-<% I18n.with_locale(user.language&.abbreviation || I18n.locale) do %>
+<% LocaleService.with_preferred_locale(user) do %>
   <%
     tool_name = _(ApplicationService.application_name)
     email_subject = _('Query or feedback related to %{tool_name}') %{ :tool_name => tool_name }

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,26 +1,23 @@
 <%
+  tool_name = _(ApplicationService.application_name)
   helpdesk_email = Rails.configuration.x.organisation.helpdesk_email
   contact_us = Rails.configuration.x.organisation.contact_us_url || contact_us_url
+  email_subject = _('Query or feedback related to %{tool_name}') %{ :tool_name => tool_name }
   user = User.find_by(email: @resource.email)
   helpdesk_email = user.org&.helpdesk_email ||
                    Rails.configuration.x.organisation.helpdesk_email
-%>
-<% LocaleService.with_preferred_locale(user) do %>
-  <%
-    tool_name = _(ApplicationService.application_name)
-    email_subject = _('Query or feedback related to %{tool_name}') %{ :tool_name => tool_name }
   %>
-  <p>
-    <%= _('Hello %{user_email}') %{ :user_email => @resource.email } %>
-  </p>
-  <p>
-    <%= _('Someone has requested a link to change your %{tool_name} password. You can do this through the link below.') %{ :tool_name => tool_name } %>
-  </p>
-  <p><%= link_to _('Change my password'), edit_password_url(@resource, :reset_password_token => @token) %></p>
-  <p><%= _("If you didn't request this, please ignore this email.") %></p>
-  <p>
-    <%= _('All the best') %>
-    <br />
-    <%= _('The %{tool_name} team') %{:tool_name => tool_name} %>
-  </p>
-<% end %>
+
+<p>
+  <%= _('Hello %{user_email}') %{ :user_email => @resource.email } %>
+</p>
+<p>
+  <%= _('Someone has requested a link to change your %{tool_name} password. You can do this through the link below.') %{ :tool_name => tool_name } %>
+</p>
+<p><%= link_to _('Change my password'), edit_password_url(@resource, :reset_password_token => @token) %></p>
+<p><%= _("If you didn't request this, please ignore this email.") %></p>
+<p>
+  <%= _('All the best') %>
+  <br />
+  <%= _('The %{tool_name} team') %{:tool_name => tool_name} %>
+</p>

--- a/app/views/user_mailer/admin_privileges.html.erb
+++ b/app/views/user_mailer/admin_privileges.html.erb
@@ -6,7 +6,7 @@
     <%= _('You have been granted administrator privileges in %{tool_name}:') %{ tool_name: tool_name } %>
   </p>
   <p>
-    <%= sanitize(@ul_list) %>
+    <%= sanitize(privileges_list(@user)) %>
   </p>
 <% else %>
   <p>

--- a/app/views/user_mailer/sharing_notification.html.erb
+++ b/app/views/user_mailer/sharing_notification.html.erb
@@ -2,10 +2,8 @@
   <%= _('Hello %{username}') %{ username: @username } %>
 </p>
 <p>
-  <%= _("Your colleague %{inviter_name} has invited you to contribute to
-          their Data Management Plan in %{tool_name}") % {
-            inviter_name: @inviter.name(false), tool_name: tool_name
-            } %>
+  <%= _("Your colleague %{inviter_name} has invited you to contribute to their Data Management Plan in %{tool_name}") % {
+        inviter_name: @inviter.name(false), tool_name: tool_name } %>
 </p>
 <p>
   <%= sanitize(_('%{click_here} to accept the invitation, (or copy %{link} into your browser). If you don\'t want to accept the invitation, please ignore this email.') % { 

--- a/app/views/user_mailer/welcome_notification.html.erb
+++ b/app/views/user_mailer/welcome_notification.html.erb
@@ -1,3 +1,5 @@
+<% last_locale = I18n.available_locales.last %>
+
 <% LocaleService.with_each_available_locale do |locale| %>
   <% @email_subject  = format(_('Query or feedback related to %{tool_name}'), tool_name: _(tool_name)) %>
   <p>
@@ -14,7 +16,6 @@
   <p>
     <%= _('You may change your notification preferences on your profile page.') %>&nbsp;<%= _('Please do not reply to this email.') %>
   </p>
-    <% unless locale == I18n.available_locales.last %>
-        <hr>
-    <% end %>
+
+  <% concat(tag.hr) unless locale == last_locale %>
 <% end %>

--- a/app/views/user_mailer/welcome_notification.html.erb
+++ b/app/views/user_mailer/welcome_notification.html.erb
@@ -1,22 +1,20 @@
-<% I18n.available_locales.each do |locale| %>
-	<% I18n.with_locale(locale) do %>
-    <% @email_subject  = format(_('Query or feedback related to %{tool_name}'), tool_name: _(tool_name)) %>
-    <p>
-      <%= _('Welcome to %{tool_name}, %{username}') %{ tool_name: _(tool_name), username: @username } %>
-    </p>
-    <p>
-      <%= sanitize(_('%{tool_name} will help you to develop your Data Management Plan. If you have any queries or feedback as you use the tool, please contact us at %{helpdesk_email} or visit %{contact_us}') %{ tool_name: _(tool_name), helpdesk_email: mail_to( helpdesk_email, helpdesk_email, subject: @email_subject), contact_us: link_to(@contact_us, @contact_us) }) %>
-    </p>
-    <p>
-      <%= _('All the best') %>
-      <br />
-      <%= _('The %{tool_name} team') %{ tool_name: _(tool_name) } %>
-    </p>
-    <p>
-      <%= _('You may change your notification preferences on your profile page.') %>&nbsp;<%= _('Please do not reply to this email.') %>
-    </p>
-      <% unless locale == I18n.available_locales.last %>
-          <hr>
-      <% end %>
-  <% end %>
+<% LocaleService.with_each_available_locale do |locale| %>
+  <% @email_subject  = format(_('Query or feedback related to %{tool_name}'), tool_name: _(tool_name)) %>
+  <p>
+    <%= _('Welcome to %{tool_name}, %{username}') %{ tool_name: _(tool_name), username: @username } %>
+  </p>
+  <p>
+    <%= sanitize(_('%{tool_name} will help you to develop your Data Management Plan. If you have any queries or feedback as you use the tool, please contact us at %{helpdesk_email} or visit %{contact_us}') %{ tool_name: _(tool_name), helpdesk_email: mail_to( helpdesk_email, helpdesk_email, subject: @email_subject), contact_us: link_to(@contact_us, @contact_us) }) %>
+  </p>
+  <p>
+    <%= _('All the best') %>
+    <br />
+    <%= _('The %{tool_name} team') %{ tool_name: _(tool_name) } %>
+  </p>
+  <p>
+    <%= _('You may change your notification preferences on your profile page.') %>&nbsp;<%= _('Please do not reply to this email.') %>
+  </p>
+    <% unless locale == I18n.available_locales.last %>
+        <hr>
+    <% end %>
 <% end %>

--- a/app/views/user_mailer/welcome_notification.html.erb
+++ b/app/views/user_mailer/welcome_notification.html.erb
@@ -1,14 +1,22 @@
-<p>
-  <%= _('Welcome to %{tool_name}, %{username}') %{ tool_name: tool_name, username: @username } %>
-</p>
-<p>
-  <%= sanitize(_('%{tool_name} will help you to develop your Data Management Plan. If you have any queries or feedback as you use the tool, please contact us at %{helpdesk_email} or visit %{contact_us}') %{ tool_name: tool_name, helpdesk_email: mail_to( helpdesk_email, helpdesk_email, subject: @email_subject), contact_us: link_to(@contact_us, @contact_us) }) %>
-</p>
-<p>
-  <%= _('All the best') %>
-  <br />
-  <%= _('The %{tool_name} team') %{ tool_name: tool_name} %>
-</p>
-<p>
-  <%= _('You may change your notification preferences on your profile page.') %>&nbsp;<%= _('Please do not reply to this email.') %>
-</p>
+<% I18n.available_locales.each do |locale| %>
+	<% I18n.with_locale(locale) do %>
+    <% @email_subject  = format(_('Query or feedback related to %{tool_name}'), tool_name: _(tool_name)) %>
+    <p>
+      <%= _('Welcome to %{tool_name}, %{username}') %{ tool_name: _(tool_name), username: @username } %>
+    </p>
+    <p>
+      <%= sanitize(_('%{tool_name} will help you to develop your Data Management Plan. If you have any queries or feedback as you use the tool, please contact us at %{helpdesk_email} or visit %{contact_us}') %{ tool_name: _(tool_name), helpdesk_email: mail_to( helpdesk_email, helpdesk_email, subject: @email_subject), contact_us: link_to(@contact_us, @contact_us) }) %>
+    </p>
+    <p>
+      <%= _('All the best') %>
+      <br />
+      <%= _('The %{tool_name} team') %{ tool_name: _(tool_name) } %>
+    </p>
+    <p>
+      <%= _('You may change your notification preferences on your profile page.') %>&nbsp;<%= _('Please do not reply to this email.') %>
+    </p>
+      <% unless locale == I18n.available_locales.last %>
+          <hr>
+      <% end %>
+  <% end %>
+<% end %>

--- a/config/locales/translation.en-CA.yml
+++ b/config/locales/translation.en-CA.yml
@@ -234,7 +234,7 @@ en-CA:
       invited: You have a pending invitation, accept it to finish creating your account.
     mailer:
       confirmation_instructions:
-        subject: Confirm your DMP Assistant account
+        subject: Confirm your DMP Assistant account / Validez votre compte Assistant PGD
       reset_password_instructions:
         subject: Reset password instructions
       unlock_instructions:

--- a/config/locales/translation.en-CA.yml
+++ b/config/locales/translation.en-CA.yml
@@ -234,7 +234,8 @@ en-CA:
       invited: You have a pending invitation, accept it to finish creating your account.
     mailer:
       confirmation_instructions:
-        subject: Confirm your DMP Assistant account / Validez votre compte Assistant PGD
+        subject: Confirm your DMP Assistant account / Validez votre compte l'Assistant
+          PGD
       reset_password_instructions:
         subject: Reset password instructions
       unlock_instructions:

--- a/config/locales/translation.fr-CA.yml
+++ b/config/locales/translation.fr-CA.yml
@@ -247,7 +247,7 @@ fr-CA:
         de votre compte.
     mailer:
       confirmation_instructions:
-        subject: Validez votre compte Assistant PGD
+        subject: Confirm your DMP Assistant account / Validez votre compte Assistant PGD
       reset_password_instructions:
         subject: Directives pour réinitialiser le mot de passe
       unlock_instructions:

--- a/config/locales/translation.fr-CA.yml
+++ b/config/locales/translation.fr-CA.yml
@@ -247,7 +247,8 @@ fr-CA:
         de votre compte.
     mailer:
       confirmation_instructions:
-        subject: Confirm your DMP Assistant account / Validez votre compte Assistant PGD
+        subject: Confirm your DMP Assistant account / Validez votre compte l'Assistant
+          PGD
       reset_password_instructions:
         subject: Directives pour réinitialiser le mot de passe
       unlock_instructions:

--- a/spec/mailers/user_invitation_mailer_spec.rb
+++ b/spec/mailers/user_invitation_mailer_spec.rb
@@ -6,26 +6,46 @@ require 'rails_helper'
 RSpec.describe 'User invitation email', type: :mailer do
   describe 'Invitation Email to User Not in DB' do
     let(:inviter) { create(:user) }
-    let(:invitee) { User.new(email: 'newuser@example.com') }
+    let(:invitee_email) { 'newuser@example.com' }
+    # For ensuring I18n.locale value remains intact.
+    let(:original_locale) { I18n.locale }
 
     before do
       ActionMailer::Base.deliveries.clear
+      # TODO: Update spec/support/locales.rb to actually use DMP Assistant's locales.
+      @original_locales = I18n.available_locales
+      I18n.available_locales = %i[en-CA fr-CA]
     end
 
-    it 'sends an invitation email with a bilingual subject' do
-      # Simulate Devise invitation context
-      invitee.invitation_token = Devise.friendly_token
-      invitee.invited_by = inviter
-      invitee.invited_by_type = 'User'
+    after do
+      I18n.available_locales = @original_locales
+    end
 
-      # Trigger mailer directly
-      # deliver_invitation overrides devise_invitable
-      invitee.deliver_invitation
-
+    it 'sends an invitation with the expected content' do
+      invite_new_user
       mail = ActionMailer::Base.deliveries.last
-      expect(mail.to).to include('newuser@example.com')
-      expect(mail.subject).to include('A Data Management Plan in DMP Assistant has been shared with you')
-      expect(mail.subject).to include("Un plan de gestion des données dans l'Assistant PGD a été partagé avec vous")
+      expect(mail.to).to include(invitee_email)
+      # The subject line is bilingual
+      expect(mail.subject).to eq('A Data Management Plan in DMP Assistant has been shared with you / ' \
+                                 "Un plan de gestion des données dans l'Assistant PGD a été partagé avec vous")
+      # The body is bilingual
+      # (TODO: Fix this generic name greeting)
+      expect(mail.body).to include('Hello First Name Surname')
+      expect(mail.body).to include('Bonjour First Name Surname')
+      # I18n.locale value remains intact
+      expect(I18n.locale).to eq(original_locale)
     end
+  end
+
+  private
+
+  def invite_new_user
+    # This code is copied from RolesController#create to simulate its User.invite! behavior.
+    # The controller action is large, so copying the code here is a pragmatic testing approach
+    User.invite!({ email: invitee_email,
+                   firstname: _('First Name'),
+                   surname: _('Surname'),
+                   org: inviter.org },
+                 inviter)
   end
 end

--- a/spec/mailers/user_invitation_mailer_spec.rb
+++ b/spec/mailers/user_invitation_mailer_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# spec/mailers/user_invitation_mailer_spec.rb
+require 'rails_helper'
+
+RSpec.describe 'User invitation email', type: :mailer do
+  describe 'Invitation Email to User Not in DB' do
+    let(:inviter) { create(:user) }
+    let(:invitee) { User.new(email: 'newuser@example.com') }
+
+    before do
+      ActionMailer::Base.deliveries.clear
+    end
+
+    it 'sends an invitation email with a bilingual subject' do
+      # Simulate Devise invitation context
+      invitee.invitation_token = Devise.friendly_token
+      invitee.invited_by = inviter
+      invitee.invited_by_type = 'User'
+
+      # Trigger mailer directly
+      # deliver_invitation overrides devise_invitable
+      invitee.deliver_invitation
+
+      mail = ActionMailer::Base.deliveries.last
+      expect(mail.to).to include('newuser@example.com')
+      expect(mail.subject).to include('A Data Management Plan in DMP Assistant has been shared with you')
+      expect(mail.subject).to include("Un plan de gestion des données dans l'Assistant PGD a été partagé avec vous")
+    end
+  end
+end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -5,7 +5,7 @@
 require 'rails_helper'
 
 RSpec.describe UserMailer, type: :mailer do
-  describe 'UserMailer methods' do
+  describe 'UserMailer Welcome Email' do
     let(:user) { create(:user) }
 
     context '.welcome_notification email contents' do
@@ -14,6 +14,80 @@ RSpec.describe UserMailer, type: :mailer do
       it 'renders the correct email subject' do
         expect(mail.subject).to eq("Welcome to DMP Assistant / Bienvenue sur l'Assistant PGD")
       end
+    end
+  end
+
+  describe 'UserMailer Sharing Email' do
+    let!(:org) { create(:org, :organisation, name: 'Test org') }
+    let!(:inviter) { create(:user, org: org) }
+
+    context 'when the user language is set to English' do
+      before do
+        @original_locale = I18n.locale
+        I18n.locale = :'en-CA'
+      end
+
+      after do
+        I18n.locale = @original_locale
+      end
+
+      let!(:user) { create(:user, language: create(:language, abbreviation: 'en-CA'), org: org) }
+      let!(:plan) { create(:plan, org: org, visibility: 'publicly_visible') }
+      let!(:role) { create(:role, :creator, :active, plan: plan, user: user) }
+
+      let!(:mail) { UserMailer.sharing_notification(role, user, inviter: inviter) }
+
+      it 'renders the email subject in English' do
+        Rails.configuration.x.application.name = 'Foo'
+        expect(mail.subject).to include('A Data Management Plan in Foo has been shared with you')
+      end
+    end
+
+    context 'when the user language is set to French' do
+      before do
+        @original_locale = I18n.locale
+        I18n.locale = :'fr-CA'
+      end
+
+      after do
+        I18n.locale = @original_locale
+      end
+
+      let!(:user) { create(:user, language: create(:language, abbreviation: 'fr-CA'), org: org) }
+      let!(:plan) { create(:plan, org: org, visibility: 'publicly_visible') }
+      let!(:role) { create(:role, :creator, :active, plan: plan, user: user) }
+
+      let!(:mail) { UserMailer.sharing_notification(role, user, inviter: inviter) }
+
+      it 'renders the email subject in French' do
+        Rails.configuration.x.application.name = 'Bar'
+        expect(mail.subject).to include('Un plan de gestion des données dans Bar a été partagé avec vous')
+      end
+    end
+  end
+
+  describe 'Invitation Email to User Not in DB' do
+    let(:inviter) { create(:user) }
+    let(:invitee) { User.new(email: 'newuser@example.com') }
+
+    before do
+      ActionMailer::Base.deliveries.clear
+    end
+
+    it 'sends an invitation email with a bilingual subject' do
+      # Simulate Devise invitation context
+      invitee.invitation_token = Devise.friendly_token
+      invitee.invited_by = inviter
+      invitee.invited_by_type = 'User'
+
+      # Trigger mailer directly
+      # deliver_invitation overrides devise_invitable
+      invitee.deliver_invitation
+
+      mail = ActionMailer::Base.deliveries.last
+      expect(mail.to).to include('newuser@example.com')
+      expect(mail.subject).to include('A Data Management Plan in DMP Assistant has been shared with you')
+      expect(mail.subject).to include("Un plan de gestion des données dans l'Assistant PGD a été partagé avec vous")
     end
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,4 +1,3 @@
-#
 # frozen_string_literal: true
 
 # spec/mailers/user_mailer_spec.rb
@@ -63,31 +62,6 @@ RSpec.describe UserMailer, type: :mailer do
         Rails.configuration.x.application.name = 'Bar'
         expect(mail.subject).to include('Un plan de gestion des données dans Bar a été partagé avec vous')
       end
-    end
-  end
-
-  describe 'Invitation Email to User Not in DB' do
-    let(:inviter) { create(:user) }
-    let(:invitee) { User.new(email: 'newuser@example.com') }
-
-    before do
-      ActionMailer::Base.deliveries.clear
-    end
-
-    it 'sends an invitation email with a bilingual subject' do
-      # Simulate Devise invitation context
-      invitee.invitation_token = Devise.friendly_token
-      invitee.invited_by = inviter
-      invitee.invited_by_type = 'User'
-
-      # Trigger mailer directly
-      # deliver_invitation overrides devise_invitable
-      invitee.deliver_invitation
-
-      mail = ActionMailer::Base.deliveries.last
-      expect(mail.to).to include('newuser@example.com')
-      expect(mail.subject).to include('A Data Management Plan in DMP Assistant has been shared with you')
-      expect(mail.subject).to include("Un plan de gestion des données dans l'Assistant PGD a été partagé avec vous")
     end
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -4,64 +4,76 @@
 require 'rails_helper'
 
 RSpec.describe UserMailer, type: :mailer do
+  # For ensuring I18n.locale value remains intact.
+  let(:original_locale) { I18n.locale }
+
+  before(:all) do
+    # TODO: Update spec/support/locales.rb to actually use DMP Assistant's locales.
+    @original_locales = I18n.available_locales
+    I18n.available_locales = %i[en-CA fr-CA]
+  end
+
+  after(:all) do
+    I18n.available_locales = @original_locales
+  end
+
   describe 'UserMailer Welcome Email' do
     let(:user) { create(:user) }
 
     context '.welcome_notification email contents' do
       let(:mail) { UserMailer.welcome_notification(user) }
 
-      it 'renders the correct email subject' do
+      it 'Renders the bilingual welcome message as expected' do
+        expect(mail.to).to include(user.email)
+        # Email subject is bilingual
         expect(mail.subject).to eq("Welcome to DMP Assistant / Bienvenue sur l'Assistant PGD")
+        # Email body has both English and French sections
+        expect(mail.body).to include('Welcome to DMP Assistant')
+        # Use Nokogiri to escape HTML (')
+        html = Nokogiri::HTML(mail.body.to_s)
+        expect(html.text).to include("Bienvenue sur l'Assistant PGD")
+        # I18n.locale value remains intact
+        expect(I18n.locale).to eq(original_locale)
       end
     end
   end
 
   describe 'UserMailer Sharing Email' do
-    let!(:org) { create(:org, :organisation, name: 'Test org') }
+    let!(:org)     { create(:org, :organisation, name: 'Test org') }
     let!(:inviter) { create(:user, org: org) }
 
-    context 'when the user language is set to English' do
-      before do
-        @original_locale = I18n.locale
-        I18n.locale = :'en-CA'
-      end
-
-      after do
-        I18n.locale = @original_locale
-      end
-
-      let!(:user) { create(:user, language: create(:language, abbreviation: 'en-CA'), org: org) }
-      let!(:plan) { create(:plan, org: org, visibility: 'publicly_visible') }
+    shared_examples 'localized .sharing_notification email' do |expected_subject, expected_body|
+      # :role and :mail depend on :user and :plan, so define them here
       let!(:role) { create(:role, :creator, :active, plan: plan, user: user) }
+      let(:mail)  { UserMailer.sharing_notification(role, user, inviter: inviter) }
 
-      let!(:mail) { UserMailer.sharing_notification(role, user, inviter: inviter) }
-
-      it 'renders the email subject in English' do
-        Rails.configuration.x.application.name = 'Foo'
-        expect(mail.subject).to include('A Data Management Plan in Foo has been shared with you')
+      it 'renders the expected email content' do
+        expect(mail.to).to include(user.email)
+        expect(mail.subject).to eq(expected_subject)
+        expect(mail.body).to include(expected_body)
+        # localized email has not changed I18n.locale
+        expect(I18n.locale).to eq(original_locale)
       end
     end
 
-    context 'when the user language is set to French' do
-      before do
-        @original_locale = I18n.locale
-        I18n.locale = :'fr-CA'
-      end
+    let!(:plan) { create(:plan, org: org, visibility: 'publicly_visible') }
 
-      after do
-        I18n.locale = @original_locale
-      end
+    context 'en-CA locale' do
+      let!(:language) { create(:language, abbreviation: 'en-CA') }
+      let!(:user)     { create(:user, language: language, org: org) }
 
-      let!(:user) { create(:user, language: create(:language, abbreviation: 'fr-CA'), org: org) }
-      let!(:plan) { create(:plan, org: org, visibility: 'publicly_visible') }
-      let!(:role) { create(:role, :creator, :active, plan: plan, user: user) }
+      include_examples 'localized .sharing_notification email',
+                       'A Data Management Plan in DMP Assistant has been shared with you',
+                       'has invited you to contribute'
+    end
 
-      let!(:mail) { UserMailer.sharing_notification(role, user, inviter: inviter) }
+    context 'fr-CA locale' do
+      let!(:language) { create(:language, abbreviation: 'fr-CA') }
+      let!(:user)     { create(:user, language: language, org: org) }
 
-      it 'renders the email subject in French' do
-        Rails.configuration.x.application.name = 'Bar'
-        expect(mail.subject).to include('Un plan de gestion des données dans Bar a été partagé avec vous')
-      end
+      include_examples 'localized .sharing_notification email',
+                       'Un plan de gestion des données dans Assistant PGD a été partagé avec vous',
+                       'Si vous ne souhaitez pas accepter l’invitation'
     end
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -5,42 +5,14 @@
 require 'rails_helper'
 
 RSpec.describe UserMailer, type: :mailer do
-  describe 'my_email' do
-    let(:user) { User.create(email: Faker::Internet.email) }
+  describe 'UserMailer methods' do
+    let(:user) { create(:user) }
 
-    context 'when the user language is set to English' do
-      before do
-        @original_locale = I18n.locale
-        I18n.locale = :'en-CA'
-      end
-
-      after do
-        I18n.locale = @original_locale
-      end
-
+    context '.welcome_notification email contents' do
       let(:mail) { UserMailer.welcome_notification(user) }
 
-      it 'renders the email subject in English' do
-        Rails.configuration.x.application.name = 'Foo'
-        expect(mail.subject).to include('Welcome to Foo')
-      end
-    end
-
-    context 'when the user language is set to French' do
-      before do
-        @original_locale = I18n.locale
-        I18n.locale = :'fr-CA'
-      end
-
-      after do
-        I18n.locale = @original_locale
-      end
-
-      let(:mail) { UserMailer.welcome_notification(user) }
-
-      it 'renders the email subject in French' do
-        Rails.configuration.x.application.name = 'Bar'
-        expect(mail.subject).to include("Bienvenue sur l'Bar")
+      it 'renders the correct email subject' do
+        expect(mail.subject).to eq("Welcome to DMP Assistant / Bienvenue sur l'Assistant PGD")
       end
     end
   end

--- a/spec/services/locale_service_spec.rb
+++ b/spec/services/locale_service_spec.rb
@@ -57,6 +57,43 @@ RSpec.describe LocaleService do
     end
   end
 
+  describe '#with_preferred_locale(recipient, &)' do
+    let(:recipient) { create(:user, language: @default) }
+    it "uses the recipient's preferred locale when it is different from I18n.locale. " \
+       'I18n.locale is restored after completion.' do
+      current_locale = I18n.locale
+
+      expect(I18n.locale).to_not eq(recipient.language.abbreviation)
+      described_class.with_preferred_locale(recipient) do
+        # I18n.locale == recipient.language.abbreviation within the `with_preferred_locale` block
+        expect(I18n.locale.to_s).to eq(recipient.language.abbreviation)
+      end
+      # I18n.locale is restored after the `with_preferred_locale` block
+      expect(I18n.locale).to eq(current_locale)
+    end
+
+    it "Uses I18n.locale when recipient doesn't respond to `.language.abbreviation`." do
+      current_locale = I18n.locale
+
+      described_class.with_preferred_locale(nil) do
+        # I18n.locale doesn't change when recipient.language.abbreviation is falsy
+        expect(I18n.locale).to eq(current_locale)
+      end
+    end
+  end
+
+  describe '#with_each_available_locale' do
+    it 'yields once for each available locale, and restores I18n.locale after completion.' do
+      yielded_locales = []
+
+      LocaleService.with_each_available_locale { |locale| yielded_locales << locale }
+
+      expect(yielded_locales).to eq(I18n.available_locales)
+      # Verify .count > 1 to increase our testing confidence
+      expect(yielded_locales.count).to be > 1
+    end
+  end
+
   describe '#translations_for_all_locales(string)' do
     before do
       # Override `I18n.available_locales` value to match DMP Assistant


### PR DESCRIPTION
# Changes Proposed in this PR:

## Added the following methods to `LocaleService`:
 - `def with_preferred_locale(recipient, &)`
   - Localizes the given block to the recipient's preferred locale.
   - `recipient` may be an instance of User or Org (is able to respond to `language&.abbreviation`)
   - Fallback to to the current locale (`I18n.locale`), if necessary.
 - `def with_each_available_locale`
   - Iterates over each available locale, switching to that locale, and yields the locale to the given block for translation and processing.
   
## Updated locale handling for outgoing emails:
 - The following outgoing emails are now localized to a recipient's preferred locale (via `LocaleService.with_preferred_locale(recipient)`):
   - `UserMailer.question_answered`
   - `UserMailer.sharing_notification`
   - `UserMailer.permissions_change_notification`
   - `UserMailer.plan_access_removed`
   - `UserMailer.feedback_notification`
   - `UserMailer.feedback_complete`
   - `UserMailer.plan_visibility`
   - `UserMailer.new_comment`
   - `UserMailer.admin_privileges`
   - `UserMailer.api_credentials`
   - NOTE: The Devise reset password email has not yet been added here. This should eventually be implemented, but will require some Devise overriding to use the recipient's preferrred locale when localising the email subject.
 
 - The following outgoing emails are now rendered in both English and French via (`LocaleService.with_each_available_locale`):
   - `UserMailer.welcome_notification`
   - Devise's Confirmation Instructions email
   - Devise's Invitation Instructions email (triggered when a non-existing email is added as a plan collaborator
   
   - These three emails are English and French because the recipient has not yet had the opportunity to select their preferred locale within the app. Note that the email subject is also rendered in both English and French for all 3 of these emails (can be verified via the following links):
     - https://github.com/portagenetwork/roadmap/pull/1100/files#diff-9802ca3c9c4cf89904fd44bc114e35ebdf2c5dd3d5b645491e2b253e1afef29bL423
     - https://github.com/portagenetwork/roadmap/pull/1100/files#diff-55254045ba774e4c360d7bbfde054665072d2ab49abc3f21add15a37bba65a1cR23
     - https://github.com/portagenetwork/roadmap/pull/1100/files#diff-d3f6ed8387f43b48699fba03e304c682fa7f665c0eb9edfe5d9562b80cc5eca7R237
     - https://github.com/portagenetwork/roadmap/pull/1100/files#diff-b7c9801079388d7d92e11a05faae74843651a70316579aa432c8240e20d767e3R250

## Enabled translations for several strings in several mailer views.

## Added tests for the new mailer localization behaviour, as well as for the new `LocaleService` methods.