### PR TITLE
Migrate to helm-schema and fix values validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
         language: system
         files: (Chart\.yaml|values\.yaml|README\.md\.gotmpl)$
         pass_filenames: false
-        
+
   - repo: https://github.com/dadav/helm-schema
     rev: 0.18.1
     hooks:
@@ -33,7 +33,7 @@ repos:
         # for all available options: helm-schema -h
         args:
           # directory to search recursively within for charts
-          - --chart-search-root=.
+          - --chart-search-root=charts/
 
           # don't analyze dependencies
           - --no-dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,11 +25,22 @@ repos:
         language: system
         files: (Chart\.yaml|values\.yaml|README\.md\.gotmpl)$
         pass_filenames: false
-
-      # Schema generation
+        
+  - repo: https://github.com/dadav/helm-schema
+    rev: 0.18.1
+    hooks:
       - id: helm-schema
-        name: Generate Helm schema
-        entry: bash -c 'cd charts/dmp-roadmap && helm schema dmp-roadmap/values.schema.json -f values.yaml'
-        language: system
-        files: values\.yaml$
-        pass_filenames: false
+        # for all available options: helm-schema -h
+        args:
+          # directory to search recursively within for charts
+          - --chart-search-root=.
+
+          # don't analyze dependencies
+          - --no-dependencies
+
+          # add references to values file if not exist
+          - --add-schema-reference
+
+          # list of fields to skip from being created by default
+          # e.g. generate a relatively permissive schema
+          # - "--skip-auto-generation=required,additionalProperties"

--- a/charts/dmp-roadmap/README.md
+++ b/charts/dmp-roadmap/README.md
@@ -301,11 +301,11 @@ Automatically generates `values.schema.json` from `values.yaml`:
 
 ```bash
 # Install the plugin
-helm plugin install https://github.com/karuppiah7890/helm-schema
+helm plugin install https://github.com/dadav/helm-schema
 
 # Generate schema from values.yaml
 cd charts/dmp-roadmap
-helm schema values.yaml > values.schema.json
+helm-schema
 ```
 
 #### Pre-commit Hooks

--- a/charts/dmp-roadmap/README.md.gotmpl
+++ b/charts/dmp-roadmap/README.md.gotmpl
@@ -301,11 +301,11 @@ Automatically generates `values.schema.json` from `values.yaml`:
 
 ```bash
 # Install the plugin
-helm plugin install https://github.com/karuppiah7890/helm-schema
+helm plugin install https://github.com/dadav/helm-schema
 
 # Generate schema from values.yaml
 cd charts/dmp-roadmap
-helm schema values.yaml > values.schema.json
+helm-schema 
 ```
 
 #### Pre-commit Hooks

--- a/charts/dmp-roadmap/values.schema.json
+++ b/charts/dmp-roadmap/values.schema.json
@@ -4,7 +4,6 @@
   "properties": {
     "app": {
       "additionalProperties": false,
-      "description": "#",
       "properties": {
         "affinity": {
           "additionalProperties": false,
@@ -80,9 +79,14 @@
             "imagePullPolicy": {
               "default": "",
               "description": "Image pull policy for the DMP Roadmap app",
+              "enum": [
+                "Always",
+                "IfNotPresent",
+                "Never",
+                ""
+              ],
               "required": [],
-              "title": "imagePullPolicy",
-              "type": "string"
+              "title": "imagePullPolicy"
             },
             "repository": {
               "default": "",
@@ -99,11 +103,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "repository",
-            "tag",
-            "imagePullPolicy"
-          ],
+          "required": [],
           "title": "image",
           "type": "object"
         },
@@ -295,6 +295,7 @@
         "replicas": {
           "default": 1,
           "description": "Number of app replicas",
+          "minimum": 1,
           "required": [],
           "title": "replicas",
           "type": "integer"
@@ -450,6 +451,8 @@
             "port": {
               "default": 8080,
               "description": "Service port for the app",
+              "maximum": 65535,
+              "minimum": 1,
               "required": [],
               "title": "port",
               "type": "integer"
@@ -457,6 +460,8 @@
             "targetPort": {
               "default": 3000,
               "description": "Target port for the app container",
+              "maximum": 65535,
+              "minimum": 1,
               "required": [],
               "title": "targetPort",
               "type": "integer"
@@ -464,16 +469,17 @@
             "type": {
               "default": "ClusterIP",
               "description": "Service type for the app",
+              "enum": [
+                "ClusterIP",
+                "NodePort",
+                "LoadBalancer",
+                "ExternalName"
+              ],
               "required": [],
-              "title": "type",
-              "type": "string"
+              "title": "type"
             }
           },
-          "required": [
-            "type",
-            "port",
-            "targetPort"
-          ],
+          "required": [],
           "title": "service",
           "type": "object"
         },
@@ -510,12 +516,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "create",
-            "automount",
-            "annotations",
-            "name"
-          ],
+          "required": [],
           "title": "serviceAccount",
           "type": "object"
         },
@@ -548,18 +549,6 @@
         }
       },
       "required": [
-        "replicas",
-        "image",
-        "imagePullSecrets",
-        "env",
-        "envFrom",
-        "serviceAccount",
-        "podAnnotations",
-        "podLabels",
-        "podSecurityContext",
-        "securityContext",
-        "service",
-        "resources",
         "livenessProbe",
         "readinessProbe",
         "autoscaling",
@@ -1174,14 +1163,15 @@
             "onSandbox": {
               "default": "false",
               "description": "Set to true for sandbox mode",
+              "enum": [
+                "true",
+                "false"
+              ],
               "required": [],
-              "title": "onSandbox",
-              "type": "string"
+              "title": "onSandbox"
             }
           },
           "required": [
-            "dmproadmapHost",
-            "onSandbox",
             "httpProxy",
             "httpProxyPort"
           ],
