### PR TITLE
Correct Sample Message Behaviour

### DIFF
--- a/.github/workflows/docker-push-image.yml
+++ b/.github/workflows/docker-push-image.yml
@@ -23,7 +23,7 @@ jobs:
 
       # Buildx allows for advanced Docker build features like multi-platform builds and layer caching
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9

--- a/.github/workflows/docker-push-image.yml
+++ b/.github/workflows/docker-push-image.yml
@@ -34,7 +34,7 @@ jobs:
       # Extract metadata for app image
       - name: Extract metadata (tags) for Docker app Image
         id: meta_app
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: ualbertalib/dmp_roadmap
           flavor: |
@@ -55,7 +55,7 @@ jobs:
       # Extract metadata for assets image
       - name: Extract metadata (tags) for Docker assets image
         id: meta_assets
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: ualbertalib/dmp_roadmap
           flavor: |

--- a/.github/workflows/docker-push-image.yml
+++ b/.github/workflows/docker-push-image.yml
@@ -26,7 +26,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@
 
 ### Fixed
  - Fix Translation of Permissions in Email [#1123](https://github.com/portagenetwork/roadmap/pull/1123)
+
  - Fix/Re-Enable "Create Plan" RSpec Test [#798](https://github.com/portagenetwork/roadmap/pull/798)
+
+ - Fix Feedback Sample Message Behaviour [#1156](https://github.com/portagenetwork/roadmap/pull/1156)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@
 
 ### Fixed
  - Fix Translation of Permissions in Email [#1123](https://github.com/portagenetwork/roadmap/pull/1123)
+ 
  - Fix/Re-Enable "Create Plan" RSpec Test [#798](https://github.com/portagenetwork/roadmap/pull/798)
 
 ### Changed
+ - Strengthened Password Policy [#1158](https://github.com/portagenetwork/roadmap/pull/1158)
 
 
 ### Dependency Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@
 
 ### Fixed
  - Fix Translation of Permissions in Email [#1123](https://github.com/portagenetwork/roadmap/pull/1123)
- 
+
  - Fix/Re-Enable "Create Plan" RSpec Test [#798](https://github.com/portagenetwork/roadmap/pull/798)
+
+ - Fix Feedback Sample Message Behaviour [#1156](https://github.com/portagenetwork/roadmap/pull/1156)
 
 ### Changed
  - Strengthened Password Policy [#1158](https://github.com/portagenetwork/roadmap/pull/1158)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,3 +23,5 @@ $fa-font-path: '.';
 @import "rebranding";
 @import "rebranding-animation";
 @import "grey-branding";
+
+@import "dmp-assistant/blocks"

--- a/app/assets/stylesheets/blocks/_index.scss
+++ b/app/assets/stylesheets/blocks/_index.scss
@@ -24,6 +24,7 @@
 @use 'new_window_popup';
 @use 'notification_areas';
 @use 'panels';
+@use 'password_checklist';
 @use 'profile_form';
 @use 'progress';
 @use 'project_details';

--- a/app/assets/stylesheets/blocks/_password_checklist.scss
+++ b/app/assets/stylesheets/blocks/_password_checklist.scss
@@ -1,0 +1,29 @@
+#password-requirements {
+  display: none; // hidden by default
+
+  &.visible {
+    display: block;
+    border: 1px solid #d3d3d3;
+    border-radius: 3px;
+    background-color: #f9f9f9;
+    padding: 0.5rem;
+  }
+
+  ul {
+    list-style: none;
+    padding-left: 1em;
+  }
+
+  .rule-icon {
+    width: 16px;
+    height: 16px;
+    vertical-align: middle;
+
+    &.fa-circle-check {
+      color: green;
+    }
+    &.fa-circle-xmark {
+      color: grey;
+    }
+  }
+}

--- a/app/assets/stylesheets/blocks/_password_checklist.scss
+++ b/app/assets/stylesheets/blocks/_password_checklist.scss
@@ -1,4 +1,4 @@
-#password-requirements {
+#password-checklist {
   display: none; // hidden by default
 
   &.visible {

--- a/app/assets/stylesheets/dmp-assistant/blocks/_index.scss
+++ b/app/assets/stylesheets/dmp-assistant/blocks/_index.scss
@@ -1,0 +1,1 @@
+@use 'password_checklist';

--- a/app/assets/stylesheets/dmp-assistant/blocks/_password_checklist.scss
+++ b/app/assets/stylesheets/dmp-assistant/blocks/_password_checklist.scss
@@ -1,0 +1,9 @@
+@use '../../grey-branding' as gb;
+
+#password-requirements {
+  .rule-icon {
+    &.fa-circle-check {
+      color: gb.$color-alliance-yellow;
+    }
+  }
+}

--- a/app/assets/stylesheets/dmp-assistant/blocks/_password_checklist.scss
+++ b/app/assets/stylesheets/dmp-assistant/blocks/_password_checklist.scss
@@ -1,6 +1,6 @@
 @use '../../grey-branding' as gb;
 
-#password-requirements {
+#password-checklist {
   .rule-icon {
     &.fa-circle-check {
       color: gb.$color-alliance-yellow;

--- a/app/helpers/orgs_helper.rb
+++ b/app/helpers/orgs_helper.rb
@@ -39,16 +39,12 @@ module OrgsHelper
   # Displays a sample feedback message in the org/Request Feedback section
   # that is meant to serve as an example
   #
-  # org - The current Org who owns the feedback message being displayed
-  # current_user - The current user we're showing feedback message to
-  #
   # Returns String
   def display_sample_feedback_message(org, current_user)
     email = org.contact_email || EMAIL_PLACEHOLDER
     username = current_user.name(false) || USER_PLACEHOLDER
 
-    # feedback_confirmation_default_message represents the default feedback message
-    # taken from feedbacks_helper.rb
+    # feedback_confirmation_default_message is taken from feedbacks_helper.rb
     format(feedback_confirmation_default_message, user_name: username, organisation_email: email)
   end
 

--- a/app/helpers/orgs_helper.rb
+++ b/app/helpers/orgs_helper.rb
@@ -2,6 +2,8 @@
 
 # Helper methods for Orgs
 module OrgsHelper
+  include FeedbacksHelper
+
   EMAIL_PLACEHOLDER = '[Organisation Contact Email Placeholder]'
   PLAN_PLACEHOLDER = '[Plan Name Placeholder]'
   USER_PLACEHOLDER = ''
@@ -45,12 +47,9 @@ module OrgsHelper
     email = org.contact_email || EMAIL_PLACEHOLDER
     username = current_user.name(false) || USER_PLACEHOLDER
 
-    format(_('<p>Hello %{user_name},</p>' \
-      'A member of your organisation will respond to your request to review your data management plan
-       within 48 hours. ' \
-      'If you have questions pertaining to this action please contact your local team at %{organisation_email}, ' \
-      'or for assistance with DMP Assistant contact dmp-assistant@tech.alliancecan.ca.'), user_name: username,
-                                                                                          organisation_email: email)
+    # feedback_confirmation_default_message represents the default feedback message
+    # taken from feedbacks_helper.rb
+    format(feedback_confirmation_default_message, user_name: username, organisation_email: email)
   end
 
   # The preferred logo url for the current configuration. If DRAGONFLY_AWS is true, return

--- a/app/helpers/orgs_helper.rb
+++ b/app/helpers/orgs_helper.rb
@@ -5,19 +5,20 @@ module OrgsHelper
   EMAIL_PLACEHOLDER = '[Organisation Contact Email Placeholder]'
   PLAN_PLACEHOLDER = '[Plan Name Placeholder]'
   USER_PLACEHOLDER = ''
-  # Displays a feedback message
+
+  # Displays a feedback message that the user can edit in the org/Request Feedback section
   #
   # org - The current Org who owns the feedback message being displayed
   # current_user - The current user we're showing feedback message to
   # feedack_message - The feedback message we're displaying
-  # plan_name - Name of the plan we're displaying the feedback message for;
-  #   set to nil because there is no plan name in org feedback form
+  # plan_name - Name of the plan we're displaying the feedback message for
   #
   # Returns String
-  def display_feedback_message(org, current_user, feedback_message, plan_name = nil)
+  def display_editable_feedback_message(org, current_user, feedback_message, plan_name)
     email = org.contact_email || EMAIL_PLACEHOLDER
     username = current_user.name(false) || USER_PLACEHOLDER
     plan_title = plan_name || PLAN_PLACEHOLDER
+
     format(
       _(feedback_message),
       user_name: username, organisation_email: email, plan_name: plan_title
@@ -31,6 +32,25 @@ module OrgsHelper
       message = _('Unable to render feedback message: ')
       message + _(e.message.to_s)
     end
+  end
+
+  # Displays a sample feedback message in the org/Request Feedback section
+  # that is meant to serve as an example
+  #
+  # org - The current Org who owns the feedback message being displayed
+  # current_user - The current user we're showing feedback message to
+  #
+  # Returns String
+  def display_sample_feedback_message(org, current_user)
+    email = org.contact_email || EMAIL_PLACEHOLDER
+    username = current_user.name(false) || USER_PLACEHOLDER
+
+    format(_('<p>Hello %{user_name},</p>' \
+      'A member of your organisation will respond to your request to review your data management plan
+       within 48 hours. ' \
+      'If you have questions pertaining to this action please contact your local team at %{organisation_email}, ' \
+      'or for assistance with DMP Assistant contact dmp-assistant@tech.alliancecan.ca.'), user_name: username,
+                                                                                          organisation_email: email)
   end
 
   # The preferred logo url for the current configuration. If DRAGONFLY_AWS is true, return

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -61,6 +61,7 @@ import './src/publicTemplates/show';
 import './src/researchOutputs/form';
 import './src/roles/edit';
 import './src/shared/createAccountForm';
+import './src/shared/passwordChecklist';
 import './src/shared/signInForm';
 import './src/usage/index';
 import './src/users/adminGrantPermissions';

--- a/app/javascript/src/shared/passwordChecklist.js
+++ b/app/javascript/src/shared/passwordChecklist.js
@@ -4,7 +4,7 @@ const passwordInputs = [
   document.getElementById('new_user_password')
 ].filter(Boolean); // Filter out nulls if one doesn't exist
 
-passwordRequirements = document.getElementById('password-requirements')
+passwordRequirements = document.getElementById('password-checklist')
 
 const rules = {
   length: (pw) => pw.length >= 8,

--- a/app/javascript/src/shared/passwordChecklist.js
+++ b/app/javascript/src/shared/passwordChecklist.js
@@ -4,7 +4,7 @@ const passwordInputs = [
   document.getElementById('new_user_password')
 ].filter(Boolean); // Filter out nulls if one doesn't exist
 
-passwordRequirements = document.getElementById('password-checklist')
+const passwordRequirements = document.getElementById('password-checklist')
 
 const rules = {
   length: (pw) => pw.length >= 8,

--- a/app/javascript/src/shared/passwordChecklist.js
+++ b/app/javascript/src/shared/passwordChecklist.js
@@ -1,39 +1,47 @@
-const passwordInputs = [
-  document.getElementById('user_password'),
-  // Some forms append 'new' to ID names
-  document.getElementById('new_user_password')
-].filter(Boolean); // Filter out nulls if one doesn't exist
 
-const passwordRequirements = document.getElementById('password-checklist')
+const passwordChecklist = () => {
+  const passwordInputs = [
+    document.getElementById('user_password'),
+    // Some forms pre-append 'new' to ID names
+    document.getElementById('new_user_password')
+  ].filter(Boolean); // Filter out nulls if one doesn't exist
 
-const rules = {
-  length: (pw) => pw.length >= 8,
-  uppercase: (pw) => /[A-Z]/.test(pw),
-  lowercase: (pw) => /[a-z]/.test(pw),
-  digit: (pw) => /[0-9]/.test(pw),
-  // Only common ASCII special characters (not emojis, spaces, etc.)
-  special: (pw) => /[!@#$%^&*()_\-+=\[\]{};:'",.<>?/\\|`~]/.test(pw),
-};
+  const passwordRequirements = document.getElementById('password-checklist')
 
-const updateRequirements = (pw) => {
-  for (const rule in rules) {
-    const li = passwordRequirements.querySelector(`li[data-rule="${rule}"]`);
-    const icon = li?.querySelector('i');
+  // Exit if relevant elements are not on this page
+  if (passwordInputs.length === 0 || !passwordRequirements) return;
 
-    if (!icon) continue;
+  const rules = {
+    length: (pw) => pw.length >= 8,
+    uppercase: (pw) => /[A-Z]/.test(pw),
+    lowercase: (pw) => /[a-z]/.test(pw),
+    digit: (pw) => /[0-9]/.test(pw),
+    // Only common ASCII special characters (not emojis, spaces, etc.)
+    special: (pw) => /[!@#$%^&*()_\-+=\[\]{};:'",.<>?/\\|`~]/.test(pw),
+  };
 
-    const valid = rules[rule](pw);
-    icon.classList.toggle('fa-circle-check', valid);
-    icon.classList.toggle('fa-circle-xmark', !valid);
-  }
-};
+  const updateRequirements = (pw) => {
+    for (const rule in rules) {
+      const li = passwordRequirements.querySelector(`li[data-rule="${rule}"]`);
+      const icon = li?.querySelector('i');
 
-passwordInputs.forEach(input => {
-  input.addEventListener('input', (e) => {
-    // passwordRequirements element is hidden by default
-    if (!passwordRequirements.classList.contains('visible')) {
-      passwordRequirements.classList.add('visible');
+      if (!icon) continue;
+
+      const valid = rules[rule](pw);
+      icon.classList.toggle('fa-circle-check', valid);
+      icon.classList.toggle('fa-circle-xmark', !valid);
     }
-    updateRequirements(e.target.value);
+  };
+
+  passwordInputs.forEach(input => {
+    input.addEventListener('input', (e) => {
+      // passwordRequirements element is hidden by default
+      if (!passwordRequirements.classList.contains('visible')) {
+        passwordRequirements.classList.add('visible');
+      }
+      updateRequirements(e.target.value);
+    });
   });
-});
+};
+
+passwordChecklist();

--- a/app/javascript/src/shared/passwordChecklist.js
+++ b/app/javascript/src/shared/passwordChecklist.js
@@ -20,14 +20,22 @@ const passwordChecklist = () => {
     special: (pw) => /[!@#$%^&*()_\-+=\[\]{};:'",.<>?/\\|`~]/.test(pw),
   };
 
-  const updateRequirements = (pw) => {
-    for (const rule in rules) {
+  // Map the rule names to their icons
+  // (See app/views/shared/_password_checklist.html.erb)
+  const ruleIconsMap = Object.fromEntries(
+    Object.keys(rules).map(rule => {
       const li = passwordRequirements.querySelector(`li[data-rule="${rule}"]`);
       const icon = li?.querySelector('i');
+      return [rule, icon];
+    })
+  );
 
+  const updateRequirements = (pw) => {
+    for (const [ruleName, ruleValidator] of Object.entries(rules)) {
+      const icon = ruleIconsMap[ruleName];
       if (!icon) continue;
 
-      const valid = rules[rule](pw);
+      const valid = ruleValidator(pw);
       icon.classList.toggle('fa-circle-check', valid);
       icon.classList.toggle('fa-circle-xmark', !valid);
     }

--- a/app/javascript/src/shared/passwordChecklist.js
+++ b/app/javascript/src/shared/passwordChecklist.js
@@ -8,6 +8,8 @@ const initPasswordChecklist = () => {
   // Exit if relevant elements are not on this page
   if (!passwordInput|| !passwordChecklist) return;
 
+  // Use RegExp's .test() method for validating rules
+  // (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test)
   const rules = {
     length: (pw) => pw.length >= 8,
     uppercase: (pw) => /[A-Z]/.test(pw),
@@ -27,12 +29,17 @@ const initPasswordChecklist = () => {
     })
   );
 
+  // Updates the checklist icons to reflect which password rules are satisfied.
   const updateChecklistIcons = (pw) => {
+    // Loop over each of the defined rules
     for (const [ruleName, ruleValidator] of Object.entries(rules)) {
+      // Get the DOM icon mapped to this rule
       const icon = ruleIconsMap[ruleName];
       if (!icon) continue;
 
+      // Validate current password against current rule
       const valid = ruleValidator(pw);
+      // Update icons accordingly: ✔ if valid, ✖ if invalid
       icon.classList.toggle('fa-circle-check', valid);
       icon.classList.toggle('fa-circle-xmark', !valid);
     }

--- a/app/javascript/src/shared/passwordChecklist.js
+++ b/app/javascript/src/shared/passwordChecklist.js
@@ -1,12 +1,12 @@
 
-const passwordChecklist = () => {
+const initPasswordChecklist = () => {
 
   // Some forms pre-append 'new' to ID names
   const passwordInput = document.getElementById('user_password') || document.getElementById('new_user_password');
   
-  const passwordRequirements = document.getElementById('password-checklist')
+  const passwordChecklist = document.getElementById('password-checklist')
   // Exit if relevant elements are not on this page
-  if (!passwordInput|| !passwordRequirements) return;
+  if (!passwordInput|| !passwordChecklist) return;
 
   const rules = {
     length: (pw) => pw.length >= 8,
@@ -21,13 +21,13 @@ const passwordChecklist = () => {
   // (See app/views/shared/_password_checklist.html.erb)
   const ruleIconsMap = Object.fromEntries(
     Object.keys(rules).map(rule => {
-      const li = passwordRequirements.querySelector(`li[data-rule="${rule}"]`);
+      const li = passwordChecklist.querySelector(`li[data-rule="${rule}"]`);
       const icon = li?.querySelector('i');
       return [rule, icon];
     })
   );
 
-  const updateRequirements = (pw) => {
+  const updateChecklistIcons = (pw) => {
     for (const [ruleName, ruleValidator] of Object.entries(rules)) {
       const icon = ruleIconsMap[ruleName];
       if (!icon) continue;
@@ -39,12 +39,12 @@ const passwordChecklist = () => {
   };
 
   passwordInput.addEventListener('input', (e) => {
-    // passwordRequirements element is hidden by default
-    if (!passwordRequirements.classList.contains('visible')) {
-      passwordRequirements.classList.add('visible');
+    // passwordChecklist element is hidden by default
+    if (!passwordChecklist.classList.contains('visible')) {
+      passwordChecklist.classList.add('visible');
     }
-    updateRequirements(e.target.value);
+    updateChecklistIcons(e.target.value);
   });
 };
 
-passwordChecklist();
+initPasswordChecklist();

--- a/app/javascript/src/shared/passwordChecklist.js
+++ b/app/javascript/src/shared/passwordChecklist.js
@@ -1,15 +1,12 @@
 
 const passwordChecklist = () => {
-  const passwordInputs = [
-    document.getElementById('user_password'),
-    // Some forms pre-append 'new' to ID names
-    document.getElementById('new_user_password')
-  ].filter(Boolean); // Filter out nulls if one doesn't exist
 
+  // Some forms pre-append 'new' to ID names
+  const passwordInput = document.getElementById('user_password') || document.getElementById('new_user_password');
+  
   const passwordRequirements = document.getElementById('password-checklist')
-
   // Exit if relevant elements are not on this page
-  if (passwordInputs.length === 0 || !passwordRequirements) return;
+  if (!passwordInput|| !passwordRequirements) return;
 
   const rules = {
     length: (pw) => pw.length >= 8,
@@ -41,14 +38,12 @@ const passwordChecklist = () => {
     }
   };
 
-  passwordInputs.forEach(input => {
-    input.addEventListener('input', (e) => {
-      // passwordRequirements element is hidden by default
-      if (!passwordRequirements.classList.contains('visible')) {
-        passwordRequirements.classList.add('visible');
-      }
-      updateRequirements(e.target.value);
-    });
+  passwordInput.addEventListener('input', (e) => {
+    // passwordRequirements element is hidden by default
+    if (!passwordRequirements.classList.contains('visible')) {
+      passwordRequirements.classList.add('visible');
+    }
+    updateRequirements(e.target.value);
   });
 };
 

--- a/app/javascript/src/shared/passwordChecklist.js
+++ b/app/javascript/src/shared/passwordChecklist.js
@@ -1,0 +1,39 @@
+const passwordInputs = [
+  document.getElementById('user_password'),
+  // Some forms append 'new' to ID names
+  document.getElementById('new_user_password')
+].filter(Boolean); // Filter out nulls if one doesn't exist
+
+passwordRequirements = document.getElementById('password-requirements')
+
+const rules = {
+  length: (pw) => pw.length >= 8,
+  uppercase: (pw) => /[A-Z]/.test(pw),
+  lowercase: (pw) => /[a-z]/.test(pw),
+  digit: (pw) => /[0-9]/.test(pw),
+  // Only common ASCII special characters (not emojis, spaces, etc.)
+  special: (pw) => /[!@#$%^&*()_\-+=\[\]{};:'",.<>?/\\|`~]/.test(pw),
+};
+
+const updateRequirements = (pw) => {
+  for (const rule in rules) {
+    const li = passwordRequirements.querySelector(`li[data-rule="${rule}"]`);
+    const icon = li?.querySelector('i');
+
+    if (!icon) continue;
+
+    const valid = rules[rule](pw);
+    icon.classList.toggle('fa-circle-check', valid);
+    icon.classList.toggle('fa-circle-xmark', !valid);
+  }
+};
+
+passwordInputs.forEach(input => {
+  input.addEventListener('input', (e) => {
+    // passwordRequirements element is hidden by default
+    if (!passwordRequirements.classList.contains('visible')) {
+      passwordRequirements.classList.add('visible');
+    }
+    updateRequirements(e.target.value);
+  });
+});

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,6 +59,8 @@ class User < ApplicationRecord
 
   extend UniqueRandom
 
+  attr_accessor :skip_password_validation
+
   # =============
   # = Constants =
   # =============
@@ -114,6 +116,8 @@ class User < ApplicationRecord
   # ===============
   # = Validations =
   # ===============
+
+  validate :password_complexity, unless: :skip_password_validation
 
   validates :active, inclusion: { in: BOOLEAN_VALUES, message: INCLUSION_MESSAGE }
 
@@ -198,6 +202,10 @@ class User < ApplicationRecord
     user = User.find_or_initialize_by(email: provider_data.info.email.downcase)
 
     return user unless user.new_record?
+
+    # We are using `Devise.friendly_token[0, 20]` to generate a random password here. While it is strong,
+    # it may not satisfy our custom `password_complexity` validator, so we skip validation.
+    user.skip_password_validation = true
 
     user.update!(
       firstname: provider_data.info&.first_name.presence || _(GENERIC_USER_NAME_VALUES[:firstname]),
@@ -514,5 +522,17 @@ class User < ApplicationRecord
 
   def clear_department_id
     self.department_id = nil
+  end
+
+  def password_complexity
+    # Custom validator for password complexity to ensure each password has
+    # 1 uppercase letter, 1 lowercase letter, 1 number, and 1 special character
+
+    # Regexp that ensures requirements are met
+    regexp = %r{(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[!@#$%^&*()_\-+=\[\]{};:'",.<>?/\\|`~])}
+
+    return if password.blank? || password =~ regexp
+
+    errors.add :password, :complexity
   end
 end

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -13,7 +13,7 @@
       <%= f.hidden_field :invitation_token %>
       <div class="form-group">
         <%= f.label(:password, _('New password'), class: 'control-label') %>
-        <%= f.password_field(:password, class: 'form-control', "aria-required": true, autocomplete: "new-password", id: 'user_password') %>
+        <%= f.password_field(:password, class: 'form-control', "aria-required": true, autocomplete: "new-password") %>
         <%= render 'shared/password_checklist', f: f%>
       </div>
       <div class="form-group">

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -13,7 +13,8 @@
       <%= f.hidden_field :invitation_token %>
       <div class="form-group">
         <%= f.label(:password, _('New password'), class: 'control-label') %>
-        <%= f.password_field(:password, class: 'form-control', "aria-required": true, autocomplete: "new-password") %>
+        <%= f.password_field(:password, class: 'form-control', "aria-required": true, autocomplete: "new-password", id: 'user_password') %>
+        <%= render 'shared/password_checklist', f: f%>
       </div>
       <div class="form-group">
         <%= f.label(:password_confirmation, _('Password confirmation'), class: 'control-label') %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -17,7 +17,8 @@
       </div>
       <div class="form-group">
         <%= f.label(:password_confirmation, _('Password confirmation'), class: 'control-label') %>
-        <%= f.password_field(:password_confirmation, class: 'form-control', "aria-required": true, autocomplete: "new-password") %>
+        <%= f.password_field(:password_confirmation, class: 'form-control', "aria-required": true, autocomplete: "new-password", id: 'user_password') %>
+        <%= render 'shared/password_checklist', f: f%>
       </div>
       <div class="checkbox">
         <label>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -13,7 +13,7 @@
 
       <div class="form-group">
         <%= f.label(:password, _('New password'), class: 'control-label') %>
-        <%= f.password_field(:password, class: 'form-control', "aria-required": true, autocomplete: "new-password", id: 'user_password') %>
+        <%= f.password_field(:password, class: 'form-control', "aria-required": true, autocomplete: "new-password") %>
         <%= render 'shared/password_checklist', f: f%>
       </div>
       <div class="form-group">

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -13,12 +13,12 @@
 
       <div class="form-group">
         <%= f.label(:password, _('New password'), class: 'control-label') %>
-        <%= f.password_field(:password, class: 'form-control', "aria-required": true, autocomplete: "new-password") %>
+        <%= f.password_field(:password, class: 'form-control', "aria-required": true, autocomplete: "new-password", id: 'user_password') %>
+        <%= render 'shared/password_checklist', f: f%>
       </div>
       <div class="form-group">
         <%= f.label(:password_confirmation, _('Password confirmation'), class: 'control-label') %>
-        <%= f.password_field(:password_confirmation, class: 'form-control', "aria-required": true, autocomplete: "new-password", id: 'user_password') %>
-        <%= render 'shared/password_checklist', f: f%>
+        <%= f.password_field(:password_confirmation, class: 'form-control', "aria-required": true, autocomplete: "new-password") %>
       </div>
       <div class="checkbox">
         <label>

--- a/app/views/devise/registrations/_password_details.html.erb
+++ b/app/views/devise/registrations/_password_details.html.erb
@@ -11,7 +11,7 @@
 
   <div class="form-group col-xs-8">
     <%= f.label(:password, _('New password'),  class: 'control-label') %> 
-    <%= f.password_field(:password,  class: "form-control", "aria-required": true, autocomplete: "new-password", id: 'user_password') %>
+    <%= f.password_field(:password,  class: "form-control", "aria-required": true, autocomplete: "new-password") %>
     <%= render 'shared/password_checklist', f: f%>
   </div>
 

--- a/app/views/devise/registrations/_password_details.html.erb
+++ b/app/views/devise/registrations/_password_details.html.erb
@@ -11,7 +11,7 @@
 
   <div class="form-group col-xs-8">
     <%= f.label(:password, _('New password'),  class: 'control-label') %> 
-    <%= f.password_field(:password,  class: "form-control", "aria-required": true , id: 'user_new_password', autocomplete: "new-password", id: 'user_password') %>
+    <%= f.password_field(:password,  class: "form-control", "aria-required": true, autocomplete: "new-password", id: 'user_password') %>
     <%= render 'shared/password_checklist', f: f%>
   </div>
 

--- a/app/views/devise/registrations/_password_details.html.erb
+++ b/app/views/devise/registrations/_password_details.html.erb
@@ -11,7 +11,8 @@
 
   <div class="form-group col-xs-8">
     <%= f.label(:password, _('New password'),  class: 'control-label') %> 
-    <%= f.password_field(:password,  class: "form-control", "aria-required": true , id: 'user_new_password', autocomplete: "new-password") %>
+    <%= f.password_field(:password,  class: "form-control", "aria-required": true , id: 'user_new_password', autocomplete: "new-password", id: 'user_password') %>
+    <%= render 'shared/password_checklist', f: f%>
   </div>
 
   <div class="form-group col-xs-8">

--- a/app/views/orgs/_feedback_form.html.erb
+++ b/app/views/orgs/_feedback_form.html.erb
@@ -38,7 +38,7 @@
       </div>
       <div class="form-group col-xs-4">
         <h4><%= _('Sample Message') %></h4>
-         <%= sanitize display_feedback_message(org, current_user, org.feedback_msg) %>
+         <%= sanitize display_sample_feedback_message(org, current_user) %>
       </div>
     </div>
   </div>

--- a/app/views/plans/_request_feedback_form.html.erb
+++ b/app/views/plans/_request_feedback_form.html.erb
@@ -12,7 +12,7 @@
        %>
        </p>
       <div class="well well-sm">
-        <%= sanitize display_feedback_message(plan.owner.org, current_user, plan.owner.org.feedback_msg, plan.title) %>
+        <%= sanitize display_editable_feedback_message(plan.owner.org, current_user, plan.owner.org.feedback_msg, plan.title) %>
       </div>
       <p><%= _('You can continue to edit and download the plan in the interim.') %></p>
       <div class="form-group col-xs-8">

--- a/app/views/shared/_create_account_form.html.erb
+++ b/app/views/shared/_create_account_form.html.erb
@@ -25,7 +25,7 @@
   </div>
   <div class="form-group">
     <%= f.label(:password, _('Password'), class: "control-label") %>
-    <%= f.password_field(:password, class: "form-control", "aria-required": true, autocomplete: "new-password", id: 'user_password') %>
+    <%= f.password_field(:password, class: "form-control", "aria-required": true, autocomplete: "new-password") %>
 
     <div class="checkbox">
       <label>

--- a/app/views/shared/_create_account_form.html.erb
+++ b/app/views/shared/_create_account_form.html.erb
@@ -25,14 +25,14 @@
   </div>
   <div class="form-group">
     <%= f.label(:password, _('Password'), class: "control-label") %>
-    <%= f.password_field(:password, class: "form-control", "aria-required": true, autocomplete: "new-password") %>
-  </div>
-  <div class="form-group">
+    <%= f.password_field(:password, class: "form-control", "aria-required": true, autocomplete: "new-password", id: 'user_password') %>
+
     <div class="checkbox">
       <label>
         <input type="checkbox" id="passwords_toggle_sign_up" class="passwords_toggle" /><%= _('Show password') %>
       </label>
     </div>
+    <%= render 'shared/password_checklist', f: f%>
   </div>
 
   <div class="form-group">

--- a/app/views/shared/_password_checklist.html.erb
+++ b/app/views/shared/_password_checklist.html.erb
@@ -1,0 +1,25 @@
+<div id="password-requirements">
+    <strong><%= _('Password must have at least:') %></strong>
+    <ul class="requirements-list">
+        <li data-rule="length">
+            <i class="fa-solid fa-circle-xmark rule-icon"></i>
+            <%= _('8 Characters') %>
+        </li>
+        <li data-rule="uppercase">
+            <i class="fa-solid fa-circle-xmark rule-icon"></i>
+            <%= _('1 Uppercase Letter (A-Z)') %>
+        </li>
+        <li data-rule="lowercase">
+            <i class="fa-solid fa-circle-xmark rule-icon"></i>
+            <%= _('1 Lowercase Letter (a-z)') %>
+        </li>
+        <li data-rule="digit">
+            <i class="fa-solid fa-circle-xmark rule-icon"></i>
+            <%= _('1 Number (0-9)') %>
+        </li>
+        <li data-rule="special">
+            <i class="fa-solid fa-circle-xmark rule-icon"></i>
+            <%= _('1 Special Character (!...$)') %>
+        </li>
+    </ul>
+</div>

--- a/app/views/shared/_password_checklist.html.erb
+++ b/app/views/shared/_password_checklist.html.erb
@@ -1,4 +1,4 @@
-<div id="password-requirements">
+<div id="password-checklist">
     <strong><%= _('Password must have at least:') %></strong>
     <ul class="requirements-list">
         <li data-rule="length">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,7 @@ en:
   activerecord:
     errors:
       messages:
+        complexity: "complexity requirement not met."
         record_invalid: 'Validation failed: %{errors}'
         restrict_dependent_destroy:
           has_one: Cannot delete record because a dependent %{record} exists

--- a/config/locales/translation.en-CA.yml
+++ b/config/locales/translation.en-CA.yml
@@ -128,6 +128,7 @@ en-CA:
   activerecord:
     errors:
       messages:
+        complexity: "complexity requirement not met."
         record_invalid: 'Validation failed: %{errors}'
         restrict_dependent_destroy:
           has_one: Cannot delete record because a dependent %{record} exists

--- a/config/locales/translation.fr-CA.yml
+++ b/config/locales/translation.fr-CA.yml
@@ -136,6 +136,7 @@ fr-CA:
   activerecord:
     errors:
       messages:
+        complexity: ' Le mot de passe ne respecte pas les exigences de complexité.'
         record_invalid: 'La validation a échoué : %{errors}'
         restrict_dependent_destroy:
           has_one: Vous ne pouvez pas supprimer l'enregistrement car un(e) %{record}

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -58,7 +58,7 @@ FactoryBot.define do
     firstname    { Faker::Name.unique.first_name }
     surname      { Faker::Name.unique.last_name }
     email        { Faker::Internet.unique.email }
-    password     { 'password' }
+    password     { 'StrongP@ssw0rd!@$%#' }
     accept_terms { true }
     confirmed_at { Time.now.utc }
 

--- a/spec/features/registrations_spec.rb
+++ b/spec/features/registrations_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'Registrations', type: :feature do
 
     # Check rule indicators
     # Only 1 out of 5 should be a check mark
-    within('#password-requirements') do
+    within('#password-checklist') do
       expect(page).to have_css('.fa-circle-check', count: 1)
       expect(page).to have_css('.fa-circle-xmark', count: 4)
     end
@@ -79,7 +79,7 @@ RSpec.describe 'Registrations', type: :feature do
     end
 
     # Check rule indicators
-    within('#password-requirements') do
+    within('#password-checklist') do
       expect(page).to have_css('.fa-circle-check', count: 3)
       expect(page).to have_css('.fa-circle-xmark', count: 2)
     end
@@ -91,7 +91,7 @@ RSpec.describe 'Registrations', type: :feature do
 
     # Check rule indicators
     # All 5 requirements should be met
-    within('#password-requirements') do
+    within('#password-checklist') do
       expect(page).to have_css('.fa-circle-check', count: 5)
       expect(page).to have_css('.fa-circle-xmark', count: 0)
     end

--- a/spec/features/registrations_spec.rb
+++ b/spec/features/registrations_spec.rb
@@ -52,4 +52,48 @@ RSpec.describe 'Registrations', type: :feature do
     expect(current_path).to eql(root_path)
     expect(User.count).to be_zero
   end
+
+  scenario 'User attempts to login with weak and strong passwords', :js do
+    # Setup
+    visit root_path
+
+    # Action
+    click_link 'Create account'
+    within('#create-account-form') do
+      # Start with a very weak password
+      # Only meets one requirement (lowercase letters)
+      fill_in 'Password', with: 'abc'
+    end
+
+    # Check rule indicators
+    # Only 1 out of 5 should be a check mark
+    within('#password-requirements') do
+      expect(page).to have_css('.fa-circle-check', count: 1)
+      expect(page).to have_css('.fa-circle-xmark', count: 4)
+    end
+
+    within('#create-account-form') do
+      # Try a moderate password
+      # Meets three requirements (lowercase and uppercase letters + Number)
+      fill_in 'Password', with: 'Pass4'
+    end
+
+    # Check rule indicators
+    within('#password-requirements') do
+      expect(page).to have_css('.fa-circle-check', count: 3)
+      expect(page).to have_css('.fa-circle-xmark', count: 2)
+    end
+
+    within('#create-account-form') do
+      # Fill in a strong password
+      fill_in 'Password', with: 'StrongP@ssw0rd!@$%#'
+    end
+
+    # Check rule indicators
+    # All 5 requirements should be met
+    within('#password-requirements') do
+      expect(page).to have_css('.fa-circle-check', count: 5)
+      expect(page).to have_css('.fa-circle-xmark', count: 0)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -601,40 +601,33 @@ RSpec.describe User, type: :model do
       end
     end
 
-    context 'without uppercase letter' do
-      let(:password) { 'invalid1@password' }
+    # For more info on shared_examples:
+    # https://rspec.info/features/3-13/rspec-core/example-groups/shared-examples/
+    shared_examples 'complexity error' do |pwd|
+      let(:password) { pwd }
 
       it 'adds complexity error' do
         subject
-        expect(user.errors[:password]).to include(I18n.t('activerecord.errors.messages.complexity'))
+        expect(user.errors[:password]).to include(
+          I18n.t('activerecord.errors.messages.complexity')
+        )
       end
+    end
+
+    context 'without uppercase letter' do
+      it_behaves_like 'complexity error', 'invalid1@password'
     end
 
     context 'without lowercase letter' do
-      let(:password) { 'INVALID1@' }
-
-      it 'adds complexity error' do
-        subject
-        expect(user.errors[:password]).to include(I18n.t('activerecord.errors.messages.complexity'))
-      end
+      it_behaves_like 'complexity error', 'INVALID1@'
     end
 
     context 'without digit' do
-      let(:password) { 'Invalid@pass' }
-
-      it 'adds complexity error' do
-        subject
-        expect(user.errors[:password]).to include(I18n.t('activerecord.errors.messages.complexity'))
-      end
+      it_behaves_like 'complexity error', 'Invalid@pass'
     end
 
     context 'without special character' do
-      let(:password) { 'Invalid1pass' }
-
-      it 'adds complexity error' do
-        subject
-        expect(user.errors[:password]).to include(I18n.t('activerecord.errors.messages.complexity'))
-      end
+      it_behaves_like 'complexity error', 'Invalid1pass'
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -586,4 +586,55 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe '#password_complexity' do
+    let(:user) { build(:user, password: password) }
+
+    subject { user.valid? }
+
+    context 'with password with valid complexity' do
+      let(:password) { 'StrongP@ssw0rd!@$%#' }
+
+      it 'accepts strong password' do
+        subject
+        expect(user.errors[:password]).to be_empty
+      end
+    end
+
+    context 'without uppercase letter' do
+      let(:password) { 'invalid1@password' }
+
+      it 'adds complexity error' do
+        subject
+        expect(user.errors[:password]).to include(I18n.t('activerecord.errors.messages.complexity'))
+      end
+    end
+
+    context 'without lowercase letter' do
+      let(:password) { 'INVALID1@' }
+
+      it 'adds complexity error' do
+        subject
+        expect(user.errors[:password]).to include(I18n.t('activerecord.errors.messages.complexity'))
+      end
+    end
+
+    context 'without digit' do
+      let(:password) { 'Invalid@pass' }
+
+      it 'adds complexity error' do
+        subject
+        expect(user.errors[:password]).to include(I18n.t('activerecord.errors.messages.complexity'))
+      end
+    end
+
+    context 'without special character' do
+      let(:password) { 'Invalid1pass' }
+
+      it 'adds complexity error' do
+        subject
+        expect(user.errors[:password]).to include(I18n.t('activerecord.errors.messages.complexity'))
+      end
+    end
+  end
 end

--- a/spec/support/helpers/sessions_helper.rb
+++ b/spec/support/helpers/sessions_helper.rb
@@ -17,7 +17,7 @@ module SessionsHelper
     visit root_path
     within '#sign-in-form' do
       fill_in 'Email', with: user.email
-      fill_in 'Password', with: user.password.presence || 'password'
+      fill_in 'Password', with: user.password.presence || 'StrongP@ssw0rd!@$%#'
       click_button 'Sign in'
     end
   end


### PR DESCRIPTION
In the changes made to the request feedback behaviour [here](https://github.com/portagenetwork/roadmap/pull/1064/files), the sample message was incorrectly changed to reflect the organisation's current feedback message. The correct behaviour is for the sample message to simply serve as a static example to org admins.

Changes proposed in this PR:
- This PR makes the sample message static and also edits the naming of the functions in `orgs_helper` for more clarity.
- The function previously used to display the feedback message in both the text box and sample message (`display_feedback_message`) will be renamed to `display_editable_feedback_message` as it is only used for the editable text box message.
- The function `display_sample_feedback_message` is used to display the static sample feedback message.