### PR TITLE
Fix `.docx` issue when opening with Word

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
  - Enable `request_feedback_flash_notice` Translation and Refactor [#1176](https://github.com/portagenetwork/roadmap/pull/1176)
 
+ - Fix `.docx` issue when opening with Word [#1175](https://github.com/portagenetwork/roadmap/pull/1175)
+
 ### Changed
 
  - Strengthened Password Policy [#1158](https://github.com/portagenetwork/roadmap/pull/1158)

--- a/app/views/shared/export/_plan.erb
+++ b/app/views/shared/export/_plan.erb
@@ -44,9 +44,9 @@
                   <% if @show_unanswered %>
                     <%# Hack: for DOCX export - otherwise, bold highlighting of question inconsistent. %>
                     <% if local_assigns[:export_format] && export_format == 'docx' %>
-                      <strong><%=  sanitize question[:text].to_s, scrubber: TableFreeScrubber.new %></strong>
+                      <p class="bold"><%= sanitize question[:text].to_s, scrubber: TableFreeScrubber.new %></p>
                     <% else %>
-                     <div class="bold"><%=  sanitize question[:text].to_s, scrubber: TableFreeScrubber.new %></div>
+                      <div class="bold"><%= sanitize question[:text].to_s, scrubber: TableFreeScrubber.new %></div>
                     <% end %>
                     <br>
                   <% end %>

--- a/app/views/shared/export/_plan.erb
+++ b/app/views/shared/export/_plan.erb
@@ -42,8 +42,9 @@
                   <% blank = answer.present? ? answer.blank? : true %>
                   <% options = answer.present? ? answer.question_options : [] %>
                   <% if @show_unanswered %>
-                    <%# Hack: for DOCX export - otherwise, bold highlighting of question inconsistent. %>
                     <% if local_assigns[:export_format] && export_format == 'docx' %>
+                      <%# Use <p class="bold"> for DOCX export to generate valid paragraphs in the Word XML,
+                        # preventing file corruption and ensuring consistent bold styling. %>
                       <p class="bold"><%= sanitize question[:text].to_s, scrubber: TableFreeScrubber.new %></p>
                     <% else %>
                       <div class="bold"><%= sanitize question[:text].to_s, scrubber: TableFreeScrubber.new %></div>


### PR DESCRIPTION
Fixes # 1172

Changes proposed in this PR:
- This code change is intended to resolve #1172 (see issue for details)
  - Wraps the entire question text in a `<p>` tag with the bold class:
    - This ensures a proper paragraph is generated in the underlying Word XML, preventing corruption while keeping the bold styling.
- Also, cleaned up spacing on line 49