@@ -1380,6 +1370,7 @@
             "from": {
               "default": "support@example.com",
               "description": "From address for emails",
+              "format": "email",
               "required": [],
               "title": "from",
               "type": "string"
@@ -1387,6 +1378,7 @@
             "smtpAddress": {
               "default": "smtp.example.com",
               "description": "SMTP server address",
+              "format": "hostname",
               "required": [],
               "title": "smtpAddress",
               "type": "string"
@@ -1408,6 +1400,8 @@
             "smtpPort": {
               "default": 587,
               "description": "SMTP port",
+              "maximum": 65535,
+              "minimum": 1,
               "required": [],
               "title": "smtpPort",
               "type": "integer"
@@ -1415,6 +1409,7 @@
             "to": {
               "default": "support@example.com",
               "description": "To address for system emails",
+              "format": "email",
               "required": [],
               "title": "to",
               "type": "string"
@@ -1422,20 +1417,14 @@
           },
           "required": [
             "defaultHost",
-            "from",
-            "to",
-            "smtpAddress",
             "smtpAuthentication",
-            "smtpDomain",
-            "smtpPort"
+            "smtpDomain"
           ],
           "title": "mailer",
           "type": "object"
         }
       },
       "required": [
-        "application",
-        "mailer",
         "environment"
       ],
       "title": "config",
@@ -2097,6 +2086,7 @@
         "host": {
           "default": "localhost",
           "description": "Database host",
+          "format": "hostname",
           "required": [],
           "title": "host",
           "type": "string"
@@ -2111,6 +2101,8 @@
         "port": {
           "default": 5432,
           "description": "Database port",
+          "maximum": 65535,
+          "minimum": 1,
           "required": [],
           "title": "port",
           "type": "integer"
@@ -2124,11 +2116,7 @@
         }
       },
       "required": [
-        "host",
-        "port",
-        "database",
         "username",
-        "password",
         "existingSecret",
         "existingSecretPasswordKey"
       ],
@@ -2153,7 +2141,6 @@
     },
     "global": {
       "additionalProperties": false,
-      "description": "#",
       "properties": {
         "additionalLabels": {
           "additionalProperties": false,
@@ -2176,6 +2163,7 @@
             "name": {
               "default": "example.com",
               "description": "Main domain name used throughout the chart",
+              "format": "hostname",
               "required": [],
               "title": "name",
               "type": "string"
@@ -2195,11 +2183,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "name",
-            "path",
-            "prefix"
-          ],
+          "required": [],
           "title": "domain",
           "type": "object"
         },
@@ -2219,9 +2203,13 @@
             "imagePullPolicy": {
               "default": "IfNotPresent",
               "description": "If defined, a imagePullPolicy applied to all DMP Roadmap deployments",
+              "enum": [
+                "Always",
+                "IfNotPresent",
+                "Never"
+              ],
               "required": [],
-              "title": "imagePullPolicy",
-              "type": "string"
+              "title": "imagePullPolicy"
             },
             "repository": {
               "default": "ualbertalib/dmp_roadmap",
@@ -2238,11 +2226,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "repository",
-            "tag",
-            "imagePullPolicy"
-          ],
+          "required": [],
           "title": "image",
           "type": "object"
         },
@@ -2284,24 +2268,12 @@
           "type": "object"
         }
       },
