### PR TITLE
Enable translation of permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Unreleased]
+
+## Added 
+
+
+## Fixed
+ - Fix Translation of Permissions in Email [#1123](https://github.com/portagenetwork/roadmap/pull/1123)
+
+## Changed
+
+
+## Dependency Updates
+
 ## [4.1.1+portage-4.4.0]
 
 ### Added

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -13,7 +13,6 @@ class UserMailer < ActionMailer::Base
   def welcome_notification(user)
     @user           = user
     @username       = @user.name
-    @email_subject  = format(_('Query or feedback related to %{tool_name}'), tool_name: tool_name)
     # Override the default Rails route helper for the contact_us page IF an alternate contact_us
     # url was defined in the dmproadmap.rb initializer file
     @contact_us     = Rails.application.config.x.organisation.contact_us_url || contact_us_url
@@ -68,7 +67,6 @@ class UserMailer < ActionMailer::Base
     @plan_title = @role.plan.title
     @user       = user
     @recepient = @role.user
-    @messaging = role_text(@role)
 
     LocaleService.with_preferred_locale(@recepient) do
       mail(to: @recepient.email,

--- a/app/views/user_mailer/permissions_change_notification.html.erb
+++ b/app/views/user_mailer/permissions_change_notification.html.erb
@@ -1,12 +1,15 @@
 <p>
   <%= _('Hello %{recepientname}') %{ recepientname: @recepient.name } %>
 </p>
+
+<% messaging = role_text(@role) %>
+
 <p>
   <%= _('Your permissions relating to %{plan_title} have changed. You now have %{type} access. This means you can %{placeholder1} %{placeholder2}') % {
      plan_title: @plan_title,
-     type: @messaging[:type],
-     placeholder1: @messaging[:placeholder1],
-     placeholder2: @messaging[:placeholder2]
+     type: messaging[:type],
+     placeholder1: messaging[:placeholder1],
+     placeholder2: messaging[:placeholder2]
     } %>
 </p>
 <%= render partial: 'email_signature' %>

--- a/app/views/user_mailer/permissions_change_notification.html.erb
+++ b/app/views/user_mailer/permissions_change_notification.html.erb
@@ -1,8 +1,8 @@
+<% messaging = role_text(@role) %>
+
 <p>
   <%= _('Hello %{recepientname}') %{ recepientname: @recepient.name } %>
 </p>
-
-<% messaging = role_text(@role) %>
 
 <p>
   <%= _('Your permissions relating to %{plan_title} have changed. You now have %{type} access. This means you can %{placeholder1} %{placeholder2}') % {


### PR DESCRIPTION
Fixes permissions not properly translating in the permissions email.
