### PR TITLE
Refactor: Include `Template.default` when Querying Funder Templates in `TemplateOptionsController`

### DIFF
--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -24,8 +24,8 @@ class TemplateOptionsController < ApplicationController
     return unless (org.present? && !org.new_record?) || (funder.present? && !funder.new_record?)
 
     if org.present? && !org.new_record?
-      # Load the funder's template(s) minus the default template (that gets swapped in below)
-      @templates = Template.latest_customizable.where(org_id: funder.id, is_default: false).sort_by(&:title).to_a
+      # Load the funder's template(s)
+      @templates = Template.latest_customizable.where(org_id: funder.id).sort_by(&:title).to_a
       # Wherever possible, replace funder templates with organisational customizations
       @templates = @templates.map do |tmplt|
         customization = Template.published
@@ -46,22 +46,10 @@ class TemplateOptionsController < ApplicationController
     else
       # if'No Primary Research Institution' checkbox is checked,
       # only show publicly available template without customization
-      @templates << Template.default if Template.default.present?
-      @templates << Template.published.publicly_visible.where(org_id: funder.id, customization_of: nil,
-                                                              is_default: false).sort_by(&:title).to_a
+      @templates << Template.published.publicly_visible.where(org_id: funder.id,
+                                                              customization_of: nil).sort_by(&:title).to_a
     end
     @templates = @templates.flatten
-    # Always use the default template
-    if Template.default.present? && org.present?
-      # Fetch the org’s latest customization of the default template
-      customization = Template.published.latest_customized_version(Template.default.family_id, org.id).first
-      # In short: check if `customization` is based on `Template.default`
-      # If so, use `customization`; otherwise, fall back to `Template.default`
-      customization = Template.default unless customization.present? && !customization.upgrade_customization?
-      @templates.select! { |t| t.id != Template.default.id && t.id != customization.id }
-      # We want the default template to appear at the beggining of the list
-      @templates.unshift(customization)
-    end
 
     @templates = sort_templates(@templates, org)
   end

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -25,6 +25,7 @@ class TemplateOptionsController < ApplicationController
 
     if org.present? && !org.new_record?
       # Load the funder's template(s)
+      # (`Template.default` belongs to `funder` and will be fetched as part of this query)
       @templates = Template.latest_customizable.where(org_id: funder.id).sort_by(&:title).to_a
       # Wherever possible, replace funder templates with organisational customizations
       @templates = @templates.map do |tmplt|
@@ -46,6 +47,7 @@ class TemplateOptionsController < ApplicationController
     else
       # if'No Primary Research Institution' checkbox is checked,
       # only show publicly available template without customization
+      # (`Template.default` belongs to `funder` and will be fetched as part of this query)
       @templates << Template.published.publicly_visible.where(org_id: funder.id,
                                                               customization_of: nil).sort_by(&:title).to_a
     end

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -24,16 +24,14 @@ class TemplateOptionsController < ApplicationController
     return unless (org.present? && !org.new_record?) || (funder.present? && !funder.new_record?)
 
     if org.present? && !org.new_record?
-      # Load the funder's template(s) minus the default template (that gets swapped
-      # in below if NO other templates are available)
+      # Load the funder's template(s) minus the default template (that gets swapped in below)
       @templates = Template.latest_customizable.where(org_id: funder.id, is_default: false).sort_by(&:title).to_a
-      # Swap out any organisational cusotmizations of a funder template
+      # Wherever possible, replace funder templates with organisational customizations
       @templates = @templates.map do |tmplt|
         customization = Template.published
                                 .latest_customized_version(tmplt.family_id,
                                                            org.id).first
-        # Only provide the customized version if its still up to date with the
-        # funder template!
+        # Only provide the customized version if it's still up to date with the funder template
         if customization.present? && !customization.upgrade_customization?
           customization
         else
@@ -42,8 +40,6 @@ class TemplateOptionsController < ApplicationController
       end
       # We are using a default funder to provide with the default templates, but
       # We still want to provide the organization templates.
-      # If the no funder was specified OR the funder matches the org
-      # if funder.blank? || funder.id == org&.id
       # Retrieve the Org's templates
       @templates << Template.published.organisationally_visible.where(org_id: org.id,
                                                                       customization_of: nil).sort_by(&:title).to_a
@@ -55,9 +51,6 @@ class TemplateOptionsController < ApplicationController
                                                               is_default: false).sort_by(&:title).to_a
     end
     @templates = @templates.flatten
-    # DMP Assistant: We do not want to include not customized templates from default funder
-    # Include customizable funder templates
-    # @templates << funder_templates = Template.latest_customizable
     # Always use the default template
     if Template.default.present? && org.present?
       # Fetch the org’s latest customization of the default template

--- a/spec/features/plans_spec.rb
+++ b/spec/features/plans_spec.rb
@@ -6,12 +6,13 @@ RSpec.describe 'Plans', type: :feature do
   include Webmocks
 
   before do
-    @default_template = create(:template, :default, :published)
     @org = create(:org)
     @research_org = create(:org, :organisation, :research_institute,
                            name: 'Test Research Org', templates: 1)
     # Create the required default_funder org for DMP Assistant
     @funding_org  = create(:org, :funder, templates: 1)
+    # Create the default template for the default_funder
+    @default_template = create(:template, :default, :published, org_id: @funding_org.id)
     @original_default_funder_id = Rails.application.config.default_funder_id
     Rails.application.config.default_funder_id = @funding_org.id
     @template     = create(:template, org: @org)


### PR DESCRIPTION
# Changes proposed in this PR:
Simplified template loading logic by removing explicit `Template.default`  handling.
- `Template.latest_customizable.where(org_id: funder.id)` and `Template.published.publicly_visible.where(org_id: funder.id, customization_of: nil)` now fetch the default template as well
- Removed manual insertion and filtering of the default template; `sort_templates()` now determines ordering.