-      "required": [
-        "domain",
-        "image",
-        "additionalLabels",
-        "imagePullSecrets",
-        "statefulsetAnnotations",
-        "deploymentAnnotations",
-        "podAnnotations",
-        "podLabels",
-        "priorityClassName",
-        "env"
-      ],
+      "required": [],
       "title": "global",
       "type": "object"
     },
     "ingress": {
       "additionalProperties": false,
-      "description": "#",
       "properties": {
         "annotations": {
           "additionalProperties": false,
@@ -2385,6 +2357,7 @@
                 "email": {
                   "default": "support@example.com",
                   "description": "Email address for ACME registration",
+                  "format": "email",
                   "required": [],
                   "title": "email",
                   "type": "string"
@@ -2409,7 +2382,6 @@
                     }
                   },
                   "required": [
-                    "enabled",
                     "ingressClass"
                   ],
                   "title": "http01",
@@ -2418,15 +2390,13 @@
                 "server": {
                   "default": "https://acme-v02.api.letsencrypt.org/directory",
                   "description": "ACME server URL",
+                  "format": "uri",
                   "required": [],
                   "title": "server",
                   "type": "string"
                 }
               },
               "required": [
-                "server",
-                "email",
-                "http01",
                 "dns01"
               ],
               "title": "acme",
@@ -2693,11 +2663,6 @@
             }
           },
           "required": [
-            "enabled",
-            "issuer",
-            "clusterIssuer",
-            "annotations",
-            "acme",
             "ca",
             "vault",
             "certificateRequestPolicy",
@@ -2739,14 +2704,7 @@
           "type": "array"
         }
       },
-      "required": [
-        "enabled",
-        "annotations",
-        "className",
-        "hosts",
-        "tls",
-        "certManager"
-      ],
+      "required": [],
       "title": "ingress",
       "type": "object"
     },
@@ -3478,17 +3436,8 @@
     }
   },
   "required": [
-    "nameOverride",
-    "fullnameOverride",
-    "namespaceOverride",
-    "global",
-    "app",
     "assets",
-    "ingress",
     "storage",
-    "config",
-    "externalDatabase",
-    "cronjobs",
     "extraObjects",
     "networkPolicy"
   ],

--- a/charts/dmp-roadmap/values.schema.json
+++ b/charts/dmp-roadmap/values.schema.json
@@ -193,14 +193,14 @@
           "type": "object"
         },
         "podAnnotations": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "description": "Pod annotations for the app deployment",
           "required": [],
           "title": "podAnnotations",
           "type": "object"
         },
         "podLabels": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "description": "Pod labels for the app deployment",
           "required": [],
           "title": "podLabels",
@@ -488,7 +488,7 @@
           "description": "- configMapRef:\n    name: config-map-name\n- secretRef:\n    name: secret-name",
           "properties": {
             "annotations": {
-              "additionalProperties": false,
+              "additionalProperties": true,
               "description": "Annotations to add to the service account",
               "required": [],
               "title": "annotations",
@@ -752,14 +752,14 @@
           "type": "object"
         },
         "podAnnotations": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "description": "Pod annotations for the assets deployment",
           "required": [],
           "title": "podAnnotations",
           "type": "object"
         },
         "podLabels": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "description": "Pod labels for the assets deployment",
           "required": [],
           "title": "podLabels",
