### PR TITLE
Fix flaky tests from `application.email` overriding

### DIFF
--- a/spec/services/external_apis/base_service_spec.rb
+++ b/spec/services/external_apis/base_service_spec.rb
@@ -62,6 +62,11 @@ RSpec.describe ExternalApis::BaseService do
       end
     end
     context '#app_email' do
+      around do |example|
+        original_helpdesk_email = Rails.configuration.x.organisation[:helpdesk_email]
+        example.run
+        Rails.configuration.x.organisation[:helpdesk_email] = original_helpdesk_email
+      end
       it 'defaults to the contact_us url' do
         Rails.configuration.x.organisation.delete(:helpdesk_email)
         expected = Rails.application.routes.url_helpers.contact_us_url


### PR DESCRIPTION
Similar fix as to what was applied to `application.name` [here](https://github.com/portagenetwork/roadmap/pull/1116). 

This change wraps the affected examples in `around` blocks that capture and restore the original `Rails.configuration.x.application[:helpdesk_email]` value, ensuring test isolation and preventing cross-test contamination.