### PR TITLE
Refactor Email Localization Logic and Add Test Coverage 

### DIFF
--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -4,12 +4,6 @@
 module MailerHelper
   include PermsHelper
 
-  # Returns the email recipient's preferred locale.
-  # Falls back to the current app locale.
-  def email_locale(recipient)
-    recipient&.language&.abbreviation || I18n.locale
-  end
-
   def tool_name
     @tool_name ||= ApplicationService.application_name
   end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -39,14 +39,14 @@ class UserMailer < ActionMailer::Base
 
     recipient = User.find_by(email: data['email'])
 
-    I18n.with_locale(email_locale(recipient)) do
+    LocaleService.with_preferred_locale(recipient) do
       mail(to: data['email'],
            subject: data['subject'])
     end
   end
   # rubocop:enable Metrics/AbcSize
 
-  def sharing_notification(role, user, inviter:) # rubocop:disable Metrics/AbcSize
+  def sharing_notification(role, user, inviter:)
     @role       = role
     @user       = user
     @user_email = @user.email
@@ -55,7 +55,7 @@ class UserMailer < ActionMailer::Base
     @link       = url_for(action: 'show', controller: 'plans', id: @role.plan.id)
     @helpdesk_email = helpdesk_email(org: @inviter.org)
 
-    I18n.with_locale(email_locale(@role.user)) do
+    LocaleService.with_preferred_locale(@role.user) do
       mail(to: @role.user.email,
            subject: format(_('A Data Management Plan in %{tool_name} has been shared with you'),
                            tool_name: tool_name))
@@ -72,7 +72,7 @@ class UserMailer < ActionMailer::Base
     @messaging = role_text(@role)
     @helpdesk_email = helpdesk_email(org: @user.org)
 
-    I18n.with_locale(email_locale(@recepient)) do
+    LocaleService.with_preferred_locale(@recepient) do
       mail(to: @recepient.email,
            subject: format(_('Changed permissions on a Data Management Plan in %{tool_name}'),
                            tool_name: tool_name))
@@ -87,7 +87,7 @@ class UserMailer < ActionMailer::Base
     @current_user = current_user
     @helpdesk_email = helpdesk_email(org: @plan.org)
 
-    I18n.with_locale(email_locale(@user)) do
+    LocaleService.with_preferred_locale(@user) do
       mail(to: @user.email,
            subject: format(_('Permissions removed on a DMP in %{tool_name}'),
                            tool_name: tool_name))
@@ -105,7 +105,7 @@ class UserMailer < ActionMailer::Base
     @plan_name      = @plan.title
     @helpdesk_email = helpdesk_email(org: @plan.org)
 
-    I18n.with_locale(email_locale(@recipient)) do
+    LocaleService.with_preferred_locale(@recipient) do
       mail(to: @recipient.email,
            subject: format(_('%{user_name} has requested feedback on a %{tool_name} plan'),
                            tool_name: tool_name, user_name: @user.name(false)))
@@ -124,7 +124,7 @@ class UserMailer < ActionMailer::Base
     @plan_name      = @plan.title
     @helpdesk_email = helpdesk_email(org: @plan.org)
 
-    I18n.with_locale(email_locale(recipient)) do
+    LocaleService.with_preferred_locale(recipient) do
       sender = Rails.configuration.x.organisation.do_not_reply_email ||
                Rails.configuration.x.organisation.email
 
@@ -146,7 +146,7 @@ class UserMailer < ActionMailer::Base
     @plan_visibility = Plan::VISIBILITY_MESSAGE[@plan.visibility.to_sym]
     @helpdesk_email = helpdesk_email(org: @plan.org)
 
-    I18n.with_locale(email_locale(@user)) do
+    LocaleService.with_preferred_locale(@user) do
       mail(to: @user.email,
            subject: format(_('DMP Visibility Changed: %{plan_title}'), plan_title: @plan.title))
     end
@@ -175,7 +175,7 @@ class UserMailer < ActionMailer::Base
     @phase_link = url_for(action: 'edit', controller: 'plans', id: @plan.id, phase_id: @phase_id)
     @helpdesk_email = helpdesk_email(org: @plan.org)
 
