### PR TITLE
Hardcode `Dockerfile.production` image versions for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,21 +9,21 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     target-branch: integration
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     target-branch: integration
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     target-branch: integration
   
   - package-ecosystem: "github-actions"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Changed
  - Strengthened Password Policy [#1158](https://github.com/portagenetwork/roadmap/pull/1158)
 
+ - Hardcode `Dockerfile.production` image versions for Dependabot [#1163](https://github.com/portagenetwork/roadmap/pull/1163)
 
 ### Dependency Updates
 

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,13 +1,7 @@
-ARG RUBY_VERSION=3.1.4-alpine
-ARG NODE_VERSION=20.15.1-r0
-ARG WKHTMLTOPDF_VERSION=3.21.2-0.12.6-small
-ARG NGINX_VERSION=1.27.4-alpine
+FROM surnet/alpine-wkhtmltopdf:3.21.2-0.12.6-small AS wkhtmltopdf
 
-FROM surnet/alpine-wkhtmltopdf:$WKHTMLTOPDF_VERSION AS wkhtmltopdf
+FROM ruby:3.1.4-alpine AS builder
 
-FROM ruby:$RUBY_VERSION AS builder
-
-ARG NODE_VERSION
 ENV INSTALL_PATH=/usr/src/app \
     RAILS_ENV=production \
     NODE_ENV=production \
@@ -29,7 +23,7 @@ RUN apk update && apk add --no-cache \
     musl-dev \
     postgresql16-dev \
     git \
-    nodejs=$NODE_VERSION \
+    nodejs=20.15.1-r0 \
     yarn \
     shared-mime-info \
     tzdata
@@ -62,9 +56,8 @@ USER root
 RUN rm -rf ${INSTALL_PATH}/node_modules ${INSTALL_PATH}/tmp/*
 USER dmpuser
 
-FROM ruby:$RUBY_VERSION AS app
+FROM ruby:3.1.4-alpine AS app
 
-ARG NODE_VERSION
 ENV INSTALL_PATH=/usr/src/app
 
 # Create non-root user with same UID/GID as builder
@@ -80,7 +73,7 @@ RUN apk update && apk add --no-cache \
     imagemagick \
     libjpeg-turbo \
     wget \
-    nodejs=$NODE_VERSION \
+    nodejs=20.15.1-r0 \
     # Install dependencies for wkhtmltopdf
     # (See https://github.com/Surnet/docker-wkhtmltopdf/pkgs/container/alpine-wkhtmltopdf#other-images)
     libstdc++ \
@@ -146,7 +139,7 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
 ENTRYPOINT ["/usr/bin/entrypoint.sh"]
 
 # nginx stage to serve static assets
-FROM nginx:$NGINX_VERSION AS assets
+FROM nginx:1.27.4-alpine AS assets
 
 ENV INSTALL_PATH=/usr/src/app
 


### PR DESCRIPTION
### Changes proposed in this PR:

Previously, `Dockerfile.production` used ARGs for image versions, e.g.:

```docker
ARG RUBY_VERSION=3.1.4-alpine
ARG NGINX_VERSION=1.27.4-alpine
```

It appears that Dependabot cannot resolve these ARG values, so it could not create version update PRs.

This change replaces the ARGs with explicit version tags, allowing Dependabot to detect and propose updates for base images.