### PR TITLE
Fix flaky tests from `application.name` overriding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,9 @@
 
  - Enable translation of emails to recipient's preferred locale [#1100](https://github.com/portagenetwork/roadmap/pull/1100)
 
- - Use "Hello ${email}" When Addressing User in Devise invitation_instructions Email Body [1098](https://github.com/portagenetwork/roadmap/pull/1098)
+ - Use "Hello ${email}" When Addressing User in Devise invitation_instructions Email Body [#1098](https://github.com/portagenetwork/roadmap/pull/1098)
+
+ - Fix flaky tests from `application.name` overriding [#1116](https://github.com/portagenetwork/roadmap/pull/1116)
 
 ### Changed
 

--- a/spec/services/application_service_spec.rb
+++ b/spec/services/application_service_spec.rb
@@ -4,6 +4,12 @@ require 'rails_helper'
 
 RSpec.describe ApplicationService do
   describe '#application_name' do
+    around do |example|
+      original_name = Rails.configuration.x.application[:name]
+      example.run
+      Rails.configuration.x.application[:name] = original_name
+    end
+
     it 'returns the application name defined in the dmproadmap.rb initializer' do
       Rails.configuration.x.application.name = 'Foo'
       expect(described_class.application_name).to eql('Foo')

--- a/spec/services/external_apis/base_service_spec.rb
+++ b/spec/services/external_apis/base_service_spec.rb
@@ -45,6 +45,12 @@ RSpec.describe ExternalApis::BaseService do
 
   context 'private methods' do
     context '#app_name' do
+      around do |example|
+        original_name = Rails.configuration.x.application[:name]
+        example.run
+        Rails.configuration.x.application[:name] = original_name
+      end
+
       it 'defaults to the Rails.application.class.name' do
         Rails.configuration.x.application.delete(:name)
         expected = ApplicationService.application_name


### PR DESCRIPTION
## Changes proposed in this PR:
Both changed files were reassigning `Rails.configuration.x.application.name = 'Foo'`, which caused config leakage into other tests and led to flakiness.

These changes wrap the affected examples in `around` blocks that capture and restore the original `Rails.configuration.x.application[:name]` value, ensuring test isolation and preventing cross-test contamination.

NOTE: `spec/services/external_apis/base_service_spec.rb` is still overriding other config values (e.g. `Rails.configuration.x.organisation.helpdesk_email = 'Foo'`). These will have to also be addressed in the near future.