### PR TITLE
`passwordChecklist.js` Changes

### DIFF
--- a/app/javascript/src/shared/passwordChecklist.js
+++ b/app/javascript/src/shared/passwordChecklist.js
@@ -4,7 +4,7 @@ const passwordInputs = [
   document.getElementById('new_user_password')
 ].filter(Boolean); // Filter out nulls if one doesn't exist
 
-passwordRequirements = document.getElementById('password-checklist')
+const passwordRequirements = document.getElementById('password-checklist')
 
 const rules = {
   length: (pw) => pw.length >= 8,

--- a/app/javascript/src/shared/passwordChecklist.js
+++ b/app/javascript/src/shared/passwordChecklist.js
@@ -1,39 +1,47 @@
-const passwordInputs = [
-  document.getElementById('user_password'),
-  // Some forms append 'new' to ID names
-  document.getElementById('new_user_password')
-].filter(Boolean); // Filter out nulls if one doesn't exist
 
-const passwordRequirements = document.getElementById('password-checklist')
+const passwordChecklist = () => {
+  const passwordInputs = [
+    document.getElementById('user_password'),
+    // Some forms pre-append 'new' to ID names
+    document.getElementById('new_user_password')
+  ].filter(Boolean); // Filter out nulls if one doesn't exist
 
-const rules = {
-  length: (pw) => pw.length >= 8,
-  uppercase: (pw) => /[A-Z]/.test(pw),
-  lowercase: (pw) => /[a-z]/.test(pw),
-  digit: (pw) => /[0-9]/.test(pw),
-  // Only common ASCII special characters (not emojis, spaces, etc.)
-  special: (pw) => /[!@#$%^&*()_\-+=\[\]{};:'",.<>?/\\|`~]/.test(pw),
-};
+  const passwordRequirements = document.getElementById('password-checklist')
 
-const updateRequirements = (pw) => {
-  for (const rule in rules) {
-    const li = passwordRequirements.querySelector(`li[data-rule="${rule}"]`);
-    const icon = li?.querySelector('i');
+  // Exit if relevant elements are not on this page
+  if (passwordInputs.length === 0 || !passwordRequirements) return;
 
-    if (!icon) continue;
+  const rules = {
+    length: (pw) => pw.length >= 8,
+    uppercase: (pw) => /[A-Z]/.test(pw),
+    lowercase: (pw) => /[a-z]/.test(pw),
+    digit: (pw) => /[0-9]/.test(pw),
+    // Only common ASCII special characters (not emojis, spaces, etc.)
+    special: (pw) => /[!@#$%^&*()_\-+=\[\]{};:'",.<>?/\\|`~]/.test(pw),
+  };
 
-    const valid = rules[rule](pw);
-    icon.classList.toggle('fa-circle-check', valid);
-    icon.classList.toggle('fa-circle-xmark', !valid);
-  }
-};
+  const updateRequirements = (pw) => {
+    for (const rule in rules) {
+      const li = passwordRequirements.querySelector(`li[data-rule="${rule}"]`);
+      const icon = li?.querySelector('i');
 
-passwordInputs.forEach(input => {
-  input.addEventListener('input', (e) => {
-    // passwordRequirements element is hidden by default
-    if (!passwordRequirements.classList.contains('visible')) {
-      passwordRequirements.classList.add('visible');
+      if (!icon) continue;
+
+      const valid = rules[rule](pw);
+      icon.classList.toggle('fa-circle-check', valid);
+      icon.classList.toggle('fa-circle-xmark', !valid);
     }
-    updateRequirements(e.target.value);
+  };
+
+  passwordInputs.forEach(input => {
+    input.addEventListener('input', (e) => {
+      // passwordRequirements element is hidden by default
+      if (!passwordRequirements.classList.contains('visible')) {
+        passwordRequirements.classList.add('visible');
+      }
+      updateRequirements(e.target.value);
+    });
   });
-});
+};
+
+passwordChecklist();

--- a/app/javascript/src/shared/passwordChecklist.js
+++ b/app/javascript/src/shared/passwordChecklist.js
@@ -20,14 +20,22 @@ const passwordChecklist = () => {
     special: (pw) => /[!@#$%^&*()_\-+=\[\]{};:'",.<>?/\\|`~]/.test(pw),
   };
 
-  const updateRequirements = (pw) => {
-    for (const rule in rules) {
+  // Map the rule names to their icons
+  // (See app/views/shared/_password_checklist.html.erb)
+  const ruleIconsMap = Object.fromEntries(
+    Object.keys(rules).map(rule => {
       const li = passwordRequirements.querySelector(`li[data-rule="${rule}"]`);
       const icon = li?.querySelector('i');
+      return [rule, icon];
+    })
+  );
 
+  const updateRequirements = (pw) => {
+    for (const [ruleName, ruleValidator] of Object.entries(rules)) {
+      const icon = ruleIconsMap[ruleName];
       if (!icon) continue;
 
-      const valid = rules[rule](pw);
+      const valid = ruleValidator(pw);
       icon.classList.toggle('fa-circle-check', valid);
       icon.classList.toggle('fa-circle-xmark', !valid);
     }

--- a/app/javascript/src/shared/passwordChecklist.js
+++ b/app/javascript/src/shared/passwordChecklist.js
@@ -8,6 +8,8 @@ const initPasswordChecklist = () => {
   // Exit if relevant elements are not on this page
   if (!passwordInput|| !passwordChecklist) return;
 
+  // Use RegExp's .test() method for validating rules
+  // (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test)
   const rules = {
     length: (pw) => pw.length >= 8,
     uppercase: (pw) => /[A-Z]/.test(pw),
@@ -27,12 +29,17 @@ const initPasswordChecklist = () => {
     })
   );
 
+  // Updates the checklist icons to reflect which password rules are satisfied.
   const updateChecklistIcons = (pw) => {
+    // Loop over each of the defined rules
     for (const [ruleName, ruleValidator] of Object.entries(rules)) {
+      // Get the DOM icon mapped to this rule
       const icon = ruleIconsMap[ruleName];
       if (!icon) continue;
 
+      // Validate current password against current rule
       const valid = ruleValidator(pw);
+      // Update icons accordingly: ✔ if valid, ✖ if invalid
       icon.classList.toggle('fa-circle-check', valid);
       icon.classList.toggle('fa-circle-xmark', !valid);
     }

--- a/app/javascript/src/shared/passwordChecklist.js
+++ b/app/javascript/src/shared/passwordChecklist.js
@@ -1,12 +1,12 @@
 
-const passwordChecklist = () => {
+const initPasswordChecklist = () => {
 
   // Some forms pre-append 'new' to ID names
   const passwordInput = document.getElementById('user_password') || document.getElementById('new_user_password');
   
-  const passwordRequirements = document.getElementById('password-checklist')
+  const passwordChecklist = document.getElementById('password-checklist')
   // Exit if relevant elements are not on this page
-  if (!passwordInput|| !passwordRequirements) return;
+  if (!passwordInput|| !passwordChecklist) return;
 
   const rules = {
     length: (pw) => pw.length >= 8,
@@ -21,13 +21,13 @@ const passwordChecklist = () => {
   // (See app/views/shared/_password_checklist.html.erb)
   const ruleIconsMap = Object.fromEntries(
     Object.keys(rules).map(rule => {
-      const li = passwordRequirements.querySelector(`li[data-rule="${rule}"]`);
+      const li = passwordChecklist.querySelector(`li[data-rule="${rule}"]`);
       const icon = li?.querySelector('i');
       return [rule, icon];
     })
   );
 
-  const updateRequirements = (pw) => {
+  const updateChecklistIcons = (pw) => {
     for (const [ruleName, ruleValidator] of Object.entries(rules)) {
       const icon = ruleIconsMap[ruleName];
       if (!icon) continue;
@@ -39,12 +39,12 @@ const passwordChecklist = () => {
   };
 
   passwordInput.addEventListener('input', (e) => {
-    // passwordRequirements element is hidden by default
-    if (!passwordRequirements.classList.contains('visible')) {
-      passwordRequirements.classList.add('visible');
+    // passwordChecklist element is hidden by default
+    if (!passwordChecklist.classList.contains('visible')) {
+      passwordChecklist.classList.add('visible');
     }
-    updateRequirements(e.target.value);
+    updateChecklistIcons(e.target.value);
   });
 };
 
-passwordChecklist();
+initPasswordChecklist();

--- a/app/javascript/src/shared/passwordChecklist.js
+++ b/app/javascript/src/shared/passwordChecklist.js
@@ -1,15 +1,12 @@
 
 const passwordChecklist = () => {
-  const passwordInputs = [
-    document.getElementById('user_password'),
-    // Some forms pre-append 'new' to ID names
-    document.getElementById('new_user_password')
-  ].filter(Boolean); // Filter out nulls if one doesn't exist
 
+  // Some forms pre-append 'new' to ID names
+  const passwordInput = document.getElementById('user_password') || document.getElementById('new_user_password');
+  
   const passwordRequirements = document.getElementById('password-checklist')
-
   // Exit if relevant elements are not on this page
-  if (passwordInputs.length === 0 || !passwordRequirements) return;
+  if (!passwordInput|| !passwordRequirements) return;
 
   const rules = {
     length: (pw) => pw.length >= 8,
@@ -41,14 +38,12 @@ const passwordChecklist = () => {
     }
   };
 
-  passwordInputs.forEach(input => {
-    input.addEventListener('input', (e) => {
-      // passwordRequirements element is hidden by default
-      if (!passwordRequirements.classList.contains('visible')) {
-        passwordRequirements.classList.add('visible');
-      }
-      updateRequirements(e.target.value);
-    });
+  passwordInput.addEventListener('input', (e) => {
+    // passwordRequirements element is hidden by default
+    if (!passwordRequirements.classList.contains('visible')) {
+      passwordRequirements.classList.add('visible');
+    }
+    updateRequirements(e.target.value);
   });
 };
 

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -13,7 +13,7 @@
       <%= f.hidden_field :invitation_token %>
       <div class="form-group">
         <%= f.label(:password, _('New password'), class: 'control-label') %>
-        <%= f.password_field(:password, class: 'form-control', "aria-required": true, autocomplete: "new-password", id: 'user_password') %>
+        <%= f.password_field(:password, class: 'form-control', "aria-required": true, autocomplete: "new-password") %>
         <%= render 'shared/password_checklist', f: f%>
       </div>
       <div class="form-group">

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -13,7 +13,7 @@
 
       <div class="form-group">
         <%= f.label(:password, _('New password'), class: 'control-label') %>
-        <%= f.password_field(:password, class: 'form-control', "aria-required": true, autocomplete: "new-password", id: 'user_password') %>
+        <%= f.password_field(:password, class: 'form-control', "aria-required": true, autocomplete: "new-password") %>
         <%= render 'shared/password_checklist', f: f%>
       </div>
       <div class="form-group">

--- a/app/views/devise/registrations/_password_details.html.erb
+++ b/app/views/devise/registrations/_password_details.html.erb
@@ -11,7 +11,7 @@
 
   <div class="form-group col-xs-8">
     <%= f.label(:password, _('New password'),  class: 'control-label') %> 
-    <%= f.password_field(:password,  class: "form-control", "aria-required": true, autocomplete: "new-password", id: 'user_password') %>
+    <%= f.password_field(:password,  class: "form-control", "aria-required": true, autocomplete: "new-password") %>
     <%= render 'shared/password_checklist', f: f%>
   </div>
 

--- a/app/views/shared/_create_account_form.html.erb
+++ b/app/views/shared/_create_account_form.html.erb
@@ -25,7 +25,7 @@
   </div>
   <div class="form-group">
     <%= f.label(:password, _('Password'), class: "control-label") %>
-    <%= f.password_field(:password, class: "form-control", "aria-required": true, autocomplete: "new-password", id: 'user_password') %>
+    <%= f.password_field(:password, class: "form-control", "aria-required": true, autocomplete: "new-password") %>
 
     <div class="checkbox">
       <label>


### PR DESCRIPTION
### Changes proposed in this PR:
[Add const to passwordRequirements](https://github.com/portagenetwork/roadmap/commit/90181089eb0114df24dd3231e724bb946699d301)

[Wrap passwordChecklist.js in function / enable early return](https://github.com/portagenetwork/roadmap/commit/e9c9e287a6f1c071498a93c32b93629b789a1559)
- This change adds the early return of `passwordChecklist.js` when a page doesn't include any relevant elements (i.e. `if (passwordInputs.length === 0 || !passwordRequirements) return;`).
- To enable this early return, we are now assigning the prior code to the `passwordChecklist` function, and then calling it immediately.

[Update passwordChecklist.js to reduce DOM queries](https://github.com/portagenetwork/roadmap/commit/8f330c18f2b32fc5e177e750f7765831e1536122)
- Add `ruleIconsMap` to map password rules to their corresponding `<i>` icons.
- Eliminates repeated DOM queries previously being performed in `updateRequirements()`

[Simplify passwordChecklist.js to single password input](https://github.com/portagenetwork/roadmap/commit/c76393901188fee0ab7d6787e713bd557b4399a6)
- Replaced the `passwordsInputs` array with a single `passwordInput` variable. Pages never have more than one password field that uses `passwordField.js`, and this change should simplify the code a little bit.

[Rename variables in passwordChecklist.js](https://github.com/portagenetwork/roadmap/commit/bbdde6cf034a6d3cef44c85e6a806544b3e00e62)
- Renamed `passwordRequirements` to `passwordChecklist` to reflect elements actual name
- Renamed `passwordChecklist` function name to `initPasswordChecklist` to better distinguish it from the newly added `passwordChecklist` variable
- Renamed `updateRequirements` to `updateChecklistIcons` to clarify behaviour

[Remove redundant explicit password_field IDs](https://github.com/portagenetwork/roadmap/pull/1162/commits/e465fac00396c768de6fa278c1067e8686c5eac3)
- Rails automatically assigns `id="user_password"` to password fields, so
explicit `id: 'user_password'` attributes were unnecessary.
- Additionally, the manually defined `id: 'user_password'` in `app/views/shared/_create_account_form.html.erb` had no effect. Rather, `id="new_user_password"` was being generated due to `namespace: 'new'` being specified in the form.