@@ -1041,7 +1041,7 @@
           "description": "- configMapRef:\n    name: config-map-name\n- secretRef:\n    name: secret-name",
           "properties": {
             "annotations": {
-              "additionalProperties": false,
+              "additionalProperties": true,
               "description": "Annotations to add to the service account",
               "required": [],
               "title": "annotations",
@@ -1072,7 +1072,6 @@
           "required": [
             "create",
             "automount",
-            "annotations",
             "name"
           ],
           "title": "serviceAccount",
@@ -1113,8 +1112,6 @@
         "env",
         "envFrom",
         "serviceAccount",
-        "podAnnotations",
-        "podLabels",
         "podSecurityContext",
         "securityContext",
         "service",
@@ -1483,14 +1480,14 @@
               "type": "object"
             },
             "podAnnotations": {
-              "additionalProperties": false,
+              "additionalProperties": true,
               "description": "Pod annotations for the CronJob pods",
               "required": [],
               "title": "podAnnotations",
               "type": "object"
             },
             "podLabels": {
-              "additionalProperties": false,
+              "additionalProperties": true,
               "description": "Pod labels for the CronJob pods",
               "required": [],
               "title": "podLabels",
@@ -1625,8 +1622,6 @@
             "failedJobsHistoryLimit",
             "suspend",
             "restartPolicy",
-            "podAnnotations",
-            "podLabels",
             "priorityClassName",
             "env",
             "volumeMounts",
@@ -1688,14 +1683,14 @@
               "type": "object"
             },
             "podAnnotations": {
-              "additionalProperties": false,
+              "additionalProperties": true,
               "description": "Pod annotations for the CronJob pods",
               "required": [],
               "title": "podAnnotations",
               "type": "object"
             },
             "podLabels": {
-              "additionalProperties": false,
+              "additionalProperties": true,
               "description": "Pod labels for the CronJob pods",
               "required": [],
               "title": "podLabels",
@@ -1830,8 +1825,6 @@
             "failedJobsHistoryLimit",
             "suspend",
             "restartPolicy",
-            "podAnnotations",
-            "podLabels",
             "priorityClassName",
             "env",
             "volumeMounts",
@@ -1893,14 +1886,14 @@
               "type": "object"
             },
             "podAnnotations": {
-              "additionalProperties": false,
+              "additionalProperties": true,
               "description": "Pod annotations for the CronJob pods",
               "required": [],
               "title": "podAnnotations",
               "type": "object"
             },
             "podLabels": {
-              "additionalProperties": false,
+              "additionalProperties": true,
               "description": "Pod labels for the CronJob pods",
               "required": [],
               "title": "podLabels",
@@ -2035,8 +2028,6 @@
             "failedJobsHistoryLimit",
             "suspend",
             "restartPolicy",
-            "podAnnotations",
-            "podLabels",
             "priorityClassName",
             "env",
             "volumeMounts",
@@ -2143,14 +2134,14 @@
       "additionalProperties": false,
       "properties": {
         "additionalLabels": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "description": "Common labels for the all resources",
           "required": [],
           "title": "additionalLabels",
           "type": "object"
         },
         "deploymentAnnotations": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "description": "Annotations for the all deployed Deployments",
           "required": [],
           "title": "deploymentAnnotations",
@@ -2240,14 +2231,14 @@
           "type": "array"
         },
         "podAnnotations": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "description": "Annotations for the all deployed pods",
           "required": [],
           "title": "podAnnotations",
           "type": "object"
         },
         "podLabels": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "description": "Labels for the all deployed pods",
           "required": [],
           "title": "podLabels",
@@ -2261,7 +2252,7 @@
           "type": "string"
         },
         "statefulsetAnnotations": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "description": "Annotations for the all deployed Statefulsets",
           "required": [],
           "title": "statefulsetAnnotations",