-    I18n.with_locale(email_locale(@plan.owner)) do
+    LocaleService.with_preferred_locale(@plan.owner) do
       mail(to: @plan.owner.email,
            subject: format(_('%{tool_name}: A new comment was added to %{plan_title}'),
                            tool_name: tool_name, plan_title: @plan.title))
@@ -190,7 +190,7 @@ class UserMailer < ActionMailer::Base
     @username  = @user.name
     @helpdesk_email = helpdesk_email(org: @user.org)
 
-    I18n.with_locale(email_locale(@user)) do
+    LocaleService.with_preferred_locale(@user) do
       mail(to: user.email,
            subject: format(_('Administrator privileges updated in %{tool_name}'),
                            tool_name: tool_name))
@@ -210,7 +210,7 @@ class UserMailer < ActionMailer::Base
 
     recipient = User.find_by(email: @api_client.contact_email) || @api_client.org
 
-    I18n.with_locale(email_locale(recipient)) do
+    LocaleService.with_preferred_locale(recipient) do
       mail(to: @api_client.contact_email,
            subject: format(_('%{tool_name} API changes'), tool_name: tool_name))
     end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -50,6 +50,8 @@ class UserMailer < ActionMailer::Base
     @role       = role
     @user       = user
     @user_email = @user.email
+    # TODO: Should this be `@user.name(false)`? Currently, @username is just being assigned @user.email
+    # (There are several other user.name calls in UserMailer that should be verified as well)
     @username   = @user.name
     @inviter    = inviter
     @link       = url_for(action: 'show', controller: 'plans', id: @role.plan.id)

--- a/app/services/locale_service.rb
+++ b/app/services/locale_service.rb
@@ -33,6 +33,14 @@ class LocaleService
       convert(string: locale, join_char: join_char)
     end
 
+    # Localizes the given block to the recipient's preferred locale.
+    # recipient may be an instance of User or Org (is able to respond to language&.abbreviation)
+    def with_preferred_locale(recipient, &)
+      # Fallback to the current locale, if necessary
+      locale = recipient&.language&.abbreviation || I18n.locale
+      I18n.with_locale(locale, &)
+    end
+
     # Returns an array of string elements
     # The elements are all of the available translations of `text` across all available locales
     def translations_for_all_locales(text)

--- a/app/services/locale_service.rb
+++ b/app/services/locale_service.rb
@@ -41,6 +41,14 @@ class LocaleService
       I18n.with_locale(locale, &)
     end
 
+    # Iterates over each available locale, switching to that locale,
+    # and yields the locale to the given block for translation and processing.
+    def with_each_available_locale
+      I18n.available_locales.each do |locale|
+        I18n.with_locale(locale) { yield(locale) }
+      end
+    end
+
     # Returns an array of string elements
     # The elements are all of the available translations of `text` across all available locales
     def translations_for_all_locales(text)

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,12 +1,10 @@
-<% I18n.available_locales.each do |locale| %>
-	<% I18n.with_locale(locale) do %>
-		<p><%= _("Welcome to %{application_name}") % {application_name: _(ApplicationService.application_name) } %>, <%= @email %>!</p>
+<% LocaleService.with_each_available_locale do |locale| %>
+	<p><%= _("Welcome to %{application_name}") % {application_name: _(ApplicationService.application_name) } %>, <%= @email %>!</p>
 
-		<p><%= _("Please confirm your email address") %>:</p>
+	<p><%= _("Please confirm your email address") %>:</p>
 
-		<p><%= link_to _("Click here to confirm your account"),  confirmation_url(@resource, :confirmation_token => @token) %> (<%= _("or copy") %> <%= confirmation_url(@resource, :confirmation_token => @token) %> <%= _("into your browser") %>).</p>
-		<% unless locale == I18n.available_locales.last %>
-      		<hr>
-    	<% end %>
+	<p><%= link_to _("Click here to confirm your account"),  confirmation_url(@resource, :confirmation_token => @token) %> (<%= _("or copy") %> <%= confirmation_url(@resource, :confirmation_token => @token) %> <%= _("into your browser") %>).</p>
+	<% unless locale == I18n.available_locales.last %>
+		<hr>
 	<% end %>
 <% end %>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,10 +1,11 @@
