### PR TITLE
Add headers and "Show more templates" button to template dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-
+ - Add headers and "Show more templates" button to template dropdown [#1215](https://github.com/portagenetwork/roadmap/pull/1215) 
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
  - Refactor: Consolidate repeated custom colour variables across stylesheets [#1218](https://github.com/portagenetwork/roadmap/pull/1218)
 
+ - Update template validation on plan creation [#1225](https://github.com/portagenetwork/roadmap/pull/1225)
+
 ### Dependency Updates
 
  - chore(deps): bump nginx from 1.29.1-alpine to 1.29.2-alpine [#1207](https://github.com/portagenetwork/roadmap/pull/1207)

--- a/app/assets/stylesheets/blocks/_index.scss
+++ b/app/assets/stylesheets/blocks/_index.scss
@@ -36,6 +36,7 @@
 @use 'spinner';
 @use 'statuses';
 @use 'tables';
+@use '../dmp-assistant/blocks/template_dropdown_menu';
 @use 'template_filters';
 @use 'tinymce_content';
 @use 'tooltips';

--- a/app/assets/stylesheets/blocks/_index.scss
+++ b/app/assets/stylesheets/blocks/_index.scss
@@ -36,7 +36,6 @@
 @use 'spinner';
 @use 'statuses';
 @use 'tables';
-@use '../dmp-assistant/blocks/template_dropdown_menu';
 @use 'template_filters';
 @use 'tinymce_content';
 @use 'tooltips';

--- a/app/assets/stylesheets/dmp-assistant/blocks/_index.scss
+++ b/app/assets/stylesheets/dmp-assistant/blocks/_index.scss
@@ -1,1 +1,2 @@
 @use 'password_checklist';
+@use 'template_dropdown_menu';

--- a/app/assets/stylesheets/dmp-assistant/blocks/_template_dropdown_menu.scss
+++ b/app/assets/stylesheets/dmp-assistant/blocks/_template_dropdown_menu.scss
@@ -20,3 +20,19 @@
   background-color: #f0f0f0;
   text-decoration: none;
 }
+
+.dropdown-header {
+  font-weight: 600;
+  font-size: 1rem;
+  text-transform: uppercase;
+  color: #050404;
+  background-color: #f8f9fa;
+}
+
+.dropdown-divider {
+  margin: 0.25rem 0;
+}
+
+.dropdown-item {
+  padding-left: 1.5rem;
+}

--- a/app/assets/stylesheets/dmp-assistant/blocks/_template_dropdown_menu.scss
+++ b/app/assets/stylesheets/dmp-assistant/blocks/_template_dropdown_menu.scss
@@ -21,8 +21,10 @@
   text-decoration: none;
 }
 
+/* Style for the template headers */
 .dropdown-header {
-  font-weight: 600;
+  font-family: inherit;
+  font-weight: 500;
   font-size: 1rem;
   text-transform: uppercase;
   color: #050404;
@@ -30,9 +32,31 @@
 }
 
 .dropdown-divider {
-  margin: 0.25rem 0;
+  margin: 0.5rem 0;
 }
 
 .dropdown-item {
   padding-left: 1.5rem;
+}
+
+/* Style for the 'Show more templates' button inside dropdown */
+#show-more-templates {
+  width: 100%;
+  background: transparent;
+  border: none;
+  text-align: center;
+  font-family: inherit;
+  font-weight: 500;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+}
+
+#show-more-templates:hover {
+  text-decoration: underline;
+  background-color: rgba(0, 0, 0, 0.03);
+}
+
+#show-more-templates:focus {
+  outline: none;
+  box-shadow: none;
 }

--- a/app/assets/stylesheets/dmp-assistant/blocks/_template_dropdown_menu.scss
+++ b/app/assets/stylesheets/dmp-assistant/blocks/_template_dropdown_menu.scss
@@ -1,7 +1,6 @@
 @use '../../dmp-assistant/variables/colours' as *;
 
 #template-dropdown-menu {
-  max-height: 300px;
   overflow-y: auto;
   overflow-x: hidden;
   border: 1px solid $color-alliance-lighter-grey;

--- a/app/assets/stylesheets/dmp-assistant/blocks/_template_dropdown_menu.scss
+++ b/app/assets/stylesheets/dmp-assistant/blocks/_template_dropdown_menu.scss
@@ -1,0 +1,22 @@
+#template-dropdown-menu {
+  max-height: 300px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  border: 1px solid #ccc;
+  z-index: 1050;
+}
+
+#template-dropdown-menu .dropdown-item {
+  display: block;
+  padding: 6px 12px;
+  font-size: 14px;
+  line-height: 1.4;
+  white-space: normal;
+  color: #212529;
+  text-decoration: none;
+}
+
+#template-dropdown-menu .dropdown-item:hover {
+  background-color: #f0f0f0;
+  text-decoration: none;
+}

--- a/app/assets/stylesheets/dmp-assistant/blocks/_template_dropdown_menu.scss
+++ b/app/assets/stylesheets/dmp-assistant/blocks/_template_dropdown_menu.scss
@@ -5,47 +5,45 @@
   overflow-y: auto;
   overflow-x: hidden;
   border: 1px solid $color-alliance-lighter-grey;
-}
 
-#template-dropdown-menu .dropdown-item {
-  display: block;
-  padding: 6px 12px;
-  font-size: 14px;
-  line-height: 1.4;
-  white-space: normal;
-  color: $color-alliance-digital-grey;
-  text-decoration: none;
-}
+  /* Style for individual dropdown items */
+  .dropdown-item {
+    display: block;
+    padding: 6px 12px;
+    font-size: 14px;
+    line-height: 1.4;
+    white-space: normal;
+    color: $color-alliance-digital-grey;
+    text-decoration: none;
+    padding-left: 1.5rem;
 
-#template-dropdown-menu .dropdown-item:hover {
-  color: $color-alliance-yellow;
-  background-color:$color-alliance-digital-grey;
-}
+    &:hover {
+      color: $color-alliance-yellow;
+      background-color: $color-alliance-digital-grey;
+    }
+  }
 
-/* Style for the template headers */
-.dropdown-header {
-  font-family: inherit;
-  font-weight: 500;
-  font-size: 1rem;
-  text-transform: uppercase;
-  color: $color-alliance-yellow;
-  background-color: $color-alliance-digital-grey;
-}
+  /* Style for the template headers */
+  .dropdown-header {
+    font-family: inherit;
+    font-weight: 500;
+    font-size: 1rem;
+    text-transform: uppercase;
+    color: $color-alliance-yellow;
+    background-color: $color-alliance-digital-grey;
+  }
 
-.dropdown-divider {
-  margin: 0.5rem 0;
-}
+  .dropdown-divider {
+    margin: 0.5rem 0;
+  }
 
-.dropdown-item {
-  padding-left: 1.5rem;
-}
-
-/* Style for the 'Show more templates' button inside dropdown */
-#show-more-templates {
-  width: 100%;
-  text-align: center;
-  font-family: inherit;
-  font-weight: 500;
-  padding: 0.5rem 0.75rem;
-  cursor: pointer;
+  /* Style for the 'Show more templates' button inside dropdown */
+  #show-more-templates {
+    width: 100%;
+    text-align: center;
+    font-family: inherit;
+    font-weight: 500;
+    padding: 0.5rem 0.75rem;
+    cursor: pointer;
+  }
 }

--- a/app/assets/stylesheets/dmp-assistant/blocks/_template_dropdown_menu.scss
+++ b/app/assets/stylesheets/dmp-assistant/blocks/_template_dropdown_menu.scss
@@ -1,9 +1,10 @@
+@use '../../dmp-assistant/variables/colours' as *;
+
 #template-dropdown-menu {
   max-height: 300px;
   overflow-y: auto;
   overflow-x: hidden;
-  border: 1px solid #ccc;
-  z-index: 1050;
+  border: 1px solid $color-alliance-lighter-grey;
 }
 
 #template-dropdown-menu .dropdown-item {
@@ -12,13 +13,13 @@
   font-size: 14px;
   line-height: 1.4;
   white-space: normal;
-  color: #212529;
+  color: $color-alliance-digital-grey;
   text-decoration: none;
 }
 
 #template-dropdown-menu .dropdown-item:hover {
-  background-color: #f0f0f0;
-  text-decoration: none;
+  color: $color-alliance-yellow;
+  background-color:$color-alliance-digital-grey;
 }
 
 /* Style for the template headers */
@@ -27,8 +28,8 @@
   font-weight: 500;
   font-size: 1rem;
   text-transform: uppercase;
-  color: #050404;
-  background-color: #f8f9fa;
+  color: $color-alliance-yellow;
+  background-color: $color-alliance-digital-grey;
 }
 
 .dropdown-divider {
@@ -42,21 +43,9 @@
 /* Style for the 'Show more templates' button inside dropdown */
 #show-more-templates {
   width: 100%;
-  background: transparent;
-  border: none;
   text-align: center;
   font-family: inherit;
   font-weight: 500;
   padding: 0.5rem 0.75rem;
   cursor: pointer;
-}
-
-#show-more-templates:hover {
-  text-decoration: underline;
-  background-color: rgba(0, 0, 0, 0.03);
-}
-
-#show-more-templates:focus {
-  outline: none;
-  box-shadow: none;
 }

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -63,10 +63,9 @@ class PlansController < ApplicationController
     @plan = Plan.new
     authorize @plan
 
-    # If the template_id is blank then we need to look up the available templates and
-    # return JSON
-    if plan_params[:template_id].blank?
-      # Something went wrong there should always be a template id
+    # Ensure the plan will be associated with a valid Template
+    template = find_valid_template(plan_params[:template_id])
+    if template.nil?
       respond_to do |format|
         flash[:alert] = _('Unable to identify a suitable template for your plan.')
         format.html { redirect_to new_plan_path }
