### PR TITLE
Make session cookie secure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added 
  - Added session timeout after 90 minutes of inactivity [#1165](https://github.com/portagenetwork/roadmap/pull/1165)
 
+ - Enabled session cookie to be secure in deployed environments [#1157](https://github.com/portagenetwork/roadmap/pull/1157)
+
 ### Fixed
  - Fix Translation of Permissions in Email [#1123](https://github.com/portagenetwork/roadmap/pull/1123)
  
@@ -20,6 +22,11 @@
  - Use Default Branch for `ualbertalib/translation_io_rails` in Gemfile [#1168](https://github.com/portagenetwork/roadmap/pull/1168)
 
 ### Dependency Updates
+ - Bump docker/setup-buildx-action from 2 to 3 [#1139](https://github.com/portagenetwork/roadmap/pull/1139)
+
+ - Bump docker/login-action from 1.10.0 to 3.5.0 [#1140](https://github.com/portagenetwork/roadmap/pull/1140)
+
+ - Bump docker/metadata-action from 3 to 5 [#1142](https://github.com/portagenetwork/roadmap/pull/1142)
 
 ## [4.1.1+portage-4.4.0]
 

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -3,4 +3,4 @@
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.session_store :cookie_store, key: "_dmp_roadmap_session",
-                                                      same_site: :lax
+                                                      same_site: :lax, secure: Rails.env.production?


### PR DESCRIPTION
Changes proposed in this PR:

- Make the session cookie secure.
- Without the Secure attribute, cookies may be transmitted over unencrypted HTTP connections. This increases the risk of session hijacking through man-in-the-middle attacks, especially when users access the application over unsecured networks.