+<% last_locale = I18n.available_locales.last %>
+
 <% LocaleService.with_each_available_locale do |locale| %>
 	<p><%= _("Welcome to %{application_name}") % {application_name: _(ApplicationService.application_name) } %>, <%= @email %>!</p>
 
 	<p><%= _("Please confirm your email address") %>:</p>
 
 	<p><%= link_to _("Click here to confirm your account"),  confirmation_url(@resource, :confirmation_token => @token) %> (<%= _("or copy") %> <%= confirmation_url(@resource, :confirmation_token => @token) %> <%= _("into your browser") %>).</p>
-	<% unless locale == I18n.available_locales.last %>
-		<hr>
-	<% end %>
+
+	<% concat(tag.hr) unless locale == last_locale %>
 <% end %>

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -6,6 +6,7 @@
   inviter_name = inviter.name
   helpdesk_email = inviter.org&.helpdesk_email ||
                    Rails.configuration.x.organisation.helpdesk_email
+  last_locale = I18n.available_locales.last
 %>
 
 <% LocaleService.with_each_available_locale do |locale| %>
@@ -46,7 +47,5 @@
       }) %>
     </p>
 
-  <% unless locale == I18n.available_locales.last %>
-    <hr>
-  <% end %>
+  <% concat(tag.hr) unless locale == last_locale %>
 <% end %>

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -8,47 +8,45 @@
                    Rails.configuration.x.organisation.helpdesk_email
 %>
 
-<% I18n.available_locales.each do |locale| %>
-  <% I18n.with_locale(locale) do %>
-    <%
-      tool_name = _(ApplicationService.application_name)
-      email_subject = _('Query or feedback related to %{tool_name}') %{ :tool_name => tool_name }
-    %>
+<% LocaleService.with_each_available_locale do |locale| %>
+  <%
+    tool_name = _(ApplicationService.application_name)
+    email_subject = _('Query or feedback related to %{tool_name}') %{ :tool_name => tool_name }
+  %>
+  <p>
+
+
+  </p>
     <p>
-
-
+      <%= _("Hello %{user_name}") %{ :user_name => user_name } %>
     </p>
-      <p>
-        <%= _("Hello %{user_name}") %{ :user_name => user_name } %>
-      </p>
-      <p>
-        <%= _("Your colleague %{inviter_name} has invited you to contribute to "\
-                " their Data Management Plan in %{tool_name}") % {
-          tool_name: tool_name,
-          inviter_name: inviter_name
-        } %>
-      </p>
-      <p>
-        <%= sanitize(_('%{click_here} to accept the invitation, (or copy %{link} into your browser). If you don\'t want to accept the invitation, please ignore this email.') % {
-          click_here: link_to(_('Click here'), link), link: link
-        }) %>
-      </p>
-      <p>
-        <%= _('All the best') %>
-        <br />
-        <%= _('The %{tool_name} team') %{:tool_name => tool_name} %>
-      </p>
-      <p>
-        <%= _('Please do not reply to this email.') %>&nbsp;
-        <%= sanitize(_('If you have any questions or need help, please contact us at %{helpdesk_email} or visit %{contact_us_url}') % {
-          helpdesk_email: mail_to(helpdesk_email, helpdesk_email,
-          subject: email_subject),
-          contact_us_url: link_to(contact_us, contact_us)
-        }) %>
-      </p>
+    <p>
+      <%= _("Your colleague %{inviter_name} has invited you to contribute to "\
+              " their Data Management Plan in %{tool_name}") % {
+        tool_name: tool_name,
+        inviter_name: inviter_name
+      } %>
+    </p>
+    <p>
+      <%= sanitize(_('%{click_here} to accept the invitation, (or copy %{link} into your browser). If you don\'t want to accept the invitation, please ignore this email.') % {
+        click_here: link_to(_('Click here'), link), link: link
+      }) %>
+    </p>
+    <p>
+      <%= _('All the best') %>
+      <br />
+      <%= _('The %{tool_name} team') %{:tool_name => tool_name} %>
+    </p>
+    <p>
+      <%= _('Please do not reply to this email.') %>&nbsp;
+      <%= sanitize(_('If you have any questions or need help, please contact us at %{helpdesk_email} or visit %{contact_us_url}') % {
+        helpdesk_email: mail_to(helpdesk_email, helpdesk_email,
+        subject: email_subject),
+        contact_us_url: link_to(contact_us, contact_us)
+      }) %>
+    </p>
 
