### PR TITLE
Clear `confirmation_token` when super admin unconfirms a user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
  - Add custom validator for `Org.feedback_msg` interpolation [#1068](https://github.com/portagenetwork/roadmap/pull/1068)
 
- - Add Functionality Allowing Super Admins to Confirm/Unconfirm User Emails [#1009](https://github.com/portagenetwork/roadmap/pull/1009)
+ - Add Functionality Allowing Super Admins to Confirm/Unconfirm User Emails
+   - [#1009](https://github.com/portagenetwork/roadmap/pull/1009)
+   - [#1120](https://github.com/portagenetwork/roadmap/pull/1120)
 
  - Added Arbutus Cloud and UVic logos to footer and added institutional sign in explanation [#1063](https://github.com/portagenetwork/roadmap/pull/1063)
 

--- a/app/controllers/super_admin/users_controller.rb
+++ b/app/controllers/super_admin/users_controller.rb
@@ -141,8 +141,8 @@ module SuperAdmin
     def handle_confirmed_at_param(attrs)
       # NOTE: The :confirmed_at param is controlled by a check_box in the form
       # `app/views/super_admin/users/_email_confirmation_status.html.erb`.
-      # When the checkbox is checked, Rails submits the string '1' (indicating "confirmed").
-      # When unchecked, it submits the string '0' (indicating "unconfirmed").
+      # attrs[:confirmed_at] == '1' corresponds to "confirm user"
+      # attrs[:confirmed_at] == '0' corresponds to "unconfirm user"
 
       # if an unconfirmed email is now being confirmed
       if !@user.confirmed? && attrs[:confirmed_at] == '1'
@@ -150,6 +150,8 @@ module SuperAdmin
       # elsif a confirmed email is now being unconfirmed and the user is not a super admin
       elsif @user.confirmed? && attrs[:confirmed_at] == '0' && !@user.can_super_admin?
         attrs[:confirmed_at] = nil
+        # Nullify any outstanding confirmation_token to prevent reuse
+        attrs[:confirmation_token] = nil
       else
         # else delete the param
         # (keeps value nil for unconfirmed user and maintains previous Time value for confirmed user)

--- a/spec/controllers/super_admin/users_controller_spec.rb
+++ b/spec/controllers/super_admin/users_controller_spec.rb
@@ -21,19 +21,22 @@ RSpec.describe SuperAdmin::UsersController, type: :controller do
 
     context 'when unconfirming a confirmed user' do
       before do
-        user.update(confirmed_at: Time.current)
+        user.confirm
       end
 
       it 'sets confirmed_at to nil' do
+        expect(user.confirmed_at).to_not be_nil
+        expect(user.confirmation_token).to_not be_nil
         put :update, params: { id: user.id, user: { confirmed_at: '0' } }
         user.reload
         expect(user.confirmed_at).to be_nil
+        expect(user.confirmation_token).to be_nil
       end
     end
 
     context 'when update will not affect confirmation status' do
       it 'does not update confirmed_at value for an already confirmed user' do
-        # (usec: 0) removes mircoseconds to better enable comparison
+        # (usec: 0) removes microseconds to better enable comparison
         user.update(confirmed_at: Time.current.change(usec: 0))
         original_confirmed_at = user.confirmed_at
         put :update, params: { id: user.id, user: { firstname: 'NewName', confirmed_at: '1' } }


### PR DESCRIPTION
Fixes #1006 (addition)

Changes proposed in this PR:
- This change improves by security by nullifying the `confirmation_token` when unconfirming a user. If the `confirmation_token` persists after unconfirming a user, the token would still be valid and could allow anyone with access to the old confirmation link to re-confirm the account going through the proper process.
