### PR TITLE
Timeout session after inactivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added 
-
+ - Added session timeout after 90 minutes of inactivity [#1165](https://github.com/portagenetwork/roadmap/pull/1165)
 
 ### Fixed
  - Fix Translation of Permissions in Email [#1123](https://github.com/portagenetwork/roadmap/pull/1123)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -74,9 +74,9 @@ class User < ApplicationRecord
   # Devise
   #   Include default devise modules. Others available are:
   #   :token_authenticatable, :confirmable,
-  #   :lockable, :timeoutable and :omniauthable
+  #   :lockable, and :omniauthable
   devise :invitable, :database_authenticatable, :registerable, :recoverable,
-         :rememberable, :trackable, :validatable, :omniauthable, :confirmable,
+         :rememberable, :trackable, :validatable, :omniauthable, :confirmable, :timeoutable,
          omniauth_providers: %i[shibboleth orcid openid_connect]
 
   ##

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -173,7 +173,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  config.timeout_in = 3.hours
+  config.timeout_in = 90.minutes
 
   # If true, expires auth token on session timeout.
   # config.expire_auth_token_on_timeout = false


### PR DESCRIPTION
Enables the app to timeout sessions after 90 minutes of inactivity.

Changes proposed in this PR:
- Use the `timeoutable` function in devise to timeout users after session inactivity.
- Inactivity counts as anything that is not a request to the app. So scrolling, typing, and mouse movement with no requests all count as inactivity. 
- After the inactivity period has passed, the user will be signed out once they make a request to the app post timeout and will then be redirected to the login page with the flash message "Your session expired, please sign in again to continue".