@@ -2276,7 +2267,7 @@
       "additionalProperties": false,
       "properties": {
         "annotations": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "description": "Annotations for the ingress resource",
           "required": [],
           "title": "annotations",
@@ -2403,7 +2394,7 @@
               "type": "object"
             },
             "annotations": {
-              "additionalProperties": false,
+              "additionalProperties": true,
               "description": "Additional annotations for cert-manager",
               "required": [],
               "title": "annotations",

--- a/charts/dmp-roadmap/values.yaml
+++ b/charts/dmp-roadmap/values.yaml
@@ -1,107 +1,197 @@
 ---
+# yaml-language-server: $schema=values.schema.json
 # Default values for dmp-roadmap.
 
+# @schema
+# type: string
+# @schema
 # -- Provide a name in place of `dmp-roadmap`
 nameOverride: ''
+# @schema
+# type: string
+# @schema
 # -- String to fully override `dmp-roadmap.fullname`
 fullnameOverride: ''
+# @schema
+# type: string
+# @schema
 # -- Override the namespace
 # @default -- `.Release.Namespace`
 namespaceOverride: ''
 
 ## @section Global parameters
 
+# @schema
+# type: object
+# @schema
 global:
+  # @schema
+  # type: object
+  # @schema
   # -- Global domain configuration
   # @section -- Global parameters
   domain:
+    # @schema
+    # type: string
+    # format: hostname
+    # @schema
     # -- Main domain name used throughout the chart
     # @section -- Global parameters
     name: example.com
+    # @schema
+    # type: string
+    # @schema
     # -- Application path/context (e.g., /staging)
     # @section -- Global parameters
     path: ''
+    # @schema
+    # type: string
+    # @schema
     # -- Application prefix (e.g., staging)
     # @section -- Global parameters
     prefix: ''
 
+  # @schema
+  # type: object
+  # @schema
   # -- Default image used by all components
   # @section -- Global parameters
   image:
+    # @schema
+    # type: string
+    # @schema
     # -- If defined, a repository applied to all DMP Roadmap deployments
     # @section -- Global parameters
     repository: ualbertalib/dmp_roadmap
+    # @schema
+    # type: string
+    # @schema
     # -- Overrides the global DMP Roadmap image tag whose default is the chart appVersion
     # @section -- Global parameters
     tag: ''
+    # @schema
+    # enum: [Always, IfNotPresent, Never]
+    # @schema
     # -- If defined, a imagePullPolicy applied to all DMP Roadmap deployments
     # @section -- Global parameters
     imagePullPolicy: IfNotPresent
 
+  # @schema
+  # type: object
+  # @schema
   # -- Common labels for the all resources
   # @section -- Global parameters
   additionalLabels: {}
     # app: dmp-r
 
+  # @schema
+  # type: array
+  # @schema
   # -- Secrets with credentials to pull images from a private registry
   # @section -- Global parameters
   imagePullSecrets: []
 
+  # @schema
+  # type: object
+  # @schema
   # -- Annotations for the all deployed Statefulsets
   # @section -- Global parameters
   statefulsetAnnotations: {}
 
+  # @schema
+  # type: object
+  # @schema
   # -- Annotations for the all deployed Deployments
   # @section -- Global parameters
   deploymentAnnotations: {}
 
+  # @schema
+  # type: object
+  # @schema
   # -- Annotations for the all deployed pods
   # @section -- Global parameters
   podAnnotations: {}
 
+  # @schema
+  # type: object
+  # @schema
   # -- Labels for the all deployed pods
   # @section -- Global parameters
   podLabels: {}
 
+  # @schema
+  # type: string
+  # @schema
   # -- Default priority class for all components
   # @section -- Global parameters
   priorityClassName: ''
 
+  # @schema
+  # type: array
+  # @schema
   # -- Environment variables to pass to all deployed Deployments
   # @section -- Global parameters
   env: []
 
 ## @section Application Configuration
 
+# @schema
+# type: object
+# @schema
 app:
+  # @schema
+  # type: integer
+  # minimum: 1
+  # @schema
   # -- Number of app replicas
   # @section -- Application Configuration
   replicas: 1
 
+  # @schema
+  # type: object
+  # @schema
   ## DMP Roadmap app image
   image:
+    # @schema
+    # type: string
+    # @schema
     # -- Repository to use for the DMP Roadmap app
     # @default -- global.image.repository
     # @section -- Application Configuration
     repository: ''
+    # @schema
+    # type: string
+    # @schema
     # -- Tag to use for the DMP Roadmap app
     # @default -- global.image.tag or chart appVersion
     # @section -- Application Configuration
     tag: ''
+    # @schema
+    # enum: [Always, IfNotPresent, Never, ""]
+    # @schema
     # -- Image pull policy for the DMP Roadmap app
     # @default -- global.image.imagePullPolicy
     # @section -- Application Configuration
     imagePullPolicy: ''
 
+  # @schema
+  # type: array
+  # @schema
   # -- Secrets with credentials to pull images from a private registry
   # @default -- global.imagePullSecrets
   # @section -- Application Configuration
   imagePullSecrets: []
 
+  # @schema
+  # type: array
+  # @schema
   # -- Environment variables to pass to DMP Roadmap app
   # @section -- Application Configuration
   env: []
 
+  # @schema
+  # type: array
+  # @schema
   # -- envFrom to pass to DMP Roadmap app
   # @section -- Application Configuration
   envFrom: []
@@ -109,33 +199,60 @@ app:
   #     name: config-map-name
   # - secretRef:
   #     name: secret-name
+  # @schema
+  # type: object
+  # @schema
   serviceAccount:
+    # @schema
+    # type: boolean
+    # @schema
     # -- Specifies whether a service account should be created
     # @section -- Application Configuration
     create: true
+    # @schema
+    # type: boolean
+    # @schema
     # -- Automatically mount a ServiceAccount's API credentials?
     # @section -- Application Configuration
     automount: true
+    # @schema
+    # type: object
+    # @schema
     # -- Annotations to add to the service account
     # @section -- Application Configuration
     annotations: {}
+    # @schema
+    # type: string
+    # @schema
     # -- The name of the service account to use.
     # @default -- If not set and create is true, a name is generated using the fullname template
     # @section -- Application Configuration
     name: ''
 
+  # @schema
+  # type: object
+  # @schema
   # -- Pod annotations for the app deployment
   # @section -- Application Configuration
   podAnnotations: {}
+  # @schema
+  # type: object
+  # @schema
   # -- Pod labels for the app deployment
   # @section -- Application Configuration
   podLabels: {}
 
+  # @schema
+  # type: object
+  # @schema
   # -- Pod security context for the app deployment
   # @section -- Application Configuration
   podSecurityContext:
     fsGroup: 3000
 
+  # @schema
+  # type: object
+  # @schema
   # -- Container security context for the app deployment
   # @section -- Application Configuration
   securityContext:
@@ -149,17 +266,36 @@ app:
     runAsUser: 1000
     seccompProfile:
       type: RuntimeDefault
+  # @schema
+  # type: object
+  # @schema
   service:
+    # @schema
+    # enum: [ClusterIP, NodePort, LoadBalancer, ExternalName]
+    # @schema
     # -- Service type for the app
     # @section -- Application Configuration
     type: ClusterIP
+    # @schema
+    # type: integer
+    # minimum: 1
+    # maximum: 65535
+    # @schema
     # -- Service port for the app
     # @section -- Application Configuration
     port: 8080
+    # @schema
+    # type: integer
+    # minimum: 1
+    # maximum: 65535
+    # @schema
     # -- Target port for the app container
     # @section -- Application Configuration
     targetPort: 3000
 
+  # @schema
+  # type: object
+  # @schema
   # -- Resource requests and limits for the app
   # @section -- Application Configuration
   resources:
@@ -409,11 +545,20 @@ assets:
 
 ## @section Ingress Configuration
 
+# @schema
+# type: object
+# @schema
 ingress:
+  # @schema
+  # type: boolean
+  # @schema
   # -- Enable or disable the ingress
   # @section -- Ingress Configuration
   enabled: false
 
+  # @schema
+  # type: object
+  # @schema
   # -- Annotations for the ingress resource
   # @section -- Ingress Configuration
   annotations: {}
@@ -422,10 +567,16 @@ ingress:
     # cert-manager.io/issuer: letsencrypt-prod
     # cert-manager.io/cluster-issuer: letsencrypt-prod
 
+  # @schema
+  # type: string
+  # @schema
   # -- Ingress class name
   # @section -- Ingress Configuration
   className: ''
 
+  # @schema
+  # type: array
+  # @schema
   # -- Hosts configuration (if empty, uses global.domain.name)
   # @section -- Ingress Configuration
   hosts: []
@@ -435,6 +586,9 @@ ingress:
   #      - path: /
   #        pathType: Prefix
 
+  # @schema
+  # type: array
+  # @schema
   # -- TLS configuration for the ingress
   # @section -- Ingress Configuration
   tls: []
@@ -442,34 +596,66 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+  # @schema
+  # type: object
+  # @schema
   # -- Automatic TLS certificate management with cert-manager
   # @section -- Ingress Configuration
   certManager:
+    # @schema
+    # type: boolean
+    # @schema
     # -- Enable automatic TLS certificate management
     # @section -- Ingress Configuration
     enabled: false
+    # @schema
+    # type: string
+    # @schema
     # -- Issuer name (for namespace-scoped issuer)
     # @section -- Ingress Configuration
     issuer: ""
+    # @schema
+    # type: string
+    # @schema
     # -- ClusterIssuer name (for cluster-scoped issuer)
     # @section -- Ingress Configuration
     clusterIssuer: ""
+    # @schema
+    # type: object
+    # @schema
     # -- Additional annotations for cert-manager
     # @section -- Ingress Configuration
     annotations: {}
 
+    # @schema
+    # type: object
+    # @schema
     # -- ACME configuration for Let's Encrypt
     # @section -- Ingress Configuration
     acme:
+      # @schema
+      # type: string
+      # format: uri
+      # @schema
       # -- ACME server URL
       # @section -- Ingress Configuration
       server: https://acme-v02.api.letsencrypt.org/directory
+      # @schema
+      # type: string
+      # format: email
+      # @schema
       # -- Email address for ACME registration
       # @section -- Ingress Configuration
       email: support@example.com
+      # @schema
+      # type: object
+      # @schema
       # -- HTTP-01 challenge configuration
       # @section -- Ingress Configuration
       http01:
+        # @schema
+        # type: boolean
+        # @schema
         # -- Enable HTTP-01 challenge
         # @section -- Ingress Configuration
         enabled: false
@@ -774,16 +960,28 @@ storage:
 
 ## @section Application Settings
 
+# @schema
+# type: object
+# @schema
 # -- Configuration values for the application
 # @section -- Application Settings
 config:
+  # @schema
+  # type: object
+  # @schema
   # -- Application and host settings
   # @section -- Application Settings
   application:
+    # @schema
+    # type: string
+    # @schema
     # -- Main hostname for the application
     # @default -- global.domain.name
     # @section -- Application Settings
     dmproadmapHost: ''
+    # @schema
+    # enum: ['true', 'false']
+    # @schema
     # -- Set to true for sandbox mode
     # @section -- Application Settings
     onSandbox: 'false'
@@ -794,6 +992,9 @@ config:
     # @section -- Application Settings
     httpProxyPort: ''
 
+  # @schema
+  # type: object
+  # @schema
   # -- Mailer and SMTP settings
   # @section -- Application Settings
   mailer:
@@ -801,12 +1002,24 @@ config:
     # @default -- https://global.domain.name
     # @section -- Application Settings
     defaultHost: ''
+    # @schema
+    # type: string
+    # format: email
+    # @schema
     # -- From address for emails
     # @section -- Application Settings
     from: support@example.com
+    # @schema
+    # type: string
+    # format: email
+    # @schema
     # -- To address for system emails
     # @section -- Application Settings
     to: support@example.com
+    # @schema
+    # type: string
+    # format: hostname
+    # @schema
     # -- SMTP server address
     # @section -- Application Settings
     smtpAddress: smtp.example.com
@@ -816,6 +1029,11 @@ config:
     # -- SMTP domain
     # @section -- Application Settings
     smtpDomain: example.com
+    # @schema
+    # type: integer
+    # minimum: 1
+    # maximum: 65535
+    # @schema
     # -- SMTP port
     # @section -- Application Settings
     smtpPort: 587
@@ -892,21 +1110,39 @@ config:
 
 ## @section Database Configuration
 
+# @schema
+# type: object
+# @schema
 # -- External database configuration
 # @section -- Database Configuration
 externalDatabase:
+  # @schema
+  # type: string
+  # format: hostname
+  # @schema
   # -- Database host
   # @section -- Database Configuration
   host: localhost
+  # @schema
+  # type: integer
+  # minimum: 1
+  # maximum: 65535
+  # @schema
   # -- Database port
   # @section -- Database Configuration
   port: 5432
+  # @schema
+  # type: string
+  # @schema
   # -- Database name
   # @section -- Database Configuration
   database: dmp_roadmap_production
   # -- Database user
   # @section -- Database Configuration
   username: dmp_roadmap
+  # @schema
+  # type: string
+  # @schema
   # -- Database password (recommend using existingSecret instead)
   # @section -- Database Configuration
   password: ""
@@ -919,6 +1155,9 @@ externalDatabase:
 
 ## @section CronJobs Configuration
 
+# @schema
+# type: object
+# @schema
 # -- Scheduled tasks for the application
 # @section -- CronJobs Configuration
 cronjobs:

--- a/charts/dmp-roadmap/values.yaml
+++ b/charts/dmp-roadmap/values.yaml
@@ -78,6 +78,7 @@ global:
 
   # @schema
   # type: object
+  # additionalProperties: true
   # @schema
   # -- Common labels for the all resources
   # @section -- Global parameters
@@ -93,6 +94,7 @@ global:
 
   # @schema
   # type: object
+  # additionalProperties: true
   # @schema
   # -- Annotations for the all deployed Statefulsets
   # @section -- Global parameters
@@ -100,6 +102,7 @@ global:
 
   # @schema
   # type: object
+  # additionalProperties: true
   # @schema
   # -- Annotations for the all deployed Deployments
   # @section -- Global parameters
@@ -107,6 +110,7 @@ global:
 
   # @schema
   # type: object
+  # additionalProperties: true
   # @schema
   # -- Annotations for the all deployed pods
   # @section -- Global parameters
@@ -114,6 +118,7 @@ global:
 
   # @schema
   # type: object
+  # additionalProperties: true
   # @schema
   # -- Labels for the all deployed pods
   # @section -- Global parameters
@@ -217,6 +222,7 @@ app:
     automount: true
     # @schema
     # type: object
+    # additionalProperties: true
     # @schema
     # -- Annotations to add to the service account
     # @section -- Application Configuration
@@ -231,12 +237,14 @@ app:
 
   # @schema
   # type: object
+  # additionalProperties: true
   # @schema
   # -- Pod annotations for the app deployment
   # @section -- Application Configuration
   podAnnotations: {}
   # @schema
   # type: object
+  # additionalProperties: true
   # @schema
   # -- Pod labels for the app deployment
   # @section -- Application Configuration
@@ -420,6 +428,10 @@ assets:
     # -- Automatically mount a ServiceAccount's API credentials?
     # @section -- Assets Configuration
     automount: true
+    # @schema
+    # type: object
+    # additionalProperties: true
+    # @schema
     # -- Annotations to add to the service account
     # @section -- Assets Configuration
     annotations: {}
@@ -428,9 +440,17 @@ assets:
     # @section -- Assets Configuration
     name: ''
 
+  # @schema
+  # type: object
+  # additionalProperties: true
+  # @schema
   # -- Pod annotations for the assets deployment
   # @section -- Assets Configuration
   podAnnotations: {}
+  # @schema
+  # type: object
+  # additionalProperties: true
+  # @schema
   # -- Pod labels for the assets deployment
   # @section -- Assets Configuration
   podLabels: {}
@@ -558,6 +578,7 @@ ingress:
 
   # @schema
   # type: object
+  # additionalProperties: true
   # @schema
   # -- Annotations for the ingress resource
   # @section -- Ingress Configuration
@@ -622,6 +643,7 @@ ingress:
     clusterIssuer: ""
     # @schema
     # type: object
+    # additionalProperties: true
     # @schema
     # -- Additional annotations for cert-manager
     # @section -- Ingress Configuration
@@ -1185,9 +1207,17 @@ cronjobs:
     # -- Restart policy for the job pods
     # @section -- CronJobs Configuration
     restartPolicy: OnFailure
+    # @schema
+    # type: object
+    # additionalProperties: true
+    # @schema
     # -- Pod annotations for the CronJob pods
     # @section -- CronJobs Configuration
     podAnnotations: {}
+    # @schema
+    # type: object
+    # additionalProperties: true
+    # @schema
     # -- Pod labels for the CronJob pods
     # @section -- CronJobs Configuration
     podLabels: {}
@@ -1250,9 +1280,17 @@ cronjobs:
     # -- Restart policy for the job pods
     # @section -- CronJobs Configuration
     restartPolicy: OnFailure
+    # @schema
+    # type: object
+    # additionalProperties: true
+    # @schema
     # -- Pod annotations for the CronJob pods
     # @section -- CronJobs Configuration
     podAnnotations: {}
+    # @schema
+    # type: object
+    # additionalProperties: true
+    # @schema
     # -- Pod labels for the CronJob pods
     # @section -- CronJobs Configuration
     podLabels: {}
@@ -1315,9 +1353,17 @@ cronjobs:
     # -- Restart policy for the job pods
     # @section -- CronJobs Configuration
     restartPolicy: OnFailure
+    # @schema
+    # type: object
+    # additionalProperties: true
+    # @schema
     # -- Pod annotations for the CronJob pods
     # @section -- CronJobs Configuration
     podAnnotations: {}
+    # @schema
+    # type: object
+    # additionalProperties: true
+    # @schema
     # -- Pod labels for the CronJob pods
     # @section -- CronJobs Configuration
     podLabels: {}


### PR DESCRIPTION
## Summary
Migrated Helm chart from deprecated schema generator to modern `helm-schema` tool and fixed validation errors preventing use of custom annotations.

## Key Changes
- **Schema migration**: Replaced deprecated generator with `dadav/helm-schema`, adding proper type definitions and constraints
- **Fixed annotation validation**: Added `additionalProperties: true` to all annotation fields to support custom keys (e.g., Traefik ingress annotations)
- **Fixed validation conflicts**: Removed conflicting `type` declarations from enum fields and `format: hostname` from optional empty fields

## Affected Fields
All annotation and label fields now support arbitrary key-value pairs:
- Ingress, pod, service account, and deployment annotations
- All cronjob and label fields

## Testing
- Passes `helm lint`, `helm template` with custom annotations, and pre-commit hooks