### PR TITLE
Render Correct `helpdesk_email` (i.e. 'dmp-assistant@tech.alliancecan.ca') in Email Bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
 
  - Fix flaky tests from `application.name` overriding [#1116](https://github.com/portagenetwork/roadmap/pull/1116)
 
+ - Render Correct helpdesk_email in Email Bodies [#1121](https://github.com/portagenetwork/roadmap/pull/1121)
+
 ### Changed
 
  - Activate requests to external ROR API [#1109](https://github.com/portagenetwork/roadmap/pull/1109)

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -9,7 +9,7 @@ module MailerHelper
   end
 
   def helpdesk_email(org: nil)
-    org&.helpdesk_email || Rails.configuration.x.organisation.helpdesk_email
+    org&.helpdesk_email.presence || Rails.configuration.x.organisation.helpdesk_email
   end
 
   # Returns an unordered HTML list with the permissions associated to the user passed

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -17,7 +17,6 @@ class UserMailer < ActionMailer::Base
     # Override the default Rails route helper for the contact_us page IF an alternate contact_us
     # url was defined in the dmproadmap.rb initializer file
     @contact_us     = Rails.application.config.x.organisation.contact_us_url || contact_us_url
-    @helpdesk_email = helpdesk_email(org: @user.org)
 
     mail(to: @user.email,
          subject: "Welcome to DMP Assistant / Bienvenue sur l'Assistant PGD")
@@ -35,7 +34,6 @@ class UserMailer < ActionMailer::Base
     @recipient_name = @data['name'].to_s
     @message        = @data['message'].to_s
     @answer_text    = @options_string.to_s
-    @helpdesk_email = helpdesk_email(org: @user.org)
 
     recipient = User.find_by(email: data['email'])
 
@@ -55,7 +53,6 @@ class UserMailer < ActionMailer::Base
     @username   = @user.name
     @inviter    = inviter
     @link       = url_for(action: 'show', controller: 'plans', id: @role.plan.id)
-    @helpdesk_email = helpdesk_email(org: @inviter.org)
 
     LocaleService.with_preferred_locale(@role.user) do
       mail(to: @role.user.email,
@@ -72,7 +69,6 @@ class UserMailer < ActionMailer::Base
     @user       = user
     @recepient = @role.user
     @messaging = role_text(@role)
-    @helpdesk_email = helpdesk_email(org: @user.org)
 
     LocaleService.with_preferred_locale(@recepient) do
       mail(to: @recepient.email,
@@ -87,7 +83,6 @@ class UserMailer < ActionMailer::Base
     @user         = user
     @plan         = plan
     @current_user = current_user
-    @helpdesk_email = helpdesk_email(org: @plan.org)
 
     LocaleService.with_preferred_locale(@user) do
       mail(to: @user.email,
@@ -105,7 +100,6 @@ class UserMailer < ActionMailer::Base
     @recipient_name = @recipient.name(false)
     @requestor_name = @user.name(false)
     @plan_name      = @plan.title
-    @helpdesk_email = helpdesk_email(org: @plan.org)
 
     LocaleService.with_preferred_locale(@recipient) do
       mail(to: @recipient.email,
@@ -124,7 +118,6 @@ class UserMailer < ActionMailer::Base
     @plan           = plan
     @phase          = @plan.phases.first
     @plan_name      = @plan.title
-    @helpdesk_email = helpdesk_email(org: @plan.org)
 
     LocaleService.with_preferred_locale(recipient) do
       sender = Rails.configuration.x.organisation.do_not_reply_email ||
@@ -146,7 +139,6 @@ class UserMailer < ActionMailer::Base
     @plan            = plan
     @plan_title      = @plan.title
     @plan_visibility = Plan::VISIBILITY_MESSAGE[@plan.visibility.to_sym]
-    @helpdesk_email = helpdesk_email(org: @plan.org)
 
     LocaleService.with_preferred_locale(@user) do
       mail(to: @user.email,
@@ -175,7 +167,6 @@ class UserMailer < ActionMailer::Base
     @section_title   = @question.section.title
     @phase_id        = @question.section.phase.id
     @phase_link = url_for(action: 'edit', controller: 'plans', id: @plan.id, phase_id: @phase_id)
-    @helpdesk_email = helpdesk_email(org: @plan.org)
 
     LocaleService.with_preferred_locale(@plan.owner) do
       mail(to: @plan.owner.email,
@@ -190,7 +181,6 @@ class UserMailer < ActionMailer::Base
 
     @user      = user
     @username  = @user.name
-    @helpdesk_email = helpdesk_email(org: @user.org)
 
     LocaleService.with_preferred_locale(@user) do
       mail(to: user.email,
@@ -207,8 +197,6 @@ class UserMailer < ActionMailer::Base
     @api_docs = Rails.configuration.x.application.api_documentation_urls[:v1]
 
     @name = @api_client.contact_name.present? ? @api_client.contact_name : @api_client.contact_email
-
-    @helpdesk_email = helpdesk_email(org: @api_client.org)
 
     recipient = User.find_by(email: @api_client.contact_email) || @api_client.org
 

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -3,8 +3,7 @@
   contact_us = (Rails.configuration.x.organisation.contact_us_url || contact_us_url)
   inviter =  @resource.invited_by
   inviter_name = inviter.name
-  helpdesk_email = inviter.org&.helpdesk_email ||
-                   Rails.configuration.x.organisation.helpdesk_email
+  helpdesk_email = Rails.configuration.x.organisation.helpdesk_email
   last_locale = I18n.available_locales.last
 %>
 

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -4,8 +4,6 @@
   contact_us = Rails.configuration.x.organisation.contact_us_url || contact_us_url
   email_subject = _('Query or feedback related to %{tool_name}') %{ :tool_name => tool_name }
   user = User.find_by(email: @resource.email)
-  helpdesk_email = user.org&.helpdesk_email ||
-                   Rails.configuration.x.organisation.helpdesk_email
   %>
 
 <p>

--- a/app/views/user_mailer/_email_signature.html.erb
+++ b/app/views/user_mailer/_email_signature.html.erb
@@ -1,6 +1,7 @@
 <%
   email_subject = email_subject || _('Query or feedback related to %{tool_name}') %{ tool_name: tool_name }
   allow_change_prefs = allow_change_prefs.nil? ? true : allow_change_prefs
+  helpdesk_email = Rails.configuration.x.organisation.helpdesk_email
 
   # Override the default Rails route helper for the contact_us page IF an alternate contact_us url was defined
   # in the dmproadmap.rb initializer
@@ -17,7 +18,7 @@
   <% end %>
   <%= _('Please do not reply to this email.') %>
   <%= sanitize(_('If you have any questions or need help, please contact us at %{helpdesk_email} or visit %{contact_us}') % {
-    helpdesk_email: mail_to(@helpdesk_email, @helpdesk_email,
+    helpdesk_email: mail_to(helpdesk_email, helpdesk_email,
                       subject: email_subject),
     contact_us: link_to(contact_us, contact_us)
   }) %>

--- a/app/views/user_mailer/api_credentials.html.erb
+++ b/app/views/user_mailer/api_credentials.html.erb
@@ -1,3 +1,5 @@
+<% helpdesk_email = Rails.configuration.x.organisation.helpdesk_email %>
+
 <p>
   <%= _("Hello %{name},") %{
     name: @name }

--- a/app/views/user_mailer/welcome_notification.html.erb
+++ b/app/views/user_mailer/welcome_notification.html.erb
@@ -1,4 +1,7 @@
-<% last_locale = I18n.available_locales.last %>
+<%
+  helpdesk_email = Rails.configuration.x.organisation.helpdesk_email
+  last_locale = I18n.available_locales.last
+%>
 
 <% LocaleService.with_each_available_locale do |locale| %>
   <% @email_subject  = format(_('Query or feedback related to %{tool_name}'), tool_name: _(tool_name)) %>


### PR DESCRIPTION
Changes proposed in this PR:

[Refactor helpdesk_email](https://github.com/portagenetwork/roadmap/pull/1121/commits/419b2f443a9225b59608db37c08077929815d6d1)
- If `org&.helpdesk_email` was an empty string, then the previous logic of `org&.helpdesk_email || Rails.configuration.x.organisation.helpdesk_email`  would return an empty string (i.e.  `"" || dmp-assistant@tech.alliancecan.ca` returns `""`). `org&.helpdesk_email.presence || Rails.configuration.x.organisation.helpdesk_email` returns the intended `helpdesk_email` value.

[MailerHelper.helpdesk_email to `Rails.configuration.x.organisation.helpdesk_email` changes](https://github.com/portagenetwork/roadmap/pull/1121/commits/c92027e28051fdd5fe945b106733bdbbe49c12eb) 
- `MailerHelper.helpdesk_email` only uses `Rails.configuration.x.organisation.helpdesk_email` as a fallback, and instead prioritises `org&.helpdesk_email`, which could be any org's helpdesk_email. These changes directly use `Rails.configuration.x.organisation.helpdesk_email` (i.e. 'dmp-assistant@tech.alliancecan.ca') rather than `MailerHelper.helpdesk_email`.

- Breakdown of changes:
  - `app/mailers/user_mailer.rb`:
    - `MailerHelper.helpdesk_email` has been removed from all of the `UserMailer` methods
    - For `UserMailer.welcome_notification`, the updated `helpdesk_email` assignment has been moved to `app/views/user_mailer/welcome_notification.html.erb`
    - For `UserMailer.api_credentials`, the updated `helpdesk_email` assignment has been moved to `app/views/user_mailer/api_credentials.html.erb`
    - With the exception of the above two, all of the other `UserMailer` methods only reference `helpdesk_email` within `app/views/user_mailer/_email_signature.html.erb`. By assigning `helpdesk_email` within the `email_signature` partial, it is no longer needed in the `UserMailer` methods.
  - Equivalent changes to the `helpdesk_email` logic have been performed in `app/views/devise/mailer/invitation_instructions.html.erb` and `app/views/devise/mailer/reset_password_instructions.html.erb`