### PR TITLE
Edit request feedback email to send in app language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## [Unreleased]
+## [4.1.1+portage-4.6.0]
 
 ### Added
  - Add headers and "Show more templates" button to template dropdown [#1215](https://github.com/portagenetwork/roadmap/pull/1215) 
 
 ### Fixed
-
+ - Edit request feedback email to send in app language [#1227](https://github.com/portagenetwork/roadmap/pull/1227)
 
 ### Changed
 

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -321,15 +321,17 @@ class Plan < ApplicationRecord
   #  emails confirmation messages to owners
   #  emails org admins and org contact
   #  adds org admins to plan with the 'reviewer' Role
-  def request_feedback(user)
+  def request_feedback(user) # rubocop:disable Metrics/AbcSize
     Plan.transaction do
       self.feedback_requested = true
       return false unless save!
 
+      current_app_language = Language.find_by(abbreviation: I18n.locale.to_s)
       # Send an email to the org-admin contact
       if user.org.contact_email.present?
         contact = User.new(email: user.org.contact_email,
-                           firstname: user.org.contact_name)
+                           firstname: user.org.contact_name,
+                           language: current_app_language)
         UserMailer.feedback_notification(contact, self, user).deliver_now
       end
       true


### PR DESCRIPTION
Fixes #1224.

Changes proposed in this PR:
- Edit `request_feedback` in the plan model to ensure that the request feedback email is delivered in the app's current locale (which is selected in the language dropdown) instead of always being delivered in English.
