### PR TITLE
Enable `request_feedback_flash_notice` Translation and Refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
  - Fix Sample Feedback Message Behaviour [#1164](https://github.com/portagenetwork/roadmap/pull/1164)
 
+ - Enable `request_feedback_flash_notice` Translation and Refactor [#1176](https://github.com/portagenetwork/roadmap/pull/1176)
+
 ### Changed
 
  - Strengthened Password Policy [#1158](https://github.com/portagenetwork/roadmap/pull/1158)

--- a/app/controllers/feedback_requests_controller.rb
+++ b/app/controllers/feedback_requests_controller.rb
@@ -14,25 +14,12 @@ class FeedbackRequestsController < ApplicationController
     authorize @plan, :request_feedback?
     begin
       if @plan.request_feedback(current_user)
-        redirect_to request_feedback_plan_path(@plan), notice: _(request_feedback_flash_notice)
+        redirect_to request_feedback_plan_path(@plan), notice: request_feedback_flash_notice(@plan, current_user.org)
       else
         redirect_to request_feedback_plan_path(@plan), alert: ALERT
       end
     rescue StandardError
       redirect_to request_feedback_plan_path(@plan), alert: ERROR
     end
-  end
-
-  private
-
-  # Flash notice for successful feedback requests
-  def request_feedback_flash_notice
-    # This is the flash notice that is shown after a user clicks "Request Feedback"
-    # when creating a plan
-
-    text = _('<p>Your plan "%{plan_name}" has been submitted for feedback from an administrator at your organisation. ' \
-             'If you have questions pertaining to this action, please contact us at %{organisation_email}.</p>')
-
-    feedback_constant_to_text(text, current_user, @plan, current_user.org)
   end
 end

--- a/app/controllers/feedback_requests_controller.rb
+++ b/app/controllers/feedback_requests_controller.rb
@@ -26,16 +26,12 @@ class FeedbackRequestsController < ApplicationController
   private
 
   # Flash notice for successful feedback requests
-  #
-  # Returns String
   def request_feedback_flash_notice
     # This is the flash notice that is shown after a user clicks "Request Feedback"
     # when creating a plan
 
-    text = "<p>Your plan \"%{plan_name}\" has been submitted for feedback from an
-       administrator at your organisation. " \
-      "If you have questions pertaining to this action, please contact us
-      at %{organisation_email}.</p>"
+    text = _('<p>Your plan "%{plan_name}" has been submitted for feedback from an administrator at your organisation. ' \
+             'If you have questions pertaining to this action, please contact us at %{organisation_email}.</p>')
 
     feedback_constant_to_text(text, current_user, @plan, current_user.org)
   end

--- a/app/helpers/feedbacks_helper.rb
+++ b/app/helpers/feedbacks_helper.rb
@@ -17,9 +17,14 @@ module FeedbacksHelper
       'or for assistance with DMP Assistant contact dmp-assistant@tech.alliancecan.ca.')
   end
 
-  def feedback_constant_to_text(text, user, plan, org)
-    format(_(text.to_s), application_name: ApplicationService.application_name, user_name: user.name(false),
-                         plan_name: plan.title, organisation_email: org.contact_email)
+  def request_feedback_flash_notice(plan, org)
+    # Content for the "Request Feedback" flash notice on the plans/:id/request_feedback page
+
+    format(
+      _('<p>Your plan "%{plan_name}" has been submitted for feedback from an administrator at your organisation. ' \
+        'If you have questions pertaining to this action, please contact us at %{organisation_email}.</p>'),
+      plan_name: plan.title, organisation_email: org.contact_email
+    )
   end
 
   # Displays a feedback message that the user can edit in the org/Request Feedback section


### PR DESCRIPTION
# Changes proposed in this PR:
[Enable request_feedback_flash_notice translation](https://github.com/portagenetwork/roadmap/commit/58f7f47a41e1bd9deeec79a16018c46f0577e32f)
- Wraps the string assigned to `text` with `_()`, ensuring it is extracted and
synced to translation.io.
- NOTE: While `feedback_constant_to_text` calls `_(text)`, this does not mark
the original string for extraction, so it was previously never uploaded to
translation.io.

[Refactor request_feedback_flash_notice](https://github.com/portagenetwork/roadmap/commit/28444362539e793d488c2211e9470d44302f67cc)
- Move `request_feedback_flash_notice` from `app/controllers/feedback_requests_controller.rb` to `app/helpers/feedbacks_helper.rb`
- Remove `feedback_constant_to_text` from `app/helpers/feedbacks_helper.rb`.
  - This method was only ever used by `request_feedback_flash_notice` and `format()` can simply be used instead.
- Removed `_()` from `app/controllers/feedback_requests_controller.rb:17`
  - This was attempting to translate messages after the interpolations had been applied. Since the db fields `plan.title` and `org.contact_email` aren't enabled for translation, it is best to remove `_()` here.