@@ -78,7 +77,7 @@ class PlansController < ApplicationController
                            plan_params[:visibility]
                          end
 
-      @plan.template = Template.find(plan_params[:template_id])
+      @plan.template = template
 
       @plan.title = if plan_params[:title].blank?
                       if current_user.firstname.blank?
@@ -481,6 +480,12 @@ class PlansController < ApplicationController
                   grant: %i[name value],
                   org: %i[id org_id org_name org_sources org_crosswalk],
                   funder: %i[id org_id org_name org_sources org_crosswalk])
+  end
+
+  # Returns the template if it exists, is published, and not archived;
+  # otherwise returns nil
+  def find_valid_template(template_id)
+    Template.where(id: template_id, published: true, archived: false).first
   end
 
   # different versions of the same template have the same family_id

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -7,6 +7,8 @@ class TemplateOptionsController < ApplicationController
 
   after_action :verify_authorized
 
+  DEFAULT_FUNDER_ID = Rails.application.config.default_funder_id
+
   # GET /template_options  (AJAX)
   # Collect all of the templates available for the org+funder combination
   # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
@@ -17,7 +19,7 @@ class TemplateOptionsController < ApplicationController
     authorize Template.new, :template_options?
 
     org = org_from_params(params_in: { org_id: org_hash.to_json }) if org_hash.present?
-    funder = Org.find(Rails.application.config.default_funder_id)
+    funder = Org.find(DEFAULT_FUNDER_ID)
 
     @templates = []
 
@@ -78,7 +80,7 @@ class TemplateOptionsController < ApplicationController
     sorted_funder_templates = sort_funder_templates(templates)
 
     # If an org was selected and the selected org is not the default funder
-    if org&.id && org.id != Rails.application.config.default_funder_id
+    if org&.id && org.id != DEFAULT_FUNDER_ID
       # Return the templates with the org templates ordered in front
       org_templates = templates.select { |t| t.org_id == org.id }
       org_templates + sorted_funder_templates
@@ -93,7 +95,7 @@ class TemplateOptionsController < ApplicationController
   # 1. Priority (Simplified, Default)
   # 2. Remaining funder templates
   def sort_funder_templates(templates)
-    funder_templates = templates.select { |t| t.org_id == Rails.application.config.default_funder_id }
+    funder_templates = templates.select { |t| t.org_id == DEFAULT_FUNDER_ID }
 
     # Identify priority templates
     # NOTE: This will have to be updated if the `simplified` template is ever renamed

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -56,6 +56,10 @@ class TemplateOptionsController < ApplicationController
     @templates = @templates.flatten
 
     @templates = sort_templates(@templates, org)
+
+    respond_to do |format|
+      format.json { render json: { templates: @templates } }
+    end
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
   # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
@@ -65,6 +69,14 @@ class TemplateOptionsController < ApplicationController
   def plan_params
     params.require(:plan).permit(research_org_id: org_params,
                                  funder_id: org_params)
+  end
+
+  # Tag each template with a source
+  # Will be used to organize templates with headers
+  def tag_templates(templates, tag)
+    templates.map do |t|
+      t.as_json.merge(source: tag)
+    end
   end
 
   def org_params
@@ -83,7 +95,8 @@ class TemplateOptionsController < ApplicationController
     if org&.id && org.id != DEFAULT_FUNDER_ID
       # Return the templates with the org templates ordered in front
       org_templates = templates.select { |t| t.org_id == org.id }
-      org_templates + sorted_funder_templates
+      tagged_org_templates = tag_templates(org_templates, 'org_template')
+      tagged_org_templates + sorted_funder_templates
     # else, either no org or default_funder was selected
     else
       # All of the templates are funder templates
@@ -102,8 +115,12 @@ class TemplateOptionsController < ApplicationController
     simplified = funder_templates.find { |t| t.title.start_with?('Alliance Simplified Template') }
     default   = funder_templates.find(&:is_default)
     priority  = [simplified, default].compact
+    other = funder_templates - priority
+
+    tagged_priority = tag_templates(priority, 'priority')
+    tagged_other = tag_templates(other, 'other')
 
     # Return priority first, then remaining funder templates
-    priority + (funder_templates - priority)
+    tagged_priority + tagged_other
   end
 end

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -55,10 +55,8 @@ class TemplateOptionsController < ApplicationController
     end
     @templates = @templates.flatten
 
-    @templates = sort_templates(@templates, org)
-
     respond_to do |format|
-      format.json { render json: { templates: @templates } }
+      format.json { render json: build_templates_payload(@templates) }
     end
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
@@ -71,56 +69,25 @@ class TemplateOptionsController < ApplicationController
                                  funder_id: org_params)
   end
 
-  # Tag each template with a source
-  # Will be used to organize templates with headers
-  def tag_templates(templates, tag)
-    templates.map do |t|
-      t.as_json.merge(source: tag)
-    end
-  end
-
   def org_params
     %i[id name url language abbreviation ror fundref weight score]
   end
 
-  # Orders templates for dropdown:
-  # 1. Org templates
-  # 2. Priority funder templates (Simplified, Default)
-  # 3. Remaining funder templates
-  def sort_templates(templates, org)
-    # Get the funder templates with the Priority templates ordered in front
-    sorted_funder_templates = sort_funder_templates(templates)
-
-    # If an org was selected and the selected org is not the default funder
-    if org&.id && org.id != DEFAULT_FUNDER_ID
-      # Return the templates with the org templates ordered in front
-      org_templates = templates.select { |t| t.org_id == org.id }
-      tagged_org_templates = tag_templates(org_templates, 'org_template')
-      tagged_org_templates + sorted_funder_templates
-    # else, either no org or default_funder was selected
-    else
-      # All of the templates are funder templates
-      sorted_funder_templates
-    end
-  end
-
-  # Orders funder templates:
-  # 1. Priority (Simplified, Default)
-  # 2. Remaining funder templates
-  def sort_funder_templates(templates)
+  # Returns a JSON payload with the following structure:
+  # - templates:
+  #   - org_templates: [All non-funder templates]
+  #   - priority_templates: [The simplified and default funder templates]
+  #   - other_templates: [All non-priority funder templates]
+  # - total_templates: Count of all templates
+  def build_templates_payload(templates)
     funder_templates = templates.select { |t| t.org_id == DEFAULT_FUNDER_ID }
-
-    # Identify priority templates
-    # NOTE: This will have to be updated if the `simplified` template is ever renamed
     simplified = funder_templates.find { |t| t.title.start_with?('Alliance Simplified Template') }
-    default   = funder_templates.find(&:is_default)
-    priority  = [simplified, default].compact
-    other = funder_templates - priority
+    default    = funder_templates.find(&:is_default)
+    priority_templates = [simplified, default].compact
 
-    tagged_priority = tag_templates(priority, 'priority')
-    tagged_other = tag_templates(other, 'other')
-
-    # Return priority first, then remaining funder templates
-    tagged_priority + tagged_other
+    { templates: { org_templates: templates - funder_templates,
+                   priority_templates: priority_templates,
+                   other_templates: funder_templates - priority_templates },
+      total_templates: templates.size }
   end
 end

