### PR TITLE
Refactor org identifier rendering

### DIFF
--- a/app/helpers/identifier_helper.rb
+++ b/app/helpers/identifier_helper.rb
@@ -11,4 +11,14 @@ module IdentifierHelper
 
     link_to "#{prefix} #{without}", id.value, class: 'has-new-window-popup-info'
   end
+
+  def render_org_identifier(presenter:, scheme:, with_scheme_name: false)
+    id = presenter.id_for_scheme(scheme: scheme)
+    content_tag(:div, class: 'row') do
+      content_tag(:div, class: 'form-group col-xs-10') do
+        content_tag(:span, "#{scheme.description}: ", class: 'bold') +
+          id_for_display(id: id, with_scheme_name: with_scheme_name)
+      end
+    end
+  end
 end

--- a/app/views/orgs/_external_identifiers.html.erb
+++ b/app/views/orgs/_external_identifiers.html.erb
@@ -13,13 +13,7 @@
       %w[ror fundref].include?(s.name)
     end
     schemes.each do |scheme| %>
-      <div class="row">
-        <div class="form-group col-xs-10">
-          <% id = presenter.id_for_scheme(scheme: scheme) %>
-          <span class="bold"><%= scheme.description %>:</span>
-          <%= id_for_display(id: id, with_scheme_name: false) %>
-        </div>
-      </div>
+      <%= render_org_identifier(presenter: presenter, scheme: scheme) %>
     <% end %>
 
     <%
@@ -58,13 +52,7 @@
 <%# Otherwise this is an Org Admin so just display the identifiers %>
 <% else %>
   <% presenter.schemes.each do |scheme| %>
-    <div class="row">
-      <div class="form-group col-xs-10">
-        <% id = presenter.id_for_scheme(scheme: scheme) %>
-        <span class="bold"><%= scheme.description %>:</span>
-        <%= id_for_display(id: id, with_scheme_name: false) %>
-      </div>
-    </div>
+    <%= render_org_identifier(presenter: presenter, scheme: scheme) %>
   <% end %>
   <p><%= _("If any of the above identifiers are incorrect or missing, please <a href=\"%{contact_us_url}\">contact us</a> to have them updated.").html_safe % { contact_us_url: contact_us_path } %></p>
 <% end %>


### PR DESCRIPTION
# Changes proposed in this PR:
Moved duplicated markup for identifier rows into `IdentifierHelper#render_org_identifier`
- Keeps views cleaner and centralises the wrapper and display logic.
