### PR TITLE
Reorganize template dropdown menu and refactor `TemplateOptionsController`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [4.1.1+portage-4.6.0]
+## [Unreleased]
 
 ### Added
 
@@ -11,6 +11,8 @@
 ### Changed
 
  - Edit footer logos [#1203](https://github.com/portagenetwork/roadmap/pull/1203)
+
+ - Reorganize template dropdown menu and refactor TemplateOptionsController [#1199](https://github.com/portagenetwork/roadmap/pull/1199)
 
 ### Dependency Updates
 

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -24,8 +24,8 @@ class TemplateOptionsController < ApplicationController
     return unless (org.present? && !org.new_record?) || (funder.present? && !funder.new_record?)
 
     if org.present? && !org.new_record?
-      # Load the funder's template(s) minus the default template (that gets swapped in below)
-      @templates = Template.latest_customizable.where(org_id: funder.id, is_default: false).sort_by(&:title).to_a
+      # Load the funder's template(s)
+      @templates = Template.latest_customizable.where(org_id: funder.id).sort_by(&:title).to_a
       # Wherever possible, replace funder templates with organisational customizations
       @templates = @templates.map do |tmplt|
         customization = Template.published
@@ -46,22 +46,10 @@ class TemplateOptionsController < ApplicationController
     else
       # if'No Primary Research Institution' checkbox is checked,
       # only show publicly available template without customization
-      @templates << Template.default if Template.default.present?
-      @templates << Template.published.publicly_visible.where(org_id: funder.id, customization_of: nil,
-                                                              is_default: false).sort_by(&:title).to_a
+      @templates << Template.published.publicly_visible.where(org_id: funder.id,
+                                                              customization_of: nil).sort_by(&:title).to_a
     end
     @templates = @templates.flatten
-    # Always use the default template
-    if Template.default.present? && org.present?
-      # Fetch the org’s latest customization of the default template
-      customization = Template.published.latest_customized_version(Template.default.family_id, org.id).first
-      # In short: check if `customization` is based on `Template.default`
-      # If so, use `customization`; otherwise, fall back to `Template.default`
-      customization = Template.default unless customization.present? && !customization.upgrade_customization?
-      @templates.select! { |t| t.id != Template.default.id && t.id != customization.id }
-      # We want the default template to appear at the beggining of the list
-      @templates.unshift(customization)
-    end
 
     @templates = sort_templates(@templates, org)
   end

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -25,6 +25,7 @@ class TemplateOptionsController < ApplicationController
 
     if org.present? && !org.new_record?
       # Load the funder's template(s)
+      # (`Template.default` belongs to `funder` and will be fetched as part of this query)
       @templates = Template.latest_customizable.where(org_id: funder.id).sort_by(&:title).to_a
       # Wherever possible, replace funder templates with organisational customizations
       @templates = @templates.map do |tmplt|
@@ -46,6 +47,7 @@ class TemplateOptionsController < ApplicationController
     else
       # if'No Primary Research Institution' checkbox is checked,
       # only show publicly available template without customization
+      # (`Template.default` belongs to `funder` and will be fetched as part of this query)
       @templates << Template.published.publicly_visible.where(org_id: funder.id,
                                                               customization_of: nil).sort_by(&:title).to_a
     end

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -87,20 +87,30 @@ class TemplateOptionsController < ApplicationController
   end
 
   # Assign the order of templates in the dropdown menu
-  def sort_templates(templates, org) # rubocop:disable Metrics/AbcSize
+  # The desired order of templates in the dropdown is:
+  # All organizational templates first followed by the Alliance Simplified Template
+  # Followed by the Alliance Template and then all remaining templates
+  def sort_templates(templates, org) # rubocop:disable Metrics/AbcSize,Metrics/PerceivedComplexity
     # Get all templates belonging to the selected organization
-    org_templates = templates.select { |template| template.org_id == org&.id && template.customization_of.nil? }
+    org_templates = templates.select { |template| template.org_id == org&.id }
 
     # Get the Alliance Simplified Template and the Alliance Template
     alliance_simplified_template = templates.find { |t| t.title.start_with?('Alliance Simplified Template') }
     alliance_template = templates.find { |t| t.title == 'Alliance Template' }
 
-    remaining_templates = templates - org_templates - [alliance_simplified_template, alliance_template]
+    org_is_alliance = org&.name == 'Digital Research Alliance of Canada'
 
-    # The desired order of templates in the dropdown is:
-    # All organizational templates first followed by the Alliance Simplified Template
-    # Followed by the Alliance Template and then all remaining templates
-    # Note: .compact removes nil plans
-    (org_templates + [alliance_simplified_template, alliance_template].compact + remaining_templates).uniq
+    # If the chosen org is the Alliance, its templates must not be removed
+    remaining_templates = if org_is_alliance
+                            templates - [alliance_simplified_template, alliance_template]
+                          else
+                            templates - org_templates - [alliance_simplified_template, alliance_template]
+                          end
+
+    if org_is_alliance
+      ([alliance_simplified_template, alliance_template].compact + remaining_templates).uniq
+    else
+      (org_templates + [alliance_simplified_template, alliance_template].compact + remaining_templates).uniq
+    end
   end
 end

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -69,47 +69,39 @@ class TemplateOptionsController < ApplicationController
     %i[id name url language abbreviation ror fundref weight score]
   end
 
-  def alliance_templates(templates) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity
-    # The default funder is the Alliance
-    default_funder_id = Rails.application.config.default_funder_id
+  # Orders templates for dropdown:
+  # 1. Org templates
+  # 2. Priority funder templates (Simplified, Default)
+  # 3. Remaining funder templates
+  def sort_templates(templates, org)
+    # Get the funder templates with the Priority templates ordered in front
+    sorted_funder_templates = sort_funder_templates(templates)
 
-    simplified = templates.find do |t|
-      t.title.start_with?('Alliance Simplified Template') &&
-        t.org&.id == default_funder_id
+    # If an org was selected and the selected org is not the default funder
+    if org&.id && org.id != Rails.application.config.default_funder_id
+      # Return the templates with the org templates ordered in front
+      org_templates = templates.select { |t| t.org_id == org.id }
+      org_templates + sorted_funder_templates
+    # else, either no org or default_funder was selected
+    else
+      # All of the templates are funder templates
+      sorted_funder_templates
     end
-
-    alliance = templates.find do |t|
-      t.title == 'Alliance Template' &&
-        t.org&.id == default_funder_id &&
-        t.is_default == true
-    end
-
-    [simplified, alliance].compact
   end
 
-  # Assign the order of templates in the dropdown menu
-  # The desired order of templates in the dropdown is:
-  # All organizational templates first followed by the Alliance Simplified Template
-  # Followed by the Alliance Template and then all remaining templates
-  def sort_templates(templates, org) # rubocop:disable Metrics/AbcSize
-    # Get all templates belonging to the selected organization
-    org_templates = templates.select { |template| template.org_id == org&.id }
-    # Get the Alliance Simplified and Full Templates
-    alliance_templates = alliance_templates(templates)
+  # Orders funder templates:
+  # 1. Priority (Simplified, Default)
+  # 2. Remaining funder templates
+  def sort_funder_templates(templates)
+    funder_templates = templates.select { |t| t.org_id == Rails.application.config.default_funder_id }
 
-    org_is_alliance = org&.id == Rails.application.config.default_funder_id
+    # Identify priority templates
+    # NOTE: This will have to be updated if the `simplified` template is ever renamed
+    simplified = funder_templates.find { |t| t.title.start_with?('Alliance Simplified Template') }
+    default   = funder_templates.find(&:is_default)
+    priority  = [simplified, default].compact
 
-    # If the chosen org is the Alliance, its templates must not be removed
-    remaining_templates = if org_is_alliance
-                            templates - alliance_templates
-                          else
-                            templates - org_templates - alliance_templates
-                          end
-
-    if org_is_alliance
-      (alliance_templates + remaining_templates).uniq
-    else
-      (org_templates + alliance_templates + remaining_templates).uniq
-    end
+    # Return priority first, then remaining funder templates
+    priority + (funder_templates - priority)
   end
 end

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -69,9 +69,21 @@ class TemplateOptionsController < ApplicationController
     %i[id name url language abbreviation ror fundref weight score]
   end
 
-  def alliance_templates(templates)
-    simplified = templates.find { |t| t.title.start_with?('Alliance Simplified Template') }
-    alliance   = templates.find { |t| t.title == 'Alliance Template' }
+  def alliance_templates(templates) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity
+    # The default funder is the Alliance
+    default_funder_id = Rails.application.config.default_funder_id
+
+    simplified = templates.find do |t|
+      t.title.start_with?('Alliance Simplified Template') &&
+        t.org&.id == default_funder_id
+    end
+
+    alliance = templates.find do |t|
+      t.title == 'Alliance Template' &&
+        t.org&.id == default_funder_id &&
+        t.is_default == true
+    end
+
     [simplified, alliance].compact
   end
 
@@ -79,13 +91,13 @@ class TemplateOptionsController < ApplicationController
   # The desired order of templates in the dropdown is:
   # All organizational templates first followed by the Alliance Simplified Template
   # Followed by the Alliance Template and then all remaining templates
-  def sort_templates(templates, org)
+  def sort_templates(templates, org) # rubocop:disable Metrics/AbcSize
     # Get all templates belonging to the selected organization
     org_templates = templates.select { |template| template.org_id == org&.id }
     # Get the Alliance Simplified and Full Templates
     alliance_templates = alliance_templates(templates)
 
-    org_is_alliance = org&.name == 'Digital Research Alliance of Canada'
+    org_is_alliance = org&.id == Rails.application.config.default_funder_id
 
     # If the chosen org is the Alliance, its templates must not be removed
     remaining_templates = if org_is_alliance

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -24,16 +24,14 @@ class TemplateOptionsController < ApplicationController
     return unless (org.present? && !org.new_record?) || (funder.present? && !funder.new_record?)
 
     if org.present? && !org.new_record?
-      # Load the funder's template(s) minus the default template (that gets swapped
-      # in below if NO other templates are available)
+      # Load the funder's template(s) minus the default template (that gets swapped in below)
       @templates = Template.latest_customizable.where(org_id: funder.id, is_default: false).sort_by(&:title).to_a
-      # Swap out any organisational cusotmizations of a funder template
+      # Wherever possible, replace funder templates with organisational customizations
       @templates = @templates.map do |tmplt|
         customization = Template.published
                                 .latest_customized_version(tmplt.family_id,
                                                            org.id).first
-        # Only provide the customized version if its still up to date with the
-        # funder template!
+        # Only provide the customized version if it's still up to date with the funder template
         if customization.present? && !customization.upgrade_customization?
           customization
         else
@@ -42,8 +40,6 @@ class TemplateOptionsController < ApplicationController
       end
       # We are using a default funder to provide with the default templates, but
       # We still want to provide the organization templates.
-      # If the no funder was specified OR the funder matches the org
-      # if funder.blank? || funder.id == org&.id
       # Retrieve the Org's templates
       @templates << Template.published.organisationally_visible.where(org_id: org.id,
                                                                       customization_of: nil).sort_by(&:title).to_a
@@ -55,9 +51,6 @@ class TemplateOptionsController < ApplicationController
                                                               is_default: false).sort_by(&:title).to_a
     end
     @templates = @templates.flatten
-    # DMP Assistant: We do not want to include not customized templates from default funder
-    # Include customizable funder templates
-    # @templates << funder_templates = Template.latest_customizable
     # Always use the default template
     if Template.default.present? && org.present?
       # Fetch the org’s latest customization of the default template

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -69,6 +69,23 @@ class TemplateOptionsController < ApplicationController
       # We want the default template to appear at the beggining of the list
       @templates.unshift(customization)
     end
+
+    # Assign the order of templates in the dropdown menu
+    # Get all templates belonging to the organization
+    org_templates = @templates.select { |template| template.org_id == org&.id && template.customization_of.nil? }
+
+    # Get the Alliance Simplified Template and the Alliance Template
+    alliance_simplified_template = @templates.find { |t| t.title.start_with?('Alliance Simplified Template') }
+    alliance_template = @templates.find { |t| t.title == 'Alliance Template' }
+
+    remaining_templates = @templates - org_templates - [alliance_simplified_template, alliance_template]
+
+    # The desired order of templates in the dropdown is:
+    # All organizational templates first followed by the Alliance Simplified Template
+    # Followed by the Alliance Template and then all remaining templates
+    # Note: .compact removes nil plans
+    @templates = org_templates + [alliance_simplified_template, alliance_template].compact + remaining_templates
+
     @templates = @templates.uniq
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -70,23 +70,7 @@ class TemplateOptionsController < ApplicationController
       @templates.unshift(customization)
     end
 
-    # Assign the order of templates in the dropdown menu
-    # Get all templates belonging to the organization
-    org_templates = @templates.select { |template| template.org_id == org&.id && template.customization_of.nil? }
-
-    # Get the Alliance Simplified Template and the Alliance Template
-    alliance_simplified_template = @templates.find { |t| t.title.start_with?('Alliance Simplified Template') }
-    alliance_template = @templates.find { |t| t.title == 'Alliance Template' }
-
-    remaining_templates = @templates - org_templates - [alliance_simplified_template, alliance_template]
-
-    # The desired order of templates in the dropdown is:
-    # All organizational templates first followed by the Alliance Simplified Template
-    # Followed by the Alliance Template and then all remaining templates
-    # Note: .compact removes nil plans
-    @templates = org_templates + [alliance_simplified_template, alliance_template].compact + remaining_templates
-
-    @templates = @templates.uniq
+    @templates = sort_templates(@templates, org)
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
   # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
@@ -100,5 +84,23 @@ class TemplateOptionsController < ApplicationController
 
   def org_params
     %i[id name url language abbreviation ror fundref weight score]
+  end
+
+  # Assign the order of templates in the dropdown menu
+  def sort_templates(templates, org) # rubocop:disable Metrics/AbcSize
+    # Get all templates belonging to the selected organization
+    org_templates = templates.select { |template| template.org_id == org&.id && template.customization_of.nil? }
+
+    # Get the Alliance Simplified Template and the Alliance Template
+    alliance_simplified_template = templates.find { |t| t.title.start_with?('Alliance Simplified Template') }
+    alliance_template = templates.find { |t| t.title == 'Alliance Template' }
+
+    remaining_templates = templates - org_templates - [alliance_simplified_template, alliance_template]
+
+    # The desired order of templates in the dropdown is:
+    # All organizational templates first followed by the Alliance Simplified Template
+    # Followed by the Alliance Template and then all remaining templates
+    # Note: .compact removes nil plans
+    (org_templates + [alliance_simplified_template, alliance_template].compact + remaining_templates).uniq
   end
 end

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -86,31 +86,35 @@ class TemplateOptionsController < ApplicationController
     %i[id name url language abbreviation ror fundref weight score]
   end
 
+  def alliance_templates(templates)
+    simplified = templates.find { |t| t.title.start_with?('Alliance Simplified Template') }
+    alliance   = templates.find { |t| t.title == 'Alliance Template' }
+    [simplified, alliance].compact
+  end
+
   # Assign the order of templates in the dropdown menu
   # The desired order of templates in the dropdown is:
   # All organizational templates first followed by the Alliance Simplified Template
   # Followed by the Alliance Template and then all remaining templates
-  def sort_templates(templates, org) # rubocop:disable Metrics/AbcSize,Metrics/PerceivedComplexity
+  def sort_templates(templates, org)
     # Get all templates belonging to the selected organization
     org_templates = templates.select { |template| template.org_id == org&.id }
-
-    # Get the Alliance Simplified Template and the Alliance Template
-    alliance_simplified_template = templates.find { |t| t.title.start_with?('Alliance Simplified Template') }
-    alliance_template = templates.find { |t| t.title == 'Alliance Template' }
+    # Get the Alliance Simplified and Full Templates
+    alliance_templates = alliance_templates(templates)
 
     org_is_alliance = org&.name == 'Digital Research Alliance of Canada'
 
     # If the chosen org is the Alliance, its templates must not be removed
     remaining_templates = if org_is_alliance
-                            templates - [alliance_simplified_template, alliance_template]
+                            templates - alliance_templates
                           else
-                            templates - org_templates - [alliance_simplified_template, alliance_template]
+                            templates - org_templates - alliance_templates
                           end
 
     if org_is_alliance
-      ([alliance_simplified_template, alliance_template].compact + remaining_templates).uniq
+      (alliance_templates + remaining_templates).uniq
     else
-      (org_templates + [alliance_simplified_template, alliance_template].compact + remaining_templates).uniq
+      (org_templates + alliance_templates + remaining_templates).uniq
     end
   end
 end

--- a/spec/features/plans_spec.rb
+++ b/spec/features/plans_spec.rb
@@ -6,12 +6,13 @@ RSpec.describe 'Plans', type: :feature do
   include Webmocks
 
   before do
-    @default_template = create(:template, :default, :published)
     @org = create(:org)
     @research_org = create(:org, :organisation, :research_institute,
                            name: 'Test Research Org', templates: 1)
     # Create the required default_funder org for DMP Assistant
     @funding_org  = create(:org, :funder, templates: 1)
+    # Create the default template for the default_funder
+    @default_template = create(:template, :default, :published, org_id: @funding_org.id)
     @original_default_funder_id = Rails.application.config.default_funder_id
     Rails.application.config.default_funder_id = @funding_org.id
     @template     = create(:template, org: @org)


### PR DESCRIPTION
Fixes #1196  .

Changes proposed in this PR:
- Change the ordering of templates in the template dropdown menu from alphabetical to all organizational templates first, followed by the  Alliance Simplified Template, Alliance Template, and all remaining templates.
- Simplified template loading logic by removing explicit `Template.default`  handling.
- `Template.latest_customizable.where(org_id: funder.id)` and `Template.published.publicly_visible.where(org_id: funder.id, customization_of: nil)` now fetch the default template as well
- Removed manual insertion and filtering of the default template; `sort_templates()` now determines ordering.