--- a/app/javascript/src/plans/new.js
+++ b/app/javascript/src/plans/new.js
@@ -32,37 +32,37 @@ $(() => {
     hideNotifications();
     const menu = $('#template-dropdown-menu');
     menu.empty();
+    const templates = data.templates
 
-    if (isObject(data) && isArray(data.templates)) {
-      // Display the available_templates section
-      if (data.templates.length > 0) {
-        data.templates.forEach((t) => {
-          const item = $(`<a class="dropdown-item" href="#" data-id="${t.id}">${t.title}</a>`);
-          item.on('click', (e) => {
-            $('#templateDropdown').text(t.title);
-            $('#plan_template_id').val(t.id);
-            toggleSubmit(false);
-          });
-          menu.append(item);
-        });
-        
-        // If there is only one template, set the input field value and submit the form
-        // otherwise show the dropdown list and the 'Multiple templates found message'
-        if (data.templates.length === 1) {
-          const only = data.templates[0];
-          $('#templateDropdown').text(only.title);
-          $('#plan_template_id').val(only.id);
-          $('#multiple-templates').hide();
-          $('#available-templates').fadeOut();
-        } else {
-          $('#multiple-templates').show();
-          $('#available-templates').fadeIn();
-        }
-        toggleSubmit(false);
-      } else {
-        error();
-      }
+    if (!isObject(data) || !isArray(templates) || templates.length === 0) {
+      return error();
     }
+
+    // Display the available_templates section
+    data.templates.forEach((t) => {
+      const item = $(`<a class="dropdown-item" href="#" data-id="${t.id}">${t.title}</a>`);
+      item.on('click', (e) => {
+        $('#templateDropdown').text(t.title);
+        $('#plan_template_id').val(t.id);
+        toggleSubmit(false);
+      });
+      menu.append(item);
+    });
+        
+    // If there is only one template, set the input field value and submit the form
+    // otherwise show the dropdown list and the 'Multiple templates found message'
+    if (templates.length === 1) {
+      const only_template = templates[0];
+      $('#templateDropdown').text(only_template.title);
+      $('#plan_template_id').val(only_template.id);
+      $('#multiple-templates').hide();
+      $('#available-templates').fadeOut();
+    } else {
+      $('#multiple-templates').show();
+      $('#available-templates').fadeIn();
+    }
+    
+    toggleSubmit(false);
   };
 
   // TODO: Refactor this whole thing when we redo the create plan

--- a/app/javascript/src/plans/new.js
+++ b/app/javascript/src/plans/new.js
@@ -8,7 +8,7 @@ $(() => {
   // Cache repeatedly used selectors
   const newPlanForm = $('#new_plan');
   const planTemplateID = $('#plan_template_id');
-  const templateDropdown = $('#templateDropdown');
+  const templateDropdown = $('#template-dropdown');
   const templateDropdownMenu = $('#template-dropdown-menu');
   const multipleTemplates = $('#multiple-templates');
   const availableTemplates = $('#available-templates');
@@ -94,19 +94,21 @@ $(() => {
     });
   };
 
-  // Helper function to adjust the height of the template dropdown
-  // and make sure it does not extend beyond the footer
-  const adjustDropdownMaxHeight = () => {
+  // Helper for resizing width and height of templateDropdownMenu
+  // Matches width to that of the dropdown button (prevents resizing when "Show more..." is clicked)
+  // Sets max-height to avoid extending beyond the footer
+  const resizeTemplateDropdownMenu = () => {
     const templateDropdownEl = templateDropdown.get(0);
     const templateDropdownMenuEl = templateDropdownMenu.get(0);
     const footerEl = document.getElementById('footer-navbar');
-    // .offsetParent returns the nearest ancestor that has a position other than static
-    // (returns null if the element is not visible)
-    const isVisible = templateDropdownEl.offsetParent !== null;
 
     // Return early if any required element is missing or dropdown is not visible
-    if (!(templateDropdownEl && templateDropdownMenuEl && footerEl  && isVisible)) return;
+    if (!(templateDropdownEl && templateDropdownMenuEl && footerEl  && templateDropdown.is(':visible'))) return;
 
+    // Set width
+    templateDropdownMenu.outerWidth(templateDropdown.outerWidth());
+
+    // Set maxHeight
     const dropdownRect = templateDropdownEl.getBoundingClientRect();
     const footerRect = footerEl.getBoundingClientRect();
 
@@ -152,8 +154,7 @@ $(() => {
       multipleTemplates.show();
       availableTemplates.fadeIn();
     }
-    // Adjust templateDropdown's maxHeight to not overextend
-    adjustDropdownMaxHeight();
+    resizeTemplateDropdownMenu();
     toggleSubmit();
   };
 

--- a/app/javascript/src/plans/new.js
+++ b/app/javascript/src/plans/new.js
@@ -5,9 +5,9 @@ import { isObject, isArray, isString } from '../utils/isType';
 import { renderAlert, hideNotifications } from '../utils/notificationHelper';
 
 $(() => {
-  const toggleSubmit = (select_dropdown = true) => {
+  const toggleSubmit = (selectDropdown = true) => {
     let tmplt;
-    if (select_dropdown) {
+    if (selectDropdown) {
       tmplt = $('#plan_template_id').find(':selected').val();
     } else {
       tmplt = $('#plan_template_id').val();

--- a/app/javascript/src/plans/new.js
+++ b/app/javascript/src/plans/new.js
@@ -147,38 +147,18 @@ $(() => {
   };
 
   // Function to reset the template dropdown
-  const resetTemplateDropdown = () => {
-    // Reset dropdown text and hidden field
-    $('#templateDropdown').text('Please select a template');
+  const resetTemplateDropdown = (isValidOrg = false) => {
+    // Always fade out and reset hidden value
+    $('#available-templates').fadeOut();
     $('#plan_template_id').val('');
 
-    // Clear any existing menu items
-    $('#template-dropdown-menu').empty();
-
-    // Fade out templates section while new ones are fetched
-    $('#available-templates').fadeOut();
-  };
-
-  // Reset dropdown only when a *valid org* is selected
-  $('#research-org-controls input.autocomplete-result').on('change', function () {
-    const val = $(this).val();
-
-    if (val) {
-      try {
-        const json = JSON.parse(val);
-        if (json.id) {
-          // Only reset if the selection actually represents a valid org
-          resetTemplateDropdown();
-        }
-      } catch (e) {
-        // Ignore invalid JSON (user still typing, etc.)
-        console.log('Autocomplete change ignored (invalid JSON)');
-      }
+    if (isValidOrg) {
+      // Reset dropdown text
+      $('#templateDropdown').text('Please select a template');
+      // Clear any existing menu items
+      $('#template-dropdown-menu').empty();
     }
-  });
-
-  // Reset dropdown when "No research organisation" checkbox is toggled
-  $('#plan_no_org').on('change', resetTemplateDropdown);
+  };
 
   // TODO: Refactor this whole thing when we redo the create plan
   //       workflow and use js.erb instead!
@@ -216,16 +196,14 @@ $(() => {
     const orgContext = $('#research-org-controls');
     const funderContext = $('#funder-org-controls');
     const validOrg = validOptions(orgContext);
+    resetTemplateDropdown(validOrg)
 
     // DMP Assistant does not require a funder for creating a plan. Instead the
     // Plan controller will search for the default funder when creating the
     // plan. In our current case this will be "Portage Network"
     // const validFunder = validOptions(funderContext);
 
-    // if (!validOrg || !validFunder) {
     if (!validOrg) {
-      $('#available-templates').fadeOut();
-      $('#plan_template_id').val('');
       toggleSubmit();
     } else {
       let orgId = orgContext.find('input[id$="org_id"]').val();

--- a/app/javascript/src/plans/new.js
+++ b/app/javascript/src/plans/new.js
@@ -33,19 +33,21 @@ $(() => {
     renderAlert(getConstant('NO_TEMPLATE_FOUND_ERROR'));
   };
 
-  // Helper for success() that creates a clickable template item
-  const createTemplateItem = (template) => {
-    const title = $('<div>').text(template.title).html();
-    const item = $(`<a class="dropdown-item" href="#" data-id="${template.id}">${title}</a>`);
-
-    item.on('click', (e) => {
-      e.preventDefault()
-      templateDropdown.text(template.title);
-      planTemplateID.val(template.id);
+  // Binds a delegated click handler on templateDropdownMenu to handle clicks on template items
+  const bindTemplateDropdownMenuClickHandler = () => {
+    templateDropdownMenu.on('click', 'a.dropdown-item', (e) => {
+      e.preventDefault();
+      const target = $(e.currentTarget);
+      planTemplateID.val(target.data('id'));
+      templateDropdown.text(target.data('title'));
       toggleSubmit();
     });
+  }
 
-    return item;
+  // Helper for success() that creates a template item
+  const createTemplateItem = (template) => {
+    const title = $('<div>').text(template.title).html();
+    return $(`<a class="dropdown-item" href="#" data-id="${template.id}" data-title="${template.title}">${title}</a>`);
   };
 
   // Helper for success() that appends a group of templates with a header
@@ -286,6 +288,7 @@ $(() => {
 
   // Initialize the form
   availableTemplates.hide();
+  bindTemplateDropdownMenuClickHandler();
   handleComboboxChange();
   // Scrub out the large arrays of data used for the Org Selector JS so that they
   // are not a part of the form submissiomn

--- a/app/javascript/src/plans/new.js
+++ b/app/javascript/src/plans/new.js
@@ -27,96 +27,94 @@ $(() => {
     renderAlert(getConstant('NO_TEMPLATE_FOUND_ERROR'));
   };
 
-  // AJAX success function for available template search
-  const success = (data) => {
-    hideNotifications();
-    const menu = $('#template-dropdown-menu');
-    menu.empty();
-    const templates = data.templates
-
-    if (!isObject(data) || !isArray(templates) || templates.length === 0) {
-      return error();
-    }
-
+  // Helper for success() that separates templates by source
+  const categorizeTemplates = (templates) => {
     // Separate templates by source
     const orgTemplates = [];
     const priorityTemplates = [];
     const otherTemplates = [];
 
-    data.templates.forEach((t) => {
-      if (t.source === 'org_template') {
-        orgTemplates.push(t);
-      } else if (t.source === 'priority') {
-        priorityTemplates.push(t);
-      } else {
-        otherTemplates.push(t);
-      }
+    templates.forEach((t) => {
+      if (t.source === 'org_template') orgTemplates.push(t);
+      else if (t.source === 'priority') priorityTemplates.push(t);
+      else otherTemplates.push(t);
     });
 
-    // Helper to append a header and templates
-    const appendGroup = (header, templates) => {
-      if (templates.length === 0) return;
+    return { orgTemplates, priorityTemplates, otherTemplates };
+  };
 
-      menu.append(`<h6 class="dropdown-header text-muted">${header}</h6>`);
+  // Helper for success() that creates a clickable template item
+  const createTemplateItem = (template) => {
+    const title = $('<div>').text(template.title).html();
+    const item = $(`<a class="dropdown-item" href="#" data-id="${template.id}">${title}</a>`);
 
-      templates.forEach((t) => {
-        const title = $('<div>').text(t.title).html();
-        const item = $(`<a class="dropdown-item" href="#" data-id="${t.id}">${title}</a>`);
+    item.on('click', (e) => {
+      $('#templateDropdown').text(template.title);
+      $('#plan_template_id').val(template.id);
+      toggleSubmit(false);
+    });
 
-        item.on('click', (e) => {
-          $('#templateDropdown').text(t.title);
-          $('#plan_template_id').val(t.id);
-          toggleSubmit(false);
-        });
+    return item;
+  };
 
-        menu.append(item);
-      });
+  // Helper for success() that appends a group of templates with a header
+  // for organization in the template dropdown menu
+  const appendGroup = (menu, header, templates) => {
+    if (templates.length === 0) return;
 
-      menu.append('<div class="dropdown-divider"></div>');
-    };
+    menu.append(`<h6 class="dropdown-header text-muted">${header}</h6>`);
+    templates.forEach((t) => menu.append(createTemplateItem(t)));
+    menu.append('<div class="dropdown-divider"></div>');
+  };
 
-    // Append each category in the correct order
-    appendGroup('Organisational Templates', orgTemplates);
-    appendGroup('Alliance General Templates', priorityTemplates);
+  // Helper for success() that appends the "Show more templates" button and other templates
+  const appendShowMoreSection = (menu, otherTemplates) => {
+    if (otherTemplates.length === 0) return;
 
-    // Add "Show more templates" button to display other templates
-    if (otherTemplates.length > 0) {
-      const showMore = $(`
-        <button type="button" class="dropdown-item text-primary" id="show-more-templates">
-          Show more templates
-        </button>
-      `);
+    const showMore = $(`
+      <button type="button" class="dropdown-item text-primary" id="show-more-templates">
+        Show more templates
+      </button>
+    `);
+    
+    menu.append(showMore);
+    // Hidden section for the "other" templates
+    const hiddenContainer = $('<div id="extra-templates" style="display:none;"></div>');
+    menu.append(hiddenContainer);
 
-      menu.append(showMore);
+    // When clicked, expand the hidden templates without closing dropdown
+    showMore.on('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation(); // prevent closing dropdown
 
-      // Hidden section for the "other" templates
-      const hiddenContainer = $('<div id="extra-templates" style="display: none;"></div>');
-      menu.append(hiddenContainer);
+      hiddenContainer.empty(); // clear before adding
+      hiddenContainer.append('<h6 class="dropdown-header text-muted">Additional Alliance Templates</h6>');
+      otherTemplates.forEach((t) => hiddenContainer.append(createTemplateItem(t)));
 
-      // When clicked, expand the hidden templates without closing dropdown
-      showMore.on('click', (e) => {
-        e.preventDefault();
-        e.stopPropagation(); // prevent closing dropdown
+      hiddenContainer.slideDown(10);
+      showMore.remove(); // remove the button after expansion
+    });
+  };
 
-        hiddenContainer.empty(); // clear before adding
-        hiddenContainer.append('<h6 class="dropdown-header text-muted">Additional Alliance Templates</h6>');
-        otherTemplates.forEach((t) => {
-          const title = $('<div>').text(t.title).html();
-          const item = $(`<a class="dropdown-item" href="#" data-id="${t.id}">${title}</a>`);
-          item.on('click', (e2) => {
-            e2.preventDefault();
-            $('#templateDropdown').text(t.title);
-            $('#plan_template_id').val(t.id);
-            toggleSubmit(false);
-          });
-          hiddenContainer.append(item);
-        });
+  // AJAX success function for available template search
+  const success = (data) => {
+    hideNotifications();
+    const menu = $('#template-dropdown-menu');
+    menu.empty();
 
-        hiddenContainer.slideDown(10);
-        showMore.remove(); // remove the button after expansion
-      });
-    }
-        
+    const templates = data.templates;
+    if (!isObject(data) || !isArray(templates) || templates.length === 0) return error();
+
+    // Categorize templates based on their source tag
+    const { orgTemplates, priorityTemplates, otherTemplates } = categorizeTemplates(templates);
+
+    // Add main groups
+    appendGroup(menu, 'Organizational Templates', orgTemplates);
+    appendGroup(menu, 'Alliance General Templates', priorityTemplates);
+
+    // Add “Show more templates”
+    appendShowMoreSection(menu, otherTemplates);
+
     // If there is only one template, set the input field value and submit the form
     // otherwise show the dropdown list and the 'Multiple templates found message'
     if (templates.length === 1) {
@@ -129,7 +127,7 @@ $(() => {
       $('#multiple-templates').show();
       $('#available-templates').fadeIn();
     }
-    
+
     toggleSubmit(false);
   };
 

--- a/app/javascript/src/plans/new.js
+++ b/app/javascript/src/plans/new.js
@@ -136,6 +136,25 @@ $(() => {
     toggleSubmit(false);
   };
 
+  // Function to reset the template dropdown
+  const resetTemplateDropdown = () => {
+    // Reset dropdown text and hidden field
+    $('#templateDropdown').text('Please select a template');
+    $('#plan_template_id').val('');
+
+    // Clear any existing menu items
+    $('#template-dropdown-menu').empty();
+
+    // Fade out templates section while new ones are fetched
+    $('#available-templates').fadeOut();
+  };
+
+  // Reset dropdown when a new research organisation is selected
+  $('#research-org-controls input.autocomplete-result').on('change', resetTemplateDropdown);
+
+  // Reset dropdown when "No research organisation" checkbox is toggled
+  $('#plan_no_org').on('change', resetTemplateDropdown);
+
   // TODO: Refactor this whole thing when we redo the create plan
   //       workflow and use js.erb instead!
   const getValue = (context) => {

--- a/app/javascript/src/plans/new.js
+++ b/app/javascript/src/plans/new.js
@@ -109,7 +109,7 @@ $(() => {
     const { orgTemplates, priorityTemplates, otherTemplates } = categorizeTemplates(templates);
 
     // Add main groups
-    appendGroup(menu, 'Organizational Templates', orgTemplates);
+    appendGroup(menu, 'Organisational Templates', orgTemplates);
     appendGroup(menu, 'Alliance General Templates', priorityTemplates);
 
     // Add “Show more templates”

--- a/app/javascript/src/plans/new.js
+++ b/app/javascript/src/plans/new.js
@@ -38,16 +38,47 @@ $(() => {
       return error();
     }
 
-    // Display the available_templates section
+    // Separate templates by source
+    const orgTemplates = [];
+    const priorityTemplates = [];
+    const otherTemplates = [];
+
     data.templates.forEach((t) => {
-      const item = $(`<a class="dropdown-item" href="#" data-id="${t.id}">${t.title}</a>`);
-      item.on('click', (e) => {
-        $('#templateDropdown').text(t.title);
-        $('#plan_template_id').val(t.id);
-        toggleSubmit(false);
-      });
-      menu.append(item);
+      if (t.source === 'org_template') {
+        orgTemplates.push(t);
+      } else if (t.source === 'priority') {
+        priorityTemplates.push(t);
+      } else {
+        otherTemplates.push(t);
+      }
     });
+
+    // Helper to append a header and templates
+    const appendGroup = (header, templates) => {
+      if (templates.length === 0) return;
+
+      menu.append(`<h6 class="dropdown-header text-muted">${header}</h6>`);
+
+      templates.forEach((t) => {
+        const title = $('<div>').text(t.title).html();
+        const item = $(`<a class="dropdown-item" href="#" data-id="${t.id}">${title}</a>`);
+
+        item.on('click', (e) => {
+          $('#templateDropdown').text(t.title);
+          $('#plan_template_id').val(t.id);
+          toggleSubmit(false);
+        });
+
+        menu.append(item);
+      });
+
+      menu.append('<div class="dropdown-divider"></div>');
+    };
+
+    // Append each category in the correct order
+    appendGroup('Organisational Templates', orgTemplates);
+    appendGroup('Alliance General Templates', priorityTemplates);
+    appendGroup('Additional Alliance Templates', otherTemplates);
         
     // If there is only one template, set the input field value and submit the form
     // otherwise show the dropdown list and the 'Multiple templates found message'

--- a/app/javascript/src/plans/new.js
+++ b/app/javascript/src/plans/new.js
@@ -78,7 +78,44 @@ $(() => {
     // Append each category in the correct order
     appendGroup('Organisational Templates', orgTemplates);
     appendGroup('Alliance General Templates', priorityTemplates);
-    appendGroup('Additional Alliance Templates', otherTemplates);
+
+    // Add "Show more templates" button to display other templates
+    if (otherTemplates.length > 0) {
+      const showMore = $(`
+        <button type="button" class="dropdown-item text-primary" id="show-more-templates">
+          Show more templates
+        </button>
+      `);
+
+      menu.append(showMore);
+
+      // Hidden section for the "other" templates
+      const hiddenContainer = $('<div id="extra-templates" style="display: none;"></div>');
+      menu.append(hiddenContainer);
+
+      // When clicked, expand the hidden templates without closing dropdown
+      showMore.on('click', (e) => {
+        e.preventDefault();
+        e.stopPropagation(); // prevent closing dropdown
+
+        hiddenContainer.empty(); // clear before adding
+        hiddenContainer.append('<h6 class="dropdown-header text-muted">Additional Alliance Templates</h6>');
+        otherTemplates.forEach((t) => {
+          const title = $('<div>').text(t.title).html();
+          const item = $(`<a class="dropdown-item" href="#" data-id="${t.id}">${title}</a>`);
+          item.on('click', (e2) => {
+            e2.preventDefault();
+            $('#templateDropdown').text(t.title);
+            $('#plan_template_id').val(t.id);
+            toggleSubmit(false);
+          });
+          hiddenContainer.append(item);
+        });
+
+        hiddenContainer.slideDown(10);
+        showMore.remove(); // remove the button after expansion
+      });
+    }
         
     // If there is only one template, set the input field value and submit the form
     // otherwise show the dropdown list and the 'Multiple templates found message'

--- a/app/javascript/src/plans/new.js
+++ b/app/javascript/src/plans/new.js
@@ -77,7 +77,7 @@ $(() => {
     if (otherTemplates.length === 0) return;
 
     const showMore = $(`
-      <button type="button" class="dropdown-item text-primary" id="show-more-templates">
+      <button type="button" class="btn btn-default" id="show-more-templates">
         Show more templates
       </button>
     `);

--- a/app/javascript/src/plans/new.js
+++ b/app/javascript/src/plans/new.js
@@ -1,7 +1,7 @@
 import debounce from '../utils/debounce';
 import { initAutocomplete, scrubOrgSelectionParamsOnSubmit } from '../utils/autoComplete';
 import getConstant from '../utils/constants';
-import { isObject, isString } from '../utils/isType';
+import { isObject, isArray, isString, isNumber } from '../utils/isType';
 import { renderAlert, hideNotifications } from '../utils/notificationHelper';
 
 $(() => {
@@ -43,6 +43,15 @@ $(() => {
       toggleSubmit();
     });
   }
+
+  // Helper for success() to validate the structure and content of the template response
+  const isValidTemplateResponse = (data) => (
+    isObject(data) && isObject(data.templates) &&
+    isNumber(data.total_templates) && data.total_templates > 0 &&
+    ['org_templates', 'priority_templates', 'other_templates'].every(
+      (k) => isArray(data.templates[k])
+    )
+  );
 
   // Helper for success() that creates a template item
   const createTemplateItem = (template) => {
@@ -122,13 +131,12 @@ $(() => {
     }
   };
 
-
   // AJAX success function for available template search
   const success = (data) => {
     hideNotifications();
     templateDropdownMenu.empty();
 
-    if (!isObject(data) || !isObject(data.templates) || data.total_templates === 0) return error();
+    if (!isValidTemplateResponse(data)) return error();
     const templates = data.templates;
   
     // Add main groups
@@ -140,12 +148,15 @@ $(() => {
     // If there is only one template, set the input field value and submit the form
     // otherwise show the dropdown list and the 'Multiple templates found message'
     if (data.total_templates === 1) {
-      // Get the first and only template across all groups
+      // Get the only template
       const onlyTemplate = [
         ...templates.org_templates,
         ...templates.priority_templates,
         ...templates.other_templates
-      ][0]
+      ][0];
+      // Ensure there is in fact a template
+      if (!onlyTemplate) return error();
+
       templateDropdown.text(onlyTemplate.title);
       planTemplateID.val(onlyTemplate.id);
       multipleTemplates.hide();

--- a/app/javascript/src/plans/new.js
+++ b/app/javascript/src/plans/new.js
@@ -5,8 +5,14 @@ import { isObject, isArray, isString } from '../utils/isType';
 import { renderAlert, hideNotifications } from '../utils/notificationHelper';
 
 $(() => {
-  const toggleSubmit = () => {
-    const tmplt = $('#plan_template_id').find(':selected').val();
+  const toggleSubmit = (select_dropdown = true) => {
+    let tmplt;
+    if (select_dropdown) {
+      tmplt = $('#plan_template_id').find(':selected').val();
+    } else {
+      tmplt = $('#plan_template_id').val();
+    }
+
     if (isString(tmplt)) {
       $('#new_plan button[type="submit"]').removeAttr('disabled')
         .removeAttr('data-toggle').removeAttr('title');
@@ -24,25 +30,35 @@ $(() => {
   // AJAX success function for available template search
   const success = (data) => {
     hideNotifications();
+    const menu = $('#template-dropdown-menu');
+    menu.empty();
 
-    if (isObject(data)
-        && isArray(data.templates)) {
+    if (isObject(data) && isArray(data.templates)) {
       // Display the available_templates section
       if (data.templates.length > 0) {
         data.templates.forEach((t) => {
-          $('#plan_template_id').append(`<option value="${t.id}">${t.title}</option>`);
+          const item = $(`<a class="dropdown-item" href="#" data-id="${t.id}">${t.title}</a>`);
+          item.on('click', (e) => {
+            $('#templateDropdown').text(t.title);
+            $('#plan_template_id').val(t.id);
+            toggleSubmit(false);
+          });
+          menu.append(item);
         });
+        
         // If there is only one template, set the input field value and submit the form
         // otherwise show the dropdown list and the 'Multiple templates found message'
         if (data.templates.length === 1) {
-          $('#plan_template_id option').attr('selected', 'true');
+          const only = data.templates[0];
+          $('#templateDropdown').text(only.title);
+          $('#plan_template_id').val(only.id);
           $('#multiple-templates').hide();
           $('#available-templates').fadeOut();
         } else {
           $('#multiple-templates').show();
           $('#available-templates').fadeIn();
         }
-        toggleSubmit();
+        toggleSubmit(false);
       } else {
         error();
       }

--- a/app/javascript/src/plans/new.js
+++ b/app/javascript/src/plans/new.js
@@ -53,6 +53,18 @@ $(() => {
     )
   );
 
+  // Helper for success() to extract total_templates and all template groups from the response
+  const extractTemplateData = (data) => {
+    const { total_templates: totalTemplates, templates } = data;
+    const {
+      org_templates: orgTemplates,
+      priority_templates: priorityTemplates,
+      other_templates: otherTemplates
+    } = templates;
+
+    return { totalTemplates, orgTemplates, priorityTemplates, otherTemplates };
+  };
+
   // Helper for success() that creates a template item
   const createTemplateItem = (template) => {
     const a = $('<a>', {
@@ -137,23 +149,19 @@ $(() => {
     templateDropdownMenu.empty();
 
     if (!isValidTemplateResponse(data)) return error();
-    const templates = data.templates;
+    const { orgTemplates, priorityTemplates, otherTemplates, totalTemplates } = extractTemplateData(data);
   
     // Add main groups
-    appendGroup(templateDropdownMenu, getConstant('ORG_TEMPLATES'), templates.org_templates);
-    appendGroup(templateDropdownMenu, getConstant('PRIORITY_TEMPLATES'), templates.priority_templates);
+    appendGroup(templateDropdownMenu, getConstant('ORG_TEMPLATES'), orgTemplates);
+    appendGroup(templateDropdownMenu, getConstant('PRIORITY_TEMPLATES'), priorityTemplates);
     // Add “Show more templates”
-    appendShowMoreSection(templateDropdownMenu, templates.other_templates);
+    appendShowMoreSection(templateDropdownMenu, otherTemplates);
 
     // If there is only one template, set the input field value and submit the form
     // otherwise show the dropdown list and the 'Multiple templates found message'
-    if (data.total_templates === 1) {
+    if (totalTemplates === 1) {
       // Get the only template
-      const onlyTemplate = [
-        ...templates.org_templates,
-        ...templates.priority_templates,
-        ...templates.other_templates
-      ][0];
+      const onlyTemplate = [...orgTemplates, ...priorityTemplates, ...otherTemplates][0];
       // Ensure there is in fact a template
       if (!onlyTemplate) return error();
 

--- a/app/javascript/src/plans/new.js
+++ b/app/javascript/src/plans/new.js
@@ -5,14 +5,8 @@ import { isObject, isString } from '../utils/isType';
 import { renderAlert, hideNotifications } from '../utils/notificationHelper';
 
 $(() => {
-  const toggleSubmit = (selectDropdown = true) => {
-    let tmplt;
-    if (selectDropdown) {
-      tmplt = $('#plan_template_id').find(':selected').val();
-    } else {
-      tmplt = $('#plan_template_id').val();
-    }
-
+  const toggleSubmit = () => {
+    const tmplt = $('#plan_template_id').val();
     const submitButton = $('#new_plan button[type="submit"]');
 
     // If a template has been selected and it is a string
@@ -40,7 +34,7 @@ $(() => {
       e.preventDefault()
       $('#templateDropdown').text(template.title);
       $('#plan_template_id').val(template.id);
-      toggleSubmit(false);
+      toggleSubmit();
     });
 
     return item;
@@ -149,7 +143,7 @@ $(() => {
       adjustDropdownMaxHeight();
     }
 
-    toggleSubmit(false);
+    toggleSubmit();
   };
 
   // Function to reset the template dropdown
@@ -231,13 +225,9 @@ $(() => {
     // if (!validOrg || !validFunder) {
     if (!validOrg) {
       $('#available-templates').fadeOut();
-      $('#plan_template_id').find(':selected').removeAttr('selected');
       $('#plan_template_id').val('');
       toggleSubmit();
     } else {
-      // Clear out the old template dropdown contents
-      $('#plan_template_id option').remove();
-
       let orgId = orgContext.find('input[id$="org_id"]').val();
       let funderId = funderContext.find('input[id$="funder_id"]').val(); // funder id is default to 8 (Portage Network)
 

--- a/app/javascript/src/plans/new.js
+++ b/app/javascript/src/plans/new.js
@@ -71,7 +71,7 @@ $(() => {
 
     const showMore = $(`
       <button type="button" class="btn btn-default" id="show-more-templates">
-        Show more templates
+        ${getConstant('SHOW_MORE_TEMPLATES')}
       </button>
     `);
     
@@ -86,7 +86,7 @@ $(() => {
       e.stopPropagation(); // prevent closing dropdown
 
       hiddenContainer.empty(); // clear before adding
-      hiddenContainer.append('<h6 class="dropdown-header text-muted">Additional Alliance Templates</h6>');
+      hiddenContainer.append(`<h6 class="dropdown-header text-muted">${getConstant('OTHER_TEMPLATES')}</h6>`);
       otherTemplates.forEach((t) => hiddenContainer.append(createTemplateItem(t)));
 
       hiddenContainer.slideDown(10);
@@ -130,8 +130,8 @@ $(() => {
     const templates = data.templates;
   
     // Add main groups
-    appendGroup(templateDropdownMenu, 'Organisational Templates', templates.org_templates);
-    appendGroup(templateDropdownMenu, 'Alliance General Templates', templates.priority_templates);
+    appendGroup(templateDropdownMenu, getConstant('ORG_TEMPLATES'), templates.org_templates);
+    appendGroup(templateDropdownMenu, getConstant('PRIORITY_TEMPLATES'), templates.priority_templates);
     // Add “Show more templates”
     appendShowMoreSection(templateDropdownMenu, templates.other_templates);
 
@@ -165,7 +165,7 @@ $(() => {
 
     if (isValidOrg) {
       // Reset dropdown text
-      templateDropdown.text('Please select a template');
+      templateDropdown.text(getConstant('SELECT_TEMPLATE'));
       // Clear any existing menu items
       templateDropdownMenu.empty();
     }

--- a/app/javascript/src/plans/new.js
+++ b/app/javascript/src/plans/new.js
@@ -85,6 +85,27 @@ $(() => {
     });
   };
 
+  // Helper function to adjust the height of the template dropdown
+  // and make sure it does not extend beyond the footer
+  const adjustDropdownMaxHeight = () => {
+    const dropdown = document.getElementById('templateDropdown');
+    const dropdownMenu = document.getElementById('template-dropdown-menu');
+    const footer = document.getElementById('footer-navbar');
+
+    const dropdownRect = dropdown.getBoundingClientRect();
+    const footerRect = footer.getBoundingClientRect();
+
+    // Ideal location for dropdown to end is middle of the footer
+    const footerMiddle = (footerRect.bottom + footerRect.top) / 2;
+
+    const spaceAvailable = footerMiddle - dropdownRect.bottom;
+
+    if (spaceAvailable > 0) {
+      dropdownMenu.style.maxHeight = `${spaceAvailable}px`;
+    }
+  };
+
+
   // AJAX success function for available template search
   const success = (data) => {
     hideNotifications();
@@ -116,6 +137,16 @@ $(() => {
     } else {
       $('#multiple-templates').show();
       $('#available-templates').fadeIn();
+    }
+
+    const dropdown = document.getElementById('templateDropdown');
+    // offsetParent returns the nearest ancestor that has a position other than static
+    // offsetParent property returns null if the element is not visible
+    const dropdownIsVisible = dropdown.offsetParent !== null
+
+    // Adjust the height of the dropdown when it is visible
+    if (dropdown && dropdownIsVisible) {
+      adjustDropdownMaxHeight();
     }
 
     toggleSubmit(false);

--- a/app/javascript/src/plans/new.js
+++ b/app/javascript/src/plans/new.js
@@ -53,6 +53,7 @@ $(() => {
     const item = $(`<a class="dropdown-item" href="#" data-id="${template.id}">${title}</a>`);
 
     item.on('click', (e) => {
+      e.preventDefault()
       $('#templateDropdown').text(template.title);
       $('#plan_template_id').val(template.id);
       toggleSubmit(false);
@@ -106,8 +107,8 @@ $(() => {
     const menu = $('#template-dropdown-menu');
     menu.empty();
 
+    if (!isObject(data) || !isArray(data.templates) || data.templates.length === 0) return error();
     const templates = data.templates;
-    if (!isObject(data) || !isArray(templates) || templates.length === 0) return error();
 
     // Categorize templates based on their source tag
     const { orgTemplates, priorityTemplates, otherTemplates } = categorizeTemplates(templates);
@@ -122,9 +123,9 @@ $(() => {
     // If there is only one template, set the input field value and submit the form
     // otherwise show the dropdown list and the 'Multiple templates found message'
     if (templates.length === 1) {
-      const only_template = templates[0];
-      $('#templateDropdown').text(only_template.title);
-      $('#plan_template_id').val(only_template.id);
+      const onlyTemplate = templates[0];
+      $('#templateDropdown').text(onlyTemplate.title);
+      $('#plan_template_id').val(onlyTemplate.id);
       $('#multiple-templates').hide();
       $('#available-templates').fadeOut();
     } else {

--- a/app/javascript/src/plans/new.js
+++ b/app/javascript/src/plans/new.js
@@ -292,7 +292,6 @@ $(() => {
   });
 
   // Initialize the form
-  availableTemplates.hide();
   bindTemplateDropdownMenuClickHandler();
   handleComboboxChange();
   // Scrub out the large arrays of data used for the Org Selector JS so that they

--- a/app/javascript/src/plans/new.js
+++ b/app/javascript/src/plans/new.js
@@ -1,7 +1,7 @@
 import debounce from '../utils/debounce';
 import { initAutocomplete, scrubOrgSelectionParamsOnSubmit } from '../utils/autoComplete';
 import getConstant from '../utils/constants';
-import { isObject, isArray, isString } from '../utils/isType';
+import { isObject, isString } from '../utils/isType';
 import { renderAlert, hideNotifications } from '../utils/notificationHelper';
 
 $(() => {
@@ -29,22 +29,6 @@ $(() => {
   // AJAX error function for available template search
   const error = () => {
     renderAlert(getConstant('NO_TEMPLATE_FOUND_ERROR'));
-  };
-
-  // Helper for success() that separates templates by source
-  const categorizeTemplates = (templates) => {
-    // Separate templates by source
-    const orgTemplates = [];
-    const priorityTemplates = [];
-    const otherTemplates = [];
-
-    templates.forEach((t) => {
-      if (t.source === 'org_template') orgTemplates.push(t);
-      else if (t.source === 'priority') priorityTemplates.push(t);
-      else otherTemplates.push(t);
-    });
-
-    return { orgTemplates, priorityTemplates, otherTemplates };
   };
 
   // Helper for success() that creates a clickable template item
@@ -107,23 +91,24 @@ $(() => {
     const menu = $('#template-dropdown-menu');
     menu.empty();
 
-    if (!isObject(data) || !isArray(data.templates) || data.templates.length === 0) return error();
+    if (!isObject(data) || !isObject(data.templates) || data.total_templates === 0) return error();
     const templates = data.templates;
-
-    // Categorize templates based on their source tag
-    const { orgTemplates, priorityTemplates, otherTemplates } = categorizeTemplates(templates);
-
+  
     // Add main groups
-    appendGroup(menu, 'Organisational Templates', orgTemplates);
-    appendGroup(menu, 'Alliance General Templates', priorityTemplates);
-
+    appendGroup(menu, 'Organisational Templates', templates.org_templates);
+    appendGroup(menu, 'Alliance General Templates', templates.priority_templates);
     // Add “Show more templates”
-    appendShowMoreSection(menu, otherTemplates);
+    appendShowMoreSection(menu, templates.other_templates);
 
     // If there is only one template, set the input field value and submit the form
     // otherwise show the dropdown list and the 'Multiple templates found message'
-    if (templates.length === 1) {
-      const onlyTemplate = templates[0];
+    if (data.total_templates === 1) {
+      // Get the first and only template across all groups
+      const onlyTemplate = [
+        ...templates.org_templates,
+        ...templates.priority_templates,
+        ...templates.other_templates
+      ][0]
       $('#templateDropdown').text(onlyTemplate.title);
       $('#plan_template_id').val(onlyTemplate.id);
       $('#multiple-templates').hide();

--- a/app/javascript/src/plans/new.js
+++ b/app/javascript/src/plans/new.js
@@ -13,12 +13,16 @@ $(() => {
       tmplt = $('#plan_template_id').val();
     }
 
-    if (isString(tmplt)) {
-      $('#new_plan button[type="submit"]').removeAttr('disabled')
-        .removeAttr('data-toggle').removeAttr('title');
+    const submitButton = $('#new_plan button[type="submit"]');
+
+    // If a template has been selected and it is a string
+    if (tmplt && isString(tmplt)) {
+      // remove the disabled attribute and make the button clickable
+      submitButton.removeAttr('disabled').removeAttr('data-toggle').removeAttr('title');
     } else {
-      $('#new_plan button[type="submit"]').attr('disabled', true)
-        .attr('data-toggle', 'tooltip').attr('title', getConstant('NEW_PLAN_DISABLED_TOOLTIP'));
+      // otherwise keep it disabled
+      submitButton.attr('disabled', true).attr('data-toggle', 'tooltip')
+      .attr('title', getConstant('NEW_PLAN_DISABLED_TOOLTIP'));
     }
   };
 

--- a/app/javascript/src/plans/new.js
+++ b/app/javascript/src/plans/new.js
@@ -46,8 +46,13 @@ $(() => {
 
   // Helper for success() that creates a template item
   const createTemplateItem = (template) => {
-    const title = $('<div>').text(template.title).html();
-    return $(`<a class="dropdown-item" href="#" data-id="${template.id}" data-title="${template.title}">${title}</a>`);
+    const a = $('<a>', {
+      class: 'dropdown-item',
+      href: '#',
+      'data-id': template.id,
+      'data-title': template.title,
+    }).text(template.title);
+    return a;
   };
 
   // Helper for success() that appends a group of templates with a header

--- a/app/javascript/src/plans/new.js
+++ b/app/javascript/src/plans/new.js
@@ -5,9 +5,17 @@ import { isObject, isString } from '../utils/isType';
 import { renderAlert, hideNotifications } from '../utils/notificationHelper';
 
 $(() => {
+  // Cache repeatedly used selectors
+  const newPlanForm = $('#new_plan');
+  const planTemplateID = $('#plan_template_id');
+  const templateDropdown = $('#templateDropdown');
+  const templateDropdownMenu = $('#template-dropdown-menu');
+  const multipleTemplates = $('#multiple-templates');
+  const availableTemplates = $('#available-templates');
+
   const toggleSubmit = () => {
-    const tmplt = $('#plan_template_id').val();
-    const submitButton = $('#new_plan button[type="submit"]');
+    const tmplt = planTemplateID.val();
+    const submitButton = newPlanForm.find('button[type="submit"]');
 
     // If a template has been selected and it is a string
     if (tmplt && isString(tmplt)) {
@@ -32,8 +40,8 @@ $(() => {
 
     item.on('click', (e) => {
       e.preventDefault()
-      $('#templateDropdown').text(template.title);
-      $('#plan_template_id').val(template.id);
+      templateDropdown.text(template.title);
+      planTemplateID.val(template.id);
       toggleSubmit();
     });
 
@@ -82,11 +90,9 @@ $(() => {
   // Helper function to adjust the height of the template dropdown
   // and make sure it does not extend beyond the footer
   const adjustDropdownMaxHeight = () => {
-    const dropdown = document.getElementById('templateDropdown');
-    const dropdownMenu = document.getElementById('template-dropdown-menu');
     const footer = document.getElementById('footer-navbar');
 
-    const dropdownRect = dropdown.getBoundingClientRect();
+    const dropdownRect = templateDropdown.get(0).getBoundingClientRect();
     const footerRect = footer.getBoundingClientRect();
 
     // Ideal location for dropdown to end is middle of the footer
@@ -95,7 +101,7 @@ $(() => {
     const spaceAvailable = footerMiddle - dropdownRect.bottom;
 
     if (spaceAvailable > 0) {
-      dropdownMenu.style.maxHeight = `${spaceAvailable}px`;
+      templateDropdownMenu.get(0).style.maxHeight = `${spaceAvailable}px`;
     }
   };
 
@@ -103,17 +109,16 @@ $(() => {
   // AJAX success function for available template search
   const success = (data) => {
     hideNotifications();
-    const menu = $('#template-dropdown-menu');
-    menu.empty();
+    templateDropdownMenu.empty();
 
     if (!isObject(data) || !isObject(data.templates) || data.total_templates === 0) return error();
     const templates = data.templates;
   
     // Add main groups
-    appendGroup(menu, 'Organisational Templates', templates.org_templates);
-    appendGroup(menu, 'Alliance General Templates', templates.priority_templates);
+    appendGroup(templateDropdownMenu, 'Organisational Templates', templates.org_templates);
+    appendGroup(templateDropdownMenu, 'Alliance General Templates', templates.priority_templates);
     // Add “Show more templates”
-    appendShowMoreSection(menu, templates.other_templates);
+    appendShowMoreSection(templateDropdownMenu, templates.other_templates);
 
     // If there is only one template, set the input field value and submit the form
     // otherwise show the dropdown list and the 'Multiple templates found message'
@@ -124,16 +129,16 @@ $(() => {
         ...templates.priority_templates,
         ...templates.other_templates
       ][0]
-      $('#templateDropdown').text(onlyTemplate.title);
-      $('#plan_template_id').val(onlyTemplate.id);
-      $('#multiple-templates').hide();
-      $('#available-templates').fadeOut();
+      templateDropdown.text(onlyTemplate.title);
+      planTemplateID.val(onlyTemplate.id);
+      multipleTemplates.hide();
+      availableTemplates.fadeOut();
     } else {
-      $('#multiple-templates').show();
-      $('#available-templates').fadeIn();
+      multipleTemplates.show();
+      availableTemplates.fadeIn();
     }
 
-    const dropdown = document.getElementById('templateDropdown');
+    const dropdown = templateDropdown.get(0);
     // offsetParent returns the nearest ancestor that has a position other than static
     // offsetParent property returns null if the element is not visible
     const dropdownIsVisible = dropdown.offsetParent !== null
@@ -149,14 +154,14 @@ $(() => {
   // Function to reset the template dropdown
   const resetTemplateDropdown = (isValidOrg = false) => {
     // Always fade out and reset hidden value
-    $('#available-templates').fadeOut();
-    $('#plan_template_id').val('');
+    availableTemplates.fadeOut();
+    planTemplateID.val('');
 
     if (isValidOrg) {
       // Reset dropdown text
-      $('#templateDropdown').text('Please select a template');
+      templateDropdown.text('Please select a template');
       // Clear any existing menu items
-      $('#template-dropdown-menu').empty();
+      templateDropdownMenu.empty();
     }
   };
 
@@ -275,15 +280,15 @@ $(() => {
 
   // When the user checks the 'mock project' box we need to set the
   // visibility to 'is_test'
-  $('#new_plan #is_test').click((e) => {
+  newPlanForm.find('#is_test').click((e) => {
     $('#plan_visibility').val(($(e.currentTarget)[0].checked ? 'is_test' : defaultVisibility));
   });
 
   // Initialize the form
-  $('#new_plan #available-templates').hide();
+  availableTemplates.hide();
   handleComboboxChange();
   // Scrub out the large arrays of data used for the Org Selector JS so that they
   // are not a part of the form submissiomn
-  scrubOrgSelectionParamsOnSubmit('#new_plan');
+  scrubOrgSelectionParamsOnSubmit(newPlanForm);
   toggleSubmit();
 });

--- a/app/javascript/src/plans/new.js
+++ b/app/javascript/src/plans/new.js
@@ -149,8 +149,23 @@ $(() => {
     $('#available-templates').fadeOut();
   };
 
-  // Reset dropdown when a new research organisation is selected
-  $('#research-org-controls input.autocomplete-result').on('change', resetTemplateDropdown);
+  // Reset dropdown only when a *valid org* is selected
+  $('#research-org-controls input.autocomplete-result').on('change', function () {
+    const val = $(this).val();
+
+    if (val) {
+      try {
+        const json = JSON.parse(val);
+        if (json.id) {
+          // Only reset if the selection actually represents a valid org
+          resetTemplateDropdown();
+        }
+      } catch (e) {
+        // Ignore invalid JSON (user still typing, etc.)
+        console.log('Autocomplete change ignored (invalid JSON)');
+      }
+    }
+  });
 
   // Reset dropdown when "No research organisation" checkbox is toggled
   $('#plan_no_org').on('change', resetTemplateDropdown);

--- a/app/javascript/src/plans/new.js
+++ b/app/javascript/src/plans/new.js
@@ -92,10 +92,18 @@ $(() => {
   // Helper function to adjust the height of the template dropdown
   // and make sure it does not extend beyond the footer
   const adjustDropdownMaxHeight = () => {
-    const footer = document.getElementById('footer-navbar');
+    const templateDropdownEl = templateDropdown.get(0);
+    const templateDropdownMenuEl = templateDropdownMenu.get(0);
+    const footerEl = document.getElementById('footer-navbar');
+    // .offsetParent returns the nearest ancestor that has a position other than static
+    // (returns null if the element is not visible)
+    const isVisible = templateDropdownEl.offsetParent !== null;
 
-    const dropdownRect = templateDropdown.get(0).getBoundingClientRect();
-    const footerRect = footer.getBoundingClientRect();
+    // Return early if any required element is missing or dropdown is not visible
+    if (!(templateDropdownEl && templateDropdownMenuEl && footerEl  && isVisible)) return;
+
+    const dropdownRect = templateDropdownEl.getBoundingClientRect();
+    const footerRect = footerEl.getBoundingClientRect();
 
     // Ideal location for dropdown to end is middle of the footer
     const footerMiddle = (footerRect.bottom + footerRect.top) / 2;
@@ -103,7 +111,7 @@ $(() => {
     const spaceAvailable = footerMiddle - dropdownRect.bottom;
 
     if (spaceAvailable > 0) {
-      templateDropdownMenu.get(0).style.maxHeight = `${spaceAvailable}px`;
+      templateDropdownMenuEl.style.maxHeight = `${spaceAvailable}px`;
     }
   };
 
@@ -139,17 +147,8 @@ $(() => {
       multipleTemplates.show();
       availableTemplates.fadeIn();
     }
-
-    const dropdown = templateDropdown.get(0);
-    // offsetParent returns the nearest ancestor that has a position other than static
-    // offsetParent property returns null if the element is not visible
-    const dropdownIsVisible = dropdown.offsetParent !== null
-
-    // Adjust the height of the dropdown when it is visible
-    if (dropdown && dropdownIsVisible) {
-      adjustDropdownMaxHeight();
-    }
-
+    // Adjust templateDropdown's maxHeight to not overextend
+    adjustDropdownMaxHeight();
     toggleSubmit();
   };
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -126,6 +126,8 @@
       </footer>
 
     <%
+      # TODO: Update `/constants.js` to allow us to pass objects here
+      # (e.g. `PLAN_VISIBILITY: { TEST: _('N/A'), NOT_TEST: ...}`)
     constants_json = {
       HOST: request.host,
       PASSWORD_MIN_LENGTH: 8,
@@ -162,7 +164,13 @@
       CURRENT_LOCALE: LocaleService.to_gettext(locale: @current_locale.to_s),
 
       MORE_INFO: _("More info"),
-      LESS_INFO: _("Less info")
+      LESS_INFO: _("Less info"),
+
+      SELECT_TEMPLATE: _('Please select a template'),
+      SHOW_MORE_TEMPLATES: _('Show more templates'),
+      ORG_TEMPLATES: _('Organisational Templates'),
+      PRIORITY_TEMPLATES: _('Alliance General Templates'),
+      OTHER_TEMPLATES: _('Additional Alliance Templates')
     }.to_json
     %>
 

--- a/app/views/plans/new.html.erb
+++ b/app/views/plans/new.html.erb
@@ -112,8 +112,28 @@
         <h2 id="template-selection"><%= _('Which DMP template would you like to use?') %></h2>
         <div class="form-group row">
           <div class="col-xs-6">
-            <%= select_tag(:plan_template_id, "<option value=\"\">#{_('Please select a template')}</option>", name: 'plan[template_id]',
-                           class: 'form-control', 'aria-labelledby': 'template-selection') %>
+            <div class="form-group">
+              <div class="dropdown" id="template-dropdown-container">
+                <button
+                  class="form-control text-left"
+                  type="button"
+                  id="templateDropdown"
+                  data-toggle="dropdown"
+                  aria-haspopup="true"
+                  aria-expanded="false"
+                >
+                  <%= _('Please select a template') %>
+                </button>
+                <div
+                  class="dropdown-menu w-100"
+                  aria-labelledby="templateDropdown"
+                  id="template-dropdown-menu"
+                >
+                  <!-- JS will populate this with <a class="dropdown-item"> -->
+                </div>
+                <%= hidden_field_tag 'plan[template_id]', '', id: 'plan_template_id' %>
+              </div>
+            </div>
           </div>
           <div class="col-xs-6">
             <span id="multiple-templates">

--- a/app/views/plans/new.html.erb
+++ b/app/views/plans/new.html.erb
@@ -117,7 +117,7 @@
                 <button
                   class="form-control text-left"
                   type="button"
-                  id="templateDropdown"
+                  id="template-dropdown"
                   data-toggle="dropdown"
                   aria-haspopup="true"
                   aria-expanded="false"
@@ -126,7 +126,7 @@
                 </button>
                 <div
                   class="dropdown-menu w-100"
-                  aria-labelledby="templateDropdown"
+                  aria-labelledby="template-dropdown"
                   id="template-dropdown-menu"
                 >
                   <!-- JS will populate this with <a class="dropdown-item"> -->

--- a/app/views/plans/new.html.erb
+++ b/app/views/plans/new.html.erb
@@ -107,7 +107,7 @@
       </div>
 
       <!-- Template selection -->
-      <div id="available-templates" style="visibility: none;">
+      <div id="available-templates" style="display: none;">
         <%= hidden_field_tag 'template-option-target', template_options_path %>
         <h2 id="template-selection"><%= _('Which DMP template would you like to use?') %></h2>
         <div class="form-group row">

--- a/spec/features/plans_spec.rb
+++ b/spec/features/plans_spec.rb
@@ -10,11 +10,20 @@ RSpec.describe 'Plans', type: :feature do
     @research_org = create(:org, :organisation, :research_institute,
                            name: 'Test Research Org', templates: 1)
     # Create the required default_funder org for DMP Assistant
-    @funding_org  = create(:org, :funder, templates: 1)
-    # Create the default template for the default_funder
-    @default_template = create(:template, :default, :published, org_id: @funding_org.id)
+    @funding_org  = create(:org, :funder, templates: 2)
     @original_default_funder_id = Rails.application.config.default_funder_id
     Rails.application.config.default_funder_id = @funding_org.id
+    # Create the default template for the default_funder
+    @default_template = create(:template, :default, :published, org_id: @funding_org.id, title: 'Default template')
+    @extra_funder_template = create(:template,
+                                    :published,
+                                    :publicly_visible,
+                                    org_id: @funding_org.id,
+                                    title: 'Other Funder Template',
+                                    is_default: false,
+                                    customization_of: nil,
+                                    archived: false)
+
     @template     = create(:template, org: @org)
     @user         = create(:user, org: @org)
     sign_in(@user)
@@ -29,6 +38,7 @@ RSpec.describe 'Plans', type: :feature do
     fill_in :plan_title, with: 'My test plan'
     choose_suggestion('plan_org_org_name', @research_org)
 
+    # Open the dropdown
     find('#templateDropdown').click
 
     within('#template-dropdown-menu') do
@@ -47,5 +57,27 @@ RSpec.describe 'Plans', type: :feature do
     expect(@plan.title).to eql('My test plan')
     expect(@plan.org_id).to eql(@research_org.id)
     expect(@plan.template_id).to eql(@default_template.id)
+  end
+
+  it 'displays template dropdown headers and expands more templates', :js do
+    click_link 'Create plan'
+    fill_in :plan_title, with: 'My test plan'
+    choose_suggestion('plan_org_org_name', @research_org)
+
+    # Open the dropdown
+    find('#templateDropdown').click
+
+    within('#template-dropdown-menu') do
+      expect(page).to have_content('ORGANISATIONAL TEMPLATES')
+      expect(page).to have_content('ALLIANCE GENERAL TEMPLATES')
+      expect(page).to have_content('Show more templates')
+    end
+
+    click_button 'Show more templates'
+
+    within('#extra-templates') do
+      expect(page).to have_content('ADDITIONAL ALLIANCE TEMPLATES')
+      expect(page).to have_selector('.dropdown-item', minimum: 1)
+    end
   end
 end

--- a/spec/features/plans_spec.rb
+++ b/spec/features/plans_spec.rb
@@ -29,8 +29,10 @@ RSpec.describe 'Plans', type: :feature do
     fill_in :plan_title, with: 'My test plan'
     choose_suggestion('plan_org_org_name', @research_org)
 
-    within('#plan_template_id') do
-      select @default_template.title
+    find('#templateDropdown').click
+
+    within('#template-dropdown-menu') do
+      click_link @default_template.title
     end
     click_button 'Create plan'
 

--- a/spec/features/plans_spec.rb
+++ b/spec/features/plans_spec.rb
@@ -6,26 +6,19 @@ RSpec.describe 'Plans', type: :feature do
   include Webmocks
 
   before do
-    @org = create(:org)
-    @research_org = create(:org, :organisation, :research_institute,
-                           name: 'Test Research Org', templates: 1)
+    # Create an org to be selected from the dropdown
+    # (The associated template will serve as an ORGANISATIONAL TEMPLATE)
+    @org = create(:org, :organisation, :research_institute,
+                  name: 'Test Research Org', templates: 1)
     # Create the required default_funder org for DMP Assistant
-    @funding_org  = create(:org, :funder, templates: 2)
+    @funding_org = create(:org, :funder)
     @original_default_funder_id = Rails.application.config.default_funder_id
     Rails.application.config.default_funder_id = @funding_org.id
-    # Create the default template for the default_funder
-    @default_template = create(:template, :default, :published, org_id: @funding_org.id, title: 'Default template')
-    @extra_funder_template = create(:template,
-                                    :published,
-                                    :publicly_visible,
-                                    org_id: @funding_org.id,
-                                    title: 'Other Funder Template',
-                                    is_default: false,
-                                    customization_of: nil,
-                                    archived: false)
-
-    @template     = create(:template, org: @org)
-    @user         = create(:user, org: @org)
+    # Create the required default template (also serves as an ALLIANCE GENERAL TEMPLATE)
+    @default_template = create(:template, :default, :published, org_id: @funding_org.id)
+    # Create an ADDITIONAL ALLIANCE TEMPLATE
+    @extra_funder_template = create(:template, :published, :publicly_visible, org_id: @funding_org.id)
+    @user = create(:user, org: create(:org))
     sign_in(@user)
   end
 
@@ -36,7 +29,7 @@ RSpec.describe 'Plans', type: :feature do
   it 'User creates a new Plan', :js do
     click_link 'Create plan'
     fill_in :plan_title, with: 'My test plan'
-    choose_suggestion('plan_org_org_name', @research_org)
+    choose_suggestion('plan_org_org_name', @org)
 
     # Open the dropdown
     find('#templateDropdown').click
@@ -55,14 +48,14 @@ RSpec.describe 'Plans', type: :feature do
     expect(current_path).to eql(plan_path(@plan))
     expect(page).to have_css("input[type=text][value='#{@plan.title}']")
     expect(@plan.title).to eql('My test plan')
-    expect(@plan.org_id).to eql(@research_org.id)
+    expect(@plan.org_id).to eql(@org.id)
     expect(@plan.template_id).to eql(@default_template.id)
   end
 
   it 'displays template dropdown headers and expands more templates', :js do
     click_link 'Create plan'
     fill_in :plan_title, with: 'My test plan'
-    choose_suggestion('plan_org_org_name', @research_org)
+    choose_suggestion('plan_org_org_name', @org)
 
     # Open the dropdown
     find('#templateDropdown').click

--- a/spec/features/plans_spec.rb
+++ b/spec/features/plans_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Plans', type: :feature do
     choose_suggestion('plan_org_org_name', @org)
 
     # Open the dropdown
-    find('#templateDropdown').click
+    find('#template-dropdown').click
 
     within('#template-dropdown-menu') do
       click_link @default_template.title
@@ -58,7 +58,7 @@ RSpec.describe 'Plans', type: :feature do
     choose_suggestion('plan_org_org_name', @org)
 
     # Open the dropdown
-    find('#templateDropdown').click
+    find('#template-dropdown').click
 
     within('#template-dropdown-menu') do
       expect(page).to have_content('ORGANISATIONAL TEMPLATES')


### PR DESCRIPTION
Fixes #1196.

Changes proposed in this PR:
- Add the headers "Organisational Templates", "Alliance General Templates", and "Other Alliance Templates" to the template dropdown to allow for better organization and readability of the templates in the dropdown.
- Add the "Show more templates" button to the dropdown that, along with shortening the initial size of the menu to allow for better readability, can also be clicked to show "Other Alliance Templates."
- Change the template selection's dropdown type from a `select_tag` to a bootstrap `dropdown` in order to allow for the "Show more templates" button to be clicked without closing the dropdown.
- Add custom CSS and javascript for the template dropdown in order to standardize the dropdown's interface and behaviour for users of all systems and browsers.
- Refactor `templation_options_controller` (previously edited in [this PR](https://github.com/portagenetwork/roadmap/pull/1199)) to simplify template handling by returning a structured JSON payload.
- Edit `plans_controller` to restrict templates that can be associated with newly created plans. Now, only templates that are published and unarchived are allowed.

[Screencast from 2025-11-12 11-23-36.webm](https://github.com/user-attachments/assets/374f11e2-0a90-43cf-875b-6aaf1cc09bf7)