-    <% unless locale == I18n.available_locales.last %>
-      <hr>
-    <% end %>
+  <% unless locale == I18n.available_locales.last %>
+    <hr>
   <% end %>
 <% end %>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -5,7 +5,7 @@
   helpdesk_email = user.org&.helpdesk_email ||
                    Rails.configuration.x.organisation.helpdesk_email
 %>
-<% I18n.with_locale(user.language&.abbreviation || I18n.locale) do %>
+<% LocaleService.with_preferred_locale(user) do %>
   <%
     tool_name = _(ApplicationService.application_name)
     email_subject = _('Query or feedback related to %{tool_name}') %{ :tool_name => tool_name }

--- a/app/views/user_mailer/sharing_notification.html.erb
+++ b/app/views/user_mailer/sharing_notification.html.erb
@@ -2,10 +2,8 @@
   <%= _('Hello %{username}') %{ username: @username } %>
 </p>
 <p>
-  <%= _("Your colleague %{inviter_name} has invited you to contribute to
-          their Data Management Plan in %{tool_name}") % {
-            inviter_name: @inviter.name(false), tool_name: tool_name
-            } %>
+  <%= _("Your colleague %{inviter_name} has invited you to contribute to their Data Management Plan in %{tool_name}") % {
+        inviter_name: @inviter.name(false), tool_name: tool_name } %>
 </p>
 <p>
   <%= sanitize(_('%{click_here} to accept the invitation, (or copy %{link} into your browser). If you don\'t want to accept the invitation, please ignore this email.') % { 

--- a/app/views/user_mailer/welcome_notification.html.erb
+++ b/app/views/user_mailer/welcome_notification.html.erb
@@ -1,3 +1,5 @@
+<% last_locale = I18n.available_locales.last %>
+
 <% LocaleService.with_each_available_locale do |locale| %>
   <% @email_subject  = format(_('Query or feedback related to %{tool_name}'), tool_name: _(tool_name)) %>
   <p>
@@ -14,7 +16,6 @@
   <p>
     <%= _('You may change your notification preferences on your profile page.') %>&nbsp;<%= _('Please do not reply to this email.') %>
   </p>
-    <% unless locale == I18n.available_locales.last %>
-        <hr>
-    <% end %>
+
+  <% concat(tag.hr) unless locale == last_locale %>
 <% end %>

--- a/app/views/user_mailer/welcome_notification.html.erb
+++ b/app/views/user_mailer/welcome_notification.html.erb
@@ -1,22 +1,20 @@
-<% I18n.available_locales.each do |locale| %>
-	<% I18n.with_locale(locale) do %>
-    <% @email_subject  = format(_('Query or feedback related to %{tool_name}'), tool_name: _(tool_name)) %>
-    <p>
-      <%= _('Welcome to %{tool_name}, %{username}') %{ tool_name: _(tool_name), username: @username } %>
-    </p>
-    <p>
-      <%= sanitize(_('%{tool_name} will help you to develop your Data Management Plan. If you have any queries or feedback as you use the tool, please contact us at %{helpdesk_email} or visit %{contact_us}') %{ tool_name: _(tool_name), helpdesk_email: mail_to( helpdesk_email, helpdesk_email, subject: @email_subject), contact_us: link_to(@contact_us, @contact_us) }) %>
-    </p>
-    <p>
-      <%= _('All the best') %>
-      <br />
-      <%= _('The %{tool_name} team') %{ tool_name: _(tool_name) } %>
-    </p>
-    <p>
-      <%= _('You may change your notification preferences on your profile page.') %>&nbsp;<%= _('Please do not reply to this email.') %>
-    </p>
-      <% unless locale == I18n.available_locales.last %>
-          <hr>
-      <% end %>
-  <% end %>
+<% LocaleService.with_each_available_locale do |locale| %>
+  <% @email_subject  = format(_('Query or feedback related to %{tool_name}'), tool_name: _(tool_name)) %>
+  <p>
+    <%= _('Welcome to %{tool_name}, %{username}') %{ tool_name: _(tool_name), username: @username } %>
+  </p>
+  <p>
+    <%= sanitize(_('%{tool_name} will help you to develop your Data Management Plan. If you have any queries or feedback as you use the tool, please contact us at %{helpdesk_email} or visit %{contact_us}') %{ tool_name: _(tool_name), helpdesk_email: mail_to( helpdesk_email, helpdesk_email, subject: @email_subject), contact_us: link_to(@contact_us, @contact_us) }) %>
+  </p>
+  <p>
+    <%= _('All the best') %>
+    <br />
+    <%= _('The %{tool_name} team') %{ tool_name: _(tool_name) } %>
+  </p>
+  <p>
+    <%= _('You may change your notification preferences on your profile page.') %>&nbsp;<%= _('Please do not reply to this email.') %>
+  </p>
+    <% unless locale == I18n.available_locales.last %>
+        <hr>
+    <% end %>
 <% end %>

--- a/spec/mailers/user_invitation_mailer_spec.rb
+++ b/spec/mailers/user_invitation_mailer_spec.rb
@@ -6,26 +6,46 @@ require 'rails_helper'
 RSpec.describe 'User invitation email', type: :mailer do
   describe 'Invitation Email to User Not in DB' do
     let(:inviter) { create(:user) }
-    let(:invitee) { User.new(email: 'newuser@example.com') }
+    let(:invitee_email) { 'newuser@example.com' }
+    # For ensuring I18n.locale value remains intact.
+    let(:original_locale) { I18n.locale }
 
     before do
       ActionMailer::Base.deliveries.clear
+      # TODO: Update spec/support/locales.rb to actually use DMP Assistant's locales.
+      @original_locales = I18n.available_locales
+      I18n.available_locales = %i[en-CA fr-CA]
     end
 
-    it 'sends an invitation email with a bilingual subject' do
-      # Simulate Devise invitation context
-      invitee.invitation_token = Devise.friendly_token
-      invitee.invited_by = inviter
-      invitee.invited_by_type = 'User'
+    after do
+      I18n.available_locales = @original_locales
+    end
 
-      # Trigger mailer directly
-      # deliver_invitation overrides devise_invitable
-      invitee.deliver_invitation
-
+    it 'sends an invitation with the expected content' do
+      invite_new_user
       mail = ActionMailer::Base.deliveries.last
-      expect(mail.to).to include('newuser@example.com')
-      expect(mail.subject).to include('A Data Management Plan in DMP Assistant has been shared with you')
-      expect(mail.subject).to include("Un plan de gestion des données dans l'Assistant PGD a été partagé avec vous")
+      expect(mail.to).to include(invitee_email)
+      # The subject line is bilingual
+      expect(mail.subject).to eq('A Data Management Plan in DMP Assistant has been shared with you / ' \
+                                 "Un plan de gestion des données dans l'Assistant PGD a été partagé avec vous")
+      # The body is bilingual
+      # (TODO: Fix this generic name greeting)
+      expect(mail.body).to include('Hello First Name Surname')
+      expect(mail.body).to include('Bonjour First Name Surname')
+      # I18n.locale value remains intact
+      expect(I18n.locale).to eq(original_locale)
     end
+  end
+
+  private
+
+  def invite_new_user
+    # This code is copied from RolesController#create to simulate its User.invite! behavior.
+    # The controller action is large, so copying the code here is a pragmatic testing approach
+    User.invite!({ email: invitee_email,
+                   firstname: _('First Name'),
+                   surname: _('Surname'),
+                   org: inviter.org },
+                 inviter)
   end
 end

--- a/spec/mailers/user_invitation_mailer_spec.rb
+++ b/spec/mailers/user_invitation_mailer_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# spec/mailers/user_invitation_mailer_spec.rb
+require 'rails_helper'
+
+RSpec.describe 'User invitation email', type: :mailer do
+  describe 'Invitation Email to User Not in DB' do
+    let(:inviter) { create(:user) }
+    let(:invitee) { User.new(email: 'newuser@example.com') }
+
+    before do
+      ActionMailer::Base.deliveries.clear
+    end
+
+    it 'sends an invitation email with a bilingual subject' do
+      # Simulate Devise invitation context
+      invitee.invitation_token = Devise.friendly_token
+      invitee.invited_by = inviter
+      invitee.invited_by_type = 'User'
+
+      # Trigger mailer directly
+      # deliver_invitation overrides devise_invitable
+      invitee.deliver_invitation
+
+      mail = ActionMailer::Base.deliveries.last
+      expect(mail.to).to include('newuser@example.com')
+      expect(mail.subject).to include('A Data Management Plan in DMP Assistant has been shared with you')
+      expect(mail.subject).to include("Un plan de gestion des données dans l'Assistant PGD a été partagé avec vous")
+    end
+  end
+end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,4 +1,3 @@
-#
 # frozen_string_literal: true
 
 # spec/mailers/user_mailer_spec.rb
@@ -63,31 +62,6 @@ RSpec.describe UserMailer, type: :mailer do
         Rails.configuration.x.application.name = 'Bar'
         expect(mail.subject).to include('Un plan de gestion des données dans Bar a été partagé avec vous')
       end
-    end
-  end
-
-  describe 'Invitation Email to User Not in DB' do
-    let(:inviter) { create(:user) }
-    let(:invitee) { User.new(email: 'newuser@example.com') }
-
-    before do
-      ActionMailer::Base.deliveries.clear
-    end
-
-    it 'sends an invitation email with a bilingual subject' do
-      # Simulate Devise invitation context
-      invitee.invitation_token = Devise.friendly_token
-      invitee.invited_by = inviter
-      invitee.invited_by_type = 'User'
-
-      # Trigger mailer directly
-      # deliver_invitation overrides devise_invitable
-      invitee.deliver_invitation
-
-      mail = ActionMailer::Base.deliveries.last
-      expect(mail.to).to include('newuser@example.com')
-      expect(mail.subject).to include('A Data Management Plan in DMP Assistant has been shared with you')
-      expect(mail.subject).to include("Un plan de gestion des données dans l'Assistant PGD a été partagé avec vous")
     end
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -4,64 +4,76 @@
 require 'rails_helper'
 
 RSpec.describe UserMailer, type: :mailer do
+  # For ensuring I18n.locale value remains intact.
+  let(:original_locale) { I18n.locale }
+
+  before(:all) do
+    # TODO: Update spec/support/locales.rb to actually use DMP Assistant's locales.
+    @original_locales = I18n.available_locales
+    I18n.available_locales = %i[en-CA fr-CA]
+  end
+
+  after(:all) do
+    I18n.available_locales = @original_locales
+  end
+
   describe 'UserMailer Welcome Email' do
     let(:user) { create(:user) }
 
     context '.welcome_notification email contents' do
       let(:mail) { UserMailer.welcome_notification(user) }
 
-      it 'renders the correct email subject' do
+      it 'Renders the bilingual welcome message as expected' do
+        expect(mail.to).to include(user.email)
+        # Email subject is bilingual
         expect(mail.subject).to eq("Welcome to DMP Assistant / Bienvenue sur l'Assistant PGD")
+        # Email body has both English and French sections
+        expect(mail.body).to include('Welcome to DMP Assistant')
+        # Use Nokogiri to escape HTML (')
+        html = Nokogiri::HTML(mail.body.to_s)
+        expect(html.text).to include("Bienvenue sur l'Assistant PGD")
+        # I18n.locale value remains intact
+        expect(I18n.locale).to eq(original_locale)
       end
     end
   end
 
   describe 'UserMailer Sharing Email' do
-    let!(:org) { create(:org, :organisation, name: 'Test org') }
+    let!(:org)     { create(:org, :organisation, name: 'Test org') }
     let!(:inviter) { create(:user, org: org) }
 
-    context 'when the user language is set to English' do
-      before do
-        @original_locale = I18n.locale
-        I18n.locale = :'en-CA'
-      end
-
-      after do
-        I18n.locale = @original_locale
-      end
-
-      let!(:user) { create(:user, language: create(:language, abbreviation: 'en-CA'), org: org) }
-      let!(:plan) { create(:plan, org: org, visibility: 'publicly_visible') }
+    shared_examples 'localized .sharing_notification email' do |expected_subject, expected_body|
+      # :role and :mail depend on :user and :plan, so define them here
       let!(:role) { create(:role, :creator, :active, plan: plan, user: user) }
+      let(:mail)  { UserMailer.sharing_notification(role, user, inviter: inviter) }
 
-      let!(:mail) { UserMailer.sharing_notification(role, user, inviter: inviter) }
-
-      it 'renders the email subject in English' do
-        Rails.configuration.x.application.name = 'Foo'
-        expect(mail.subject).to include('A Data Management Plan in Foo has been shared with you')
+      it 'renders the expected email content' do
+        expect(mail.to).to include(user.email)
+        expect(mail.subject).to eq(expected_subject)
+        expect(mail.body).to include(expected_body)
+        # localized email has not changed I18n.locale
+        expect(I18n.locale).to eq(original_locale)
       end
     end
 
-    context 'when the user language is set to French' do
-      before do
-        @original_locale = I18n.locale
-        I18n.locale = :'fr-CA'
-      end
+    let!(:plan) { create(:plan, org: org, visibility: 'publicly_visible') }
 
-      after do
-        I18n.locale = @original_locale
-      end
+    context 'en-CA locale' do
+      let!(:language) { create(:language, abbreviation: 'en-CA') }
+      let!(:user)     { create(:user, language: language, org: org) }
 
-      let!(:user) { create(:user, language: create(:language, abbreviation: 'fr-CA'), org: org) }
-      let!(:plan) { create(:plan, org: org, visibility: 'publicly_visible') }
-      let!(:role) { create(:role, :creator, :active, plan: plan, user: user) }
+      include_examples 'localized .sharing_notification email',
+                       'A Data Management Plan in DMP Assistant has been shared with you',
+                       'has invited you to contribute'
+    end
 
-      let!(:mail) { UserMailer.sharing_notification(role, user, inviter: inviter) }
+    context 'fr-CA locale' do
+      let!(:language) { create(:language, abbreviation: 'fr-CA') }
+      let!(:user)     { create(:user, language: language, org: org) }
 
-      it 'renders the email subject in French' do
-        Rails.configuration.x.application.name = 'Bar'
-        expect(mail.subject).to include('Un plan de gestion des données dans Bar a été partagé avec vous')
-      end
+      include_examples 'localized .sharing_notification email',
+                       'Un plan de gestion des données dans Assistant PGD a été partagé avec vous',
+                       'Si vous ne souhaitez pas accepter l’invitation'
     end
   end
 end

--- a/spec/services/locale_service_spec.rb
+++ b/spec/services/locale_service_spec.rb
@@ -57,6 +57,43 @@ RSpec.describe LocaleService do
     end
   end
 
+  describe '#with_preferred_locale(recipient, &)' do
+    let(:recipient) { create(:user, language: @default) }
+    it "uses the recipient's preferred locale when it is different from I18n.locale. " \
+       'I18n.locale is restored after completion.' do
+      current_locale = I18n.locale
+
+      expect(I18n.locale).to_not eq(recipient.language.abbreviation)
+      described_class.with_preferred_locale(recipient) do
+        # I18n.locale == recipient.language.abbreviation within the `with_preferred_locale` block
+        expect(I18n.locale.to_s).to eq(recipient.language.abbreviation)
+      end
+      # I18n.locale is restored after the `with_preferred_locale` block
+      expect(I18n.locale).to eq(current_locale)
+    end
+
+    it "Uses I18n.locale when recipient doesn't respond to `.language.abbreviation`." do
+      current_locale = I18n.locale
+
+      described_class.with_preferred_locale(nil) do
+        # I18n.locale doesn't change when recipient.language.abbreviation is falsy
+        expect(I18n.locale).to eq(current_locale)
+      end
+    end
+  end
+
+  describe '#with_each_available_locale' do
+    it 'yields once for each available locale, and restores I18n.locale after completion.' do
+      yielded_locales = []
+
+      LocaleService.with_each_available_locale { |locale| yielded_locales << locale }
+
+      expect(yielded_locales).to eq(I18n.available_locales)
+      # Verify .count > 1 to increase our testing confidence
+      expect(yielded_locales.count).to be > 1
+    end
+  end
+
   describe '#translations_for_all_locales(string)' do
     before do
       # Override `I18n.available_locales` value to match DMP Assistant


### PR DESCRIPTION
## Changes proposed in this PR:
[Refactor I18n.with_locale(email_locale(x))](https://github.com/portagenetwork/roadmap/commit/c401391f49f208aa77def1539c88b73b6506e9e5)
- Extracts logic for determining a recipient's preferred locale into `LocaleService.with_preferred_locale`. This change abstracts `I18n.with_locale(recipient.language.abbreviation)` calls.

[Refactor locale iteration into with_each_available_locale](https://github.com/portagenetwork/roadmap/commit/f8e1ee9d9a855495e636034c9dc26a916eeeb71e)
- This change introduces `LocaleService.with_each_available_locale`, which encapsulates the common pattern of iterating over `I18n.available_locales` and yielding each locale within `I18n.with_locale`.
- By extracting this logic, we reduce repetition and improve readability by eliminating the need for nested locale iteration blocks.

[Refactor conditional hr tags in mailer views](https://github.com/portagenetwork/roadmap/pull/1111/commits/84e5c22428815a452646a6536b228b931e0bb302)

[Add Tests for new LocaleService methods](https://github.com/portagenetwork/roadmap/pull/1111/commits/3e55fe77951020df46a4522a707c4943688ed9a3)
- Adds RSpec tests for the following methods:
  - `LocaleService.with_preferred_locale`
  - `LocaleServcie.with_each_available_locale`

[Move invitation email tests to separate _spec file](https://github.com/portagenetwork/roadmap/pull/1111/commits/41cd5dbaeecbc724b34cc126aa59f37aee3afe4c)

[Update user_invitation_mailer_spec.rb](https://github.com/portagenetwork/roadmap/pull/1111/commits/9a467fb28b0658078e56ce652c9d3fbdecb63420)
- Simplify the logic for mocking the delivery of the invitation email
- Add the `invite_new_user` method to more closely emulate the `User.invite!` behaviour within `RolesController#create`
- Add a test to verify that the email body is bilingual

[Fix for sharing_notification string spacing to enable translation](https://github.com/portagenetwork/roadmap/pull/1111/commits/dfcfe6356e374c83c6071127b9ac374c318d39e9)
- The translation for this string existed on translation.io, however it was not translating. This change simply removes the extra/unnecessary whitespace and newline to avoid translation issues.

[Refactor and add coverage for UserMailer tests](https://github.com/portagenetwork/roadmap/pull/1111/commits/526c9e2a4165b22229fdc95fc48dece1b05d11e5)
- Consolidated duplicate `UserMailer.sharing_notification` code via `shared_examples`
- Added coverage to also test/verify subject lines and body content of delivered emails
- Set I18n.available_locales temporarily to simulate application environment
- Ensured I18n.locale remains unchanged after mail delivery