### PR TITLE
Refactor: Consolidate repeated custom colour variables across stylesheets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
  - Reorganize template dropdown menu and refactor TemplateOptionsController [#1199](https://github.com/portagenetwork/roadmap/pull/1199)
 
+ - Refactor: Consolidate repeated custom colour variables across stylesheets [#1218](https://github.com/portagenetwork/roadmap/pull/1218)
+
 ### Dependency Updates
 
  - chore(deps): bump nginx from 1.29.1-alpine to 1.29.2-alpine [#1207](https://github.com/portagenetwork/roadmap/pull/1207)

--- a/app/assets/stylesheets/dmp-assistant/blocks/_password_checklist.scss
+++ b/app/assets/stylesheets/dmp-assistant/blocks/_password_checklist.scss
@@ -1,9 +1,9 @@
-@use '../../grey-branding' as gb;
+@use '../../dmp-assistant/variables/colours' as *;
 
 #password-checklist {
   .rule-icon {
     &.fa-circle-check {
-      color: gb.$color-alliance-yellow;
+      color: $color-alliance-yellow;
     }
   }
 }

--- a/app/assets/stylesheets/dmp-assistant/variables/_colours.scss
+++ b/app/assets/stylesheets/dmp-assistant/variables/_colours.scss
@@ -1,0 +1,9 @@
+$color-alliance-yellow: #D6AB00;
+$color-alliance-darker-yellow: #F5C400;
+$color-alliance-darkest-yellow: #8A6E00;
+$color-alliance-digital-grey: #32322F;
+$color-alliance-light-grey: #999;
+$color-alliance-lighter-grey: #CCC;
+$color-alliance-lightest-grey: #888;
+$color-white: #FFF;
+$color-alliance-darker-teal: #007283;

--- a/app/assets/stylesheets/grey-branding.scss
+++ b/app/assets/stylesheets/grey-branding.scss
@@ -1,23 +1,11 @@
 /**
- This file contains ALL the redefined variables of the DMP Assistant.
- I put it here in order to avoid merge conflict from upstream in the future. It needs to be loaded before other styles
- PENDING:
- This style sheet can be separated to multiple stylesheets and moved to corresponding folders once finished
-
  Follow Bootstrap 3 media standard (explicitly defined instead of adding classes in view):
 - phone (<768px)
 - tablets (≥768px)
 - laptops (≥992px)
 - desktops (≥1200px)
 **/
-
-/** The color variables **/
-$color-alliance-yellow: #D6AB00;
-$color-alliance-darker-yellow: #F5C400;
-$color-alliance-digital-grey: #32322F;
-$color-alliance-darkest-yellow: #8A6E00;
-$color-white: #FFF;
-$color-alliance-lighter-grey: #CCC;
+@use './dmp-assistant/variables/colours' as *;
 
 .code-darkest-yellow {
   color: $color-alliance-darkest-yellow;

--- a/app/assets/stylesheets/rebranding-animation.scss
+++ b/app/assets/stylesheets/rebranding-animation.scss
@@ -1,17 +1,4 @@
-/**
- This file contains ALL the new designs variables of the DMP Assistant animation.
- I put it here in order to avoid the desing reverting issues.
- **/
-
-/** The color variables **/
-$color-alliance-yellow: #D6AB00;
-$color-alliance-darker-yellow: #F5C400;
-$color-alliance-darkest-yellow: #8A6D00;
-$color-alliance-digital-grey: #32322F;
-$color-alliance-darker-teal: #007283;
-
-$color-alliance-lighter-grey: #CCC;
-$color-alliance-light-grey: #999;
+@use './dmp-assistant/variables/colours' as *;
 
  /** Table content shadow added to make it look good**/
 .table-hover tbody tr:hover td, .table-hover tbody tr:hover th {

--- a/app/assets/stylesheets/rebranding.scss
+++ b/app/assets/stylesheets/rebranding.scss
@@ -1,27 +1,11 @@
 /**
- This file contains ALL the redefined variables of the DMP Assistant.
- I put it here in order to avoid merge conflict from upstream in the future. It needs to be loaded before other styles
- PENDING:
- This style sheet can be separated to multiple stylesheets and moved to corresponding folders once finished
-
  Follow Bootstrap 3 media standard (explicitly defined instead of adding classes in view):
 - phone (<768px)
 - tablets (≥768px)
 - laptops (≥992px)
 - desktops (≥1200px)
 **/
-
-/** The color variables **/
-$color-alliance-yellow: #D6AB00;
-$color-alliance-darker-yellow: #F5C400;
-
-// $color-alliance-darker-yellow: $color-alliance-yellow;
-
-$color-alliance-digital-grey: #32322F;
-
-$color-alliance-lighter-grey: #CCC;
-$color-alliance-lightest-grey: #888;
-
+@use './dmp-assistant/variables/colours' as *;
 
 h1, h2, h3, h4, h5, h6{
     font-family: 'Ubuntu', sans-serif;


### PR DESCRIPTION
Changes proposed in this PR:
- Consolidate repeated $color-alliance-* and related variables into `app/assets/stylesheets/dmp-assistant/variables/_colours.scss`.
- This removes duplicate variables and centralises colour definitions for better maintainability and consistency across the app.