### PR TITLE
Correct Sample Feedback Message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
  
  - Fix/Re-Enable "Create Plan" RSpec Test [#798](https://github.com/portagenetwork/roadmap/pull/798)
 
+ - Fix Sample Feedback Message Behaviour [#1164](https://github.com/portagenetwork/roadmap/pull/1164)
+
 ### Changed
  - Strengthened Password Policy [#1158](https://github.com/portagenetwork/roadmap/pull/1158)
 

--- a/app/helpers/feedbacks_helper.rb
+++ b/app/helpers/feedbacks_helper.rb
@@ -25,7 +25,6 @@ module FeedbacksHelper
   # Displays a feedback message that the user can edit in the org/Request Feedback section
   #
   # org - The current Org who owns the feedback message being displayed
-  # current_user - The current user we're showing feedback message to
   # feedack_message - The feedback message we're displaying
   # plan_name - Name of the plan we're displaying the feedback message for
   def editable_feedback_message(org, feedback_message, plan_name)
@@ -35,6 +34,7 @@ module FeedbacksHelper
     )
   rescue KeyError, ArgumentError => e
     Rails.logger.error("Unable to display feedback message: #{e.message}")
+    ''
   end
 
   # Displays a sample feedback message in the org/Request Feedback section

--- a/app/helpers/feedbacks_helper.rb
+++ b/app/helpers/feedbacks_helper.rb
@@ -2,7 +2,7 @@
 
 # Helper methods for Feedback messages
 module FeedbacksHelper
-  EMAIL_PLACEHOLDER = '[Organisation Contact Email Placeholder]'
+  EMAIL_PLACEHOLDER = _('[Organisation Contact Email Placeholder]')
 
   def feedback_confirmation_default_subject
     _('%{application_name}: Your plan has been submitted for feedback')
@@ -28,7 +28,7 @@ module FeedbacksHelper
   # current_user - The current user we're showing feedback message to
   # feedack_message - The feedback message we're displaying
   # plan_name - Name of the plan we're displaying the feedback message for
-  def display_editable_feedback_message(org, feedback_message, plan_name)
+  def editable_feedback_message(org, feedback_message, plan_name)
     email = org.contact_email || EMAIL_PLACEHOLDER
 
     format(
@@ -41,7 +41,7 @@ module FeedbacksHelper
 
   # Displays a sample feedback message in the org/Request Feedback section
   # that is meant to serve as an example
-  def display_sample_feedback_message(org)
+  def sample_feedback_message(org)
     email = org.contact_email || EMAIL_PLACEHOLDER
 
     format(feedback_confirmation_default_message, user_name: current_user.name(false), organisation_email: email)

--- a/app/helpers/feedbacks_helper.rb
+++ b/app/helpers/feedbacks_helper.rb
@@ -2,6 +2,8 @@
 
 # Helper methods for Feedback messages
 module FeedbacksHelper
+  EMAIL_PLACEHOLDER = '[Organisation Contact Email Placeholder]'
+
   def feedback_confirmation_default_subject
     _('%{application_name}: Your plan has been submitted for feedback')
   end
@@ -18,5 +20,30 @@ module FeedbacksHelper
   def feedback_constant_to_text(text, user, plan, org)
     format(_(text.to_s), application_name: ApplicationService.application_name, user_name: user.name(false),
                          plan_name: plan.title, organisation_email: org.contact_email)
+  end
+
+  # Displays a feedback message that the user can edit in the org/Request Feedback section
+  #
+  # org - The current Org who owns the feedback message being displayed
+  # current_user - The current user we're showing feedback message to
+  # feedack_message - The feedback message we're displaying
+  # plan_name - Name of the plan we're displaying the feedback message for
+  def display_editable_feedback_message(org, feedback_message, plan_name)
+    email = org.contact_email || EMAIL_PLACEHOLDER
+
+    format(
+      _(feedback_message),
+      user_name: current_user.name(false), organisation_email: email, plan_name: plan_name
+    )
+  rescue KeyError, ArgumentError => e
+    Rails.logger.error("Unable to display feedback message: #{e.message}")
+  end
+
+  # Displays a sample feedback message in the org/Request Feedback section
+  # that is meant to serve as an example
+  def display_sample_feedback_message(org)
+    email = org.contact_email || EMAIL_PLACEHOLDER
+
+    format(feedback_confirmation_default_message, user_name: current_user.name(false), organisation_email: email)
   end
 end

--- a/app/helpers/feedbacks_helper.rb
+++ b/app/helpers/feedbacks_helper.rb
@@ -29,11 +29,9 @@ module FeedbacksHelper
   # feedack_message - The feedback message we're displaying
   # plan_name - Name of the plan we're displaying the feedback message for
   def editable_feedback_message(org, feedback_message, plan_name)
-    email = org.contact_email || EMAIL_PLACEHOLDER
-
     format(
       _(feedback_message),
-      user_name: current_user.name(false), organisation_email: email, plan_name: plan_name
+      user_name: current_user.name(false), organisation_email: org.contact_email, plan_name: plan_name
     )
   rescue KeyError, ArgumentError => e
     Rails.logger.error("Unable to display feedback message: #{e.message}")
@@ -42,6 +40,7 @@ module FeedbacksHelper
   # Displays a sample feedback message in the org/Request Feedback section
   # that is meant to serve as an example
   def sample_feedback_message(org)
+    # This is needed here because an org may not have set a contact email
     email = org.contact_email || EMAIL_PLACEHOLDER
 
     format(feedback_confirmation_default_message, user_name: current_user.name(false), organisation_email: email)

--- a/app/helpers/orgs_helper.rb
+++ b/app/helpers/orgs_helper.rb
@@ -12,7 +12,7 @@ module OrgsHelper
   # current_user - The current user we're showing feedback message to
   # feedack_message - The feedback message we're displaying
   # plan_name - Name of the plan we're displaying the feedback message for
-  def display_editable_feedback_message(org, current_user, feedback_message, plan_name)
+  def display_editable_feedback_message(org, feedback_message, plan_name)
     email = org.contact_email || EMAIL_PLACEHOLDER
 
     format(
@@ -25,7 +25,7 @@ module OrgsHelper
 
   # Displays a sample feedback message in the org/Request Feedback section
   # that is meant to serve as an example
-  def display_sample_feedback_message(org, current_user)
+  def display_sample_feedback_message(org)
     email = org.contact_email || EMAIL_PLACEHOLDER
 
     # feedback_confirmation_default_message is taken from feedbacks_helper.rb

--- a/app/helpers/orgs_helper.rb
+++ b/app/helpers/orgs_helper.rb
@@ -39,16 +39,12 @@ module OrgsHelper
   # Displays a sample feedback message in the org/Request Feedback section
   # that is meant to serve as an example
   #
-  # org - The current Org who owns the feedback message being displayed
-  # current_user - The current user we're showing feedback message to
-  #
   # Returns String
   def display_sample_feedback_message(org, current_user)
     email = org.contact_email || EMAIL_PLACEHOLDER
     username = current_user.name(false) || USER_PLACEHOLDER
 
-    # feedback_confirmation_default_message represents the default feedback message
-    # taken from feedbacks_helper.rb
+    # feedback_confirmation_default_message is taken from feedbacks_helper.rb
     format(feedback_confirmation_default_message, user_name: username, organisation_email: email)
   end
 

--- a/app/helpers/orgs_helper.rb
+++ b/app/helpers/orgs_helper.rb
@@ -2,6 +2,8 @@
 
 # Helper methods for Orgs
 module OrgsHelper
+  include FeedbacksHelper
+
   EMAIL_PLACEHOLDER = '[Organisation Contact Email Placeholder]'
   PLAN_PLACEHOLDER = '[Plan Name Placeholder]'
   USER_PLACEHOLDER = ''
@@ -45,12 +47,9 @@ module OrgsHelper
     email = org.contact_email || EMAIL_PLACEHOLDER
     username = current_user.name(false) || USER_PLACEHOLDER
 
-    format(_('<p>Hello %{user_name},</p>' \
-      'A member of your organisation will respond to your request to review your data management plan
-       within 48 hours. ' \
-      'If you have questions pertaining to this action please contact your local team at %{organisation_email}, ' \
-      'or for assistance with DMP Assistant contact dmp-assistant@tech.alliancecan.ca.'), user_name: username,
-                                                                                          organisation_email: email)
+    # feedback_confirmation_default_message represents the default feedback message
+    # taken from feedbacks_helper.rb
+    format(feedback_confirmation_default_message, user_name: username, organisation_email: email)
   end
 
   # The preferred logo url for the current configuration. If DRAGONFLY_AWS is true, return

--- a/app/helpers/orgs_helper.rb
+++ b/app/helpers/orgs_helper.rb
@@ -5,19 +5,20 @@ module OrgsHelper
   EMAIL_PLACEHOLDER = '[Organisation Contact Email Placeholder]'
   PLAN_PLACEHOLDER = '[Plan Name Placeholder]'
   USER_PLACEHOLDER = ''
-  # Displays a feedback message
+
+  # Displays a feedback message that the user can edit in the org/Request Feedback section
   #
   # org - The current Org who owns the feedback message being displayed
   # current_user - The current user we're showing feedback message to
   # feedack_message - The feedback message we're displaying
-  # plan_name - Name of the plan we're displaying the feedback message for;
-  #   set to nil because there is no plan name in org feedback form
+  # plan_name - Name of the plan we're displaying the feedback message for
   #
   # Returns String
-  def display_feedback_message(org, current_user, feedback_message, plan_name = nil)
+  def display_editable_feedback_message(org, current_user, feedback_message, plan_name)
     email = org.contact_email || EMAIL_PLACEHOLDER
     username = current_user.name(false) || USER_PLACEHOLDER
     plan_title = plan_name || PLAN_PLACEHOLDER
+
     format(
       _(feedback_message),
       user_name: username, organisation_email: email, plan_name: plan_title
@@ -31,6 +32,25 @@ module OrgsHelper
       message = _('Unable to render feedback message: ')
       message + _(e.message.to_s)
     end
+  end
+
+  # Displays a sample feedback message in the org/Request Feedback section
+  # that is meant to serve as an example
+  #
+  # org - The current Org who owns the feedback message being displayed
+  # current_user - The current user we're showing feedback message to
+  #
+  # Returns String
+  def display_sample_feedback_message(org, current_user)
+    email = org.contact_email || EMAIL_PLACEHOLDER
+    username = current_user.name(false) || USER_PLACEHOLDER
+
+    format(_('<p>Hello %{user_name},</p>' \
+      'A member of your organisation will respond to your request to review your data management plan
+       within 48 hours. ' \
+      'If you have questions pertaining to this action please contact your local team at %{organisation_email}, ' \
+      'or for assistance with DMP Assistant contact dmp-assistant@tech.alliancecan.ca.'), user_name: username,
+                                                                                          organisation_email: email)
   end
 
   # The preferred logo url for the current configuration. If DRAGONFLY_AWS is true, return

--- a/app/helpers/orgs_helper.rb
+++ b/app/helpers/orgs_helper.rb
@@ -5,8 +5,6 @@ module OrgsHelper
   include FeedbacksHelper
 
   EMAIL_PLACEHOLDER = '[Organisation Contact Email Placeholder]'
-  PLAN_PLACEHOLDER = '[Plan Name Placeholder]'
-  USER_PLACEHOLDER = ''
 
   # Displays a feedback message that the user can edit in the org/Request Feedback section
   #
@@ -14,38 +12,24 @@ module OrgsHelper
   # current_user - The current user we're showing feedback message to
   # feedack_message - The feedback message we're displaying
   # plan_name - Name of the plan we're displaying the feedback message for
-  #
-  # Returns String
   def display_editable_feedback_message(org, current_user, feedback_message, plan_name)
     email = org.contact_email || EMAIL_PLACEHOLDER
-    username = current_user.name(false) || USER_PLACEHOLDER
-    plan_title = plan_name || PLAN_PLACEHOLDER
 
     format(
       _(feedback_message),
-      user_name: username, organisation_email: email, plan_name: plan_title
+      user_name: current_user.name(false), organisation_email: email, plan_name: plan_name
     )
   rescue KeyError, ArgumentError => e
     Rails.logger.error("Unable to display feedback message: #{e.message}")
-    # /plans/:plan_id/request_feedback and /org/admin/:org_id/admin_edit both render the feedback_msg
-    # If plan_name.nil?, then we are on /org/admin/:org_id/admin_edit
-    if plan_name.nil?
-      # Only render the error on the org admin page.
-      message = _('Unable to render feedback message: ')
-      message + _(e.message.to_s)
-    end
   end
 
   # Displays a sample feedback message in the org/Request Feedback section
   # that is meant to serve as an example
-  #
-  # Returns String
   def display_sample_feedback_message(org, current_user)
     email = org.contact_email || EMAIL_PLACEHOLDER
-    username = current_user.name(false) || USER_PLACEHOLDER
 
     # feedback_confirmation_default_message is taken from feedbacks_helper.rb
-    format(feedback_confirmation_default_message, user_name: username, organisation_email: email)
+    format(feedback_confirmation_default_message, user_name: current_user.name(false), organisation_email: email)
   end
 
   # The preferred logo url for the current configuration. If DRAGONFLY_AWS is true, return

--- a/app/helpers/orgs_helper.rb
+++ b/app/helpers/orgs_helper.rb
@@ -2,36 +2,6 @@
 
 # Helper methods for Orgs
 module OrgsHelper
-  include FeedbacksHelper
-
-  EMAIL_PLACEHOLDER = '[Organisation Contact Email Placeholder]'
-
-  # Displays a feedback message that the user can edit in the org/Request Feedback section
-  #
-  # org - The current Org who owns the feedback message being displayed
-  # current_user - The current user we're showing feedback message to
-  # feedack_message - The feedback message we're displaying
-  # plan_name - Name of the plan we're displaying the feedback message for
-  def display_editable_feedback_message(org, feedback_message, plan_name)
-    email = org.contact_email || EMAIL_PLACEHOLDER
-
-    format(
-      _(feedback_message),
-      user_name: current_user.name(false), organisation_email: email, plan_name: plan_name
-    )
-  rescue KeyError, ArgumentError => e
-    Rails.logger.error("Unable to display feedback message: #{e.message}")
-  end
-
-  # Displays a sample feedback message in the org/Request Feedback section
-  # that is meant to serve as an example
-  def display_sample_feedback_message(org)
-    email = org.contact_email || EMAIL_PLACEHOLDER
-
-    # feedback_confirmation_default_message is taken from feedbacks_helper.rb
-    format(feedback_confirmation_default_message, user_name: current_user.name(false), organisation_email: email)
-  end
-
   # The preferred logo url for the current configuration. If DRAGONFLY_AWS is true, return
   # the remote_url, otherwise return the url
   def logo_url_for_org(org)

--- a/app/views/orgs/_feedback_form.html.erb
+++ b/app/views/orgs/_feedback_form.html.erb
@@ -38,7 +38,7 @@
       </div>
       <div class="form-group col-xs-4">
         <h4><%= _('Sample Message') %></h4>
-         <%= sanitize display_sample_feedback_message(org, current_user) %>
+         <%= sanitize display_sample_feedback_message(org) %>
       </div>
     </div>
   </div>

--- a/app/views/orgs/_feedback_form.html.erb
+++ b/app/views/orgs/_feedback_form.html.erb
@@ -38,7 +38,7 @@
       </div>
       <div class="form-group col-xs-4">
         <h4><%= _('Sample Message') %></h4>
-         <%= sanitize display_feedback_message(org, current_user, org.feedback_msg) %>
+         <%= sanitize display_sample_feedback_message(org, current_user) %>
       </div>
     </div>
   </div>

--- a/app/views/orgs/_feedback_form.html.erb
+++ b/app/views/orgs/_feedback_form.html.erb
@@ -38,7 +38,7 @@
       </div>
       <div class="form-group col-xs-4">
         <h4><%= _('Sample Message') %></h4>
-         <%= sanitize display_sample_feedback_message(org) %>
+         <%= sanitize sample_feedback_message(org) %>
       </div>
     </div>
   </div>

--- a/app/views/plans/_request_feedback_form.html.erb
+++ b/app/views/plans/_request_feedback_form.html.erb
@@ -12,7 +12,7 @@
        %>
        </p>
       <div class="well well-sm">
-        <%= sanitize display_editable_feedback_message(plan.owner.org, current_user, plan.owner.org.feedback_msg, plan.title) %>
+        <%= sanitize display_editable_feedback_message(plan.owner.org, plan.owner.org.feedback_msg, plan.title) %>
       </div>
       <p><%= _('You can continue to edit and download the plan in the interim.') %></p>
       <div class="form-group col-xs-8">

--- a/app/views/plans/_request_feedback_form.html.erb
+++ b/app/views/plans/_request_feedback_form.html.erb
@@ -12,7 +12,7 @@
        %>
        </p>
       <div class="well well-sm">
-        <%= sanitize display_feedback_message(plan.owner.org, current_user, plan.owner.org.feedback_msg, plan.title) %>
+        <%= sanitize display_editable_feedback_message(plan.owner.org, current_user, plan.owner.org.feedback_msg, plan.title) %>
       </div>
       <p><%= _('You can continue to edit and download the plan in the interim.') %></p>
       <div class="form-group col-xs-8">

--- a/app/views/plans/_request_feedback_form.html.erb
+++ b/app/views/plans/_request_feedback_form.html.erb
@@ -12,7 +12,7 @@
        %>
        </p>
       <div class="well well-sm">
-        <%= sanitize display_editable_feedback_message(plan.owner.org, plan.owner.org.feedback_msg, plan.title) %>
+        <%= sanitize editable_feedback_message(plan.owner.org, plan.owner.org.feedback_msg, plan.title) %>
       </div>
       <p><%= _('You can continue to edit and download the plan in the interim.') %></p>
       <div class="form-group col-xs-8">


### PR DESCRIPTION
In the changes made to the request feedback behaviour [here](https://github.com/portagenetwork/roadmap/pull/1064/files), the sample message was incorrectly changed to reflect the organisation's current feedback message. The correct behaviour is for the sample message to simply serve as a static example to org admins.

Changes proposed in this PR:
- This PR makes the sample message static and also edits the functions for more clarity.
- Both helper functions are moved from `orgs_helper.rb` to `feedbacks_helper.rb`, since that is a more logical location for helper functions for feedback messages.
- The function previously used to display the feedback message in both the text box and sample message (`display_feedback_message`) will be renamed to `editable_feedback_message` as it is only used for the editable text box message. The function `sample_feedback_message` is used to display the static sample feedback message.
- The `current_user` parameter is removed since it is a Devise helper method that can be called directly within the methods without being passed in as an argument.
- `USER_PLACEHOLDER` and `PLAN_PLACEHOLDER` are both removed since they were never necessary, as there is always a username and a plan name.