### PR TITLE
Refactor locale handling for outgoing emails

### DIFF
--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -4,10 +4,13 @@
 module MailerHelper
   include PermsHelper
 
-  # Returns the email recipient's preferred locale.
-  # Falls back to the current app locale.
-  def email_locale(recipient)
-    recipient&.language&.abbreviation || I18n.locale
+  # Localizes the given block to the email recipient's preferred locale.
+  def with_email_recipient_locale(email_recipient, &)
+    locale = email_recipient_locale(email_recipient)
+    # Avoid switching locale if it is already set correctly.
+    return yield if locale == I18n.locale
+
+    I18n.with_locale(locale, &)
   end
 
   def tool_name
@@ -51,5 +54,13 @@ module MailerHelper
         placeholder2: nil
       }
     end
+  end
+
+  private
+
+  # Returns the email recipient's preferred locale,
+  # falling back to the current app locale.
+  def email_recipient_locale(recipient)
+    recipient&.language&.abbreviation || I18n.locale
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -39,14 +39,14 @@ class UserMailer < ActionMailer::Base
 
     recipient = User.find_by(email: data['email'])
 
-    I18n.with_locale(email_locale(recipient)) do
+    with_email_recipient_locale(recipient) do
       mail(to: data['email'],
            subject: data['subject'])
     end
   end
   # rubocop:enable Metrics/AbcSize
 
-  def sharing_notification(role, user, inviter:) # rubocop:disable Metrics/AbcSize
+  def sharing_notification(role, user, inviter:)
     @role       = role
     @user       = user
     @user_email = @user.email
@@ -55,7 +55,7 @@ class UserMailer < ActionMailer::Base
     @link       = url_for(action: 'show', controller: 'plans', id: @role.plan.id)
     @helpdesk_email = helpdesk_email(org: @inviter.org)
 
-    I18n.with_locale(email_locale(@role.user)) do
+    with_email_recipient_locale(@role.user) do
       mail(to: @role.user.email,
            subject: format(_('A Data Management Plan in %{tool_name} has been shared with you'),
                            tool_name: tool_name))
@@ -72,7 +72,7 @@ class UserMailer < ActionMailer::Base
     @messaging = role_text(@role)
     @helpdesk_email = helpdesk_email(org: @user.org)
 
-    I18n.with_locale(email_locale(@recepient)) do
+    with_email_recipient_locale(@recepient) do
       mail(to: @recepient.email,
            subject: format(_('Changed permissions on a Data Management Plan in %{tool_name}'),
                            tool_name: tool_name))
@@ -87,7 +87,7 @@ class UserMailer < ActionMailer::Base
     @current_user = current_user
     @helpdesk_email = helpdesk_email(org: @plan.org)
 
-    I18n.with_locale(email_locale(@user)) do
+    with_email_recipient_locale(@user) do
       mail(to: @user.email,
            subject: format(_('Permissions removed on a DMP in %{tool_name}'),
                            tool_name: tool_name))
@@ -105,7 +105,7 @@ class UserMailer < ActionMailer::Base
     @plan_name      = @plan.title
     @helpdesk_email = helpdesk_email(org: @plan.org)
 
-    I18n.with_locale(email_locale(@recipient)) do
+    with_email_recipient_locale(@recipient) do
       mail(to: @recipient.email,
            subject: format(_('%{user_name} has requested feedback on a %{tool_name} plan'),
                            tool_name: tool_name, user_name: @user.name(false)))
@@ -124,7 +124,7 @@ class UserMailer < ActionMailer::Base
     @plan_name      = @plan.title
     @helpdesk_email = helpdesk_email(org: @plan.org)
 
-    I18n.with_locale(email_locale(recipient)) do
+    with_email_recipient_locale(recipient) do
       sender = Rails.configuration.x.organisation.do_not_reply_email ||
                Rails.configuration.x.organisation.email
 
@@ -146,7 +146,7 @@ class UserMailer < ActionMailer::Base
     @plan_visibility = Plan::VISIBILITY_MESSAGE[@plan.visibility.to_sym]
     @helpdesk_email = helpdesk_email(org: @plan.org)
 
-    I18n.with_locale(email_locale(@user)) do
+    with_email_recipient_locale(@user) do
       mail(to: @user.email,
            subject: format(_('DMP Visibility Changed: %{plan_title}'), plan_title: @plan.title))
     end
@@ -175,7 +175,7 @@ class UserMailer < ActionMailer::Base
     @phase_link = url_for(action: 'edit', controller: 'plans', id: @plan.id, phase_id: @phase_id)
     @helpdesk_email = helpdesk_email(org: @plan.org)
 
-    I18n.with_locale(email_locale(@plan.owner)) do
+    with_email_recipient_locale(@plan.owner) do
       mail(to: @plan.owner.email,
            subject: format(_('%{tool_name}: A new comment was added to %{plan_title}'),
                            tool_name: tool_name, plan_title: @plan.title))
@@ -190,7 +190,7 @@ class UserMailer < ActionMailer::Base
     @username  = @user.name
     @helpdesk_email = helpdesk_email(org: @user.org)
 
-    I18n.with_locale(email_locale(@user)) do
+    with_email_recipient_locale(@user) do
       mail(to: user.email,
            subject: format(_('Administrator privileges updated in %{tool_name}'),
                            tool_name: tool_name))
@@ -210,7 +210,7 @@ class UserMailer < ActionMailer::Base
 
     recipient = User.find_by(email: @api_client.contact_email) || @api_client.org
 
-    I18n.with_locale(email_locale(recipient)) do
+    with_email_recipient_locale(recipient) do
       mail(to: @api_client.contact_email,
            subject: format(_('%{tool_name} API changes'), tool_name: tool_name))
     end


### PR DESCRIPTION
## Changes proposed in this PR:
Replaces inline uses of `I18n.with_locale(email_locale(x))` with a new`with_email_recipient_locale(recipient, &block)` helper method.

This centralizes recipient locale handling and avoids redundant calls to `I18n.with_locale(I18n.locale)` by only switching locales when necessary.
