### PR TITLE
Refactor template options logic into `Templates::TemplateOptionService` and update template validation in `PlansController#create`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
  - Add initial request specs for PlansController [#1238](https://github.com/portagenetwork/roadmap/pull/1238)
+ - Refactor template options logic into `Templates::TemplateOptionService` and update template validation in `PlansController#create` [#1228](https://github.com/portagenetwork/roadmap/pull/1228)
 
 ### Fixed
  - Update outdated organisation-related config values [#1237](https://github.com/portagenetwork/roadmap/pull/1237)

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -89,19 +89,8 @@ class PlansController < ApplicationController
                       plan_params[:title]
                     end
 
-      # bit of hackery here. There are 2 org selectors on the page
-      # and each is within its own specific context, plan.org or
-      # plan.funder which forces the hidden id hash to be :id
-      # so we need to convert it to :org_id so it works with the
-      # OrgSelectable and OrgSelection services
-      if plan_params[:org].present? && plan_params[:org][:id].present?
-        attrs = plan_params[:org]
-        attrs[:org_id] = attrs[:id]
-        @plan.org = org_from_params(params_in: attrs, allow_create: false)
-      else
-        # The user did not specify a research Org, so default to their Org
-        @plan.org = current_user.org
-      end
+      @plan.org = resolve_plan_org
+
       if plan_params[:funder].present? && plan_params[:funder][:id].present?
         attrs = plan_params[:funder]
         attrs[:org_id] = attrs[:id]
@@ -480,6 +469,22 @@ class PlansController < ApplicationController
                   grant: %i[name value],
                   org: %i[id org_id org_name org_sources org_crosswalk],
                   funder: %i[id org_id org_name org_sources org_crosswalk])
+  end
+
+  def resolve_plan_org
+    # bit of hackery here. There are 2 org selectors on the page
+    # and each is within its own specific context, plan.org or
+    # plan.funder which forces the hidden id hash to be :id
+    # so we need to convert it to :org_id so it works with the
+    # OrgSelectable and OrgSelection services
+    if plan_params[:org].present? && plan_params[:org][:id].present?
+      attrs = plan_params[:org]
+      attrs[:org_id] = attrs[:id]
+      org_from_params(params_in: attrs, allow_create: false)
+    else
+      # The user did not specify a research Org, so default to their Org
+      current_user.org
+    end
   end
 
   # Returns the template if it exists, is published, and not archived;

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -63,8 +63,11 @@ class PlansController < ApplicationController
     @plan = Plan.new
     authorize @plan
 
-    # Ensure the plan will be associated with a valid Template
-    template = find_valid_template(plan_params[:template_id])
+    # Get the org from plan_params
+    org = resolve_plan_org
+
+    # Ensure this is a valid template
+    template = find_valid_template(org)
     if template.nil?
       respond_to do |format|
         flash[:alert] = _('Unable to identify a suitable template for your plan.')
@@ -89,7 +92,7 @@ class PlansController < ApplicationController
                       plan_params[:title]
                     end
 
-      @plan.org = resolve_plan_org
+      @plan.org = org
 
       if plan_params[:funder].present? && plan_params[:funder][:id].present?
         attrs = plan_params[:funder]
@@ -487,10 +490,13 @@ class PlansController < ApplicationController
     end
   end
 
-  # Returns the template if it exists, is published, and not archived;
-  # otherwise returns nil
-  def find_valid_template(template_id)
-    Template.where(id: template_id, published: true, archived: false).first
+  # Returns the template if it is permitted for the given org; otherwise nil.
+  def find_valid_template(org)
+    template_id = plan_params[:template_id].to_i
+    return if template_id.zero? # True if the param value was nil or non-numeric
+
+    valid_templates = Templates::TemplateOptionsService.available_templates(org)
+    valid_templates.find { |t| t.id == template_id }
   end
 
   # different versions of the same template have the same family_id

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -7,60 +7,21 @@ class TemplateOptionsController < ApplicationController
 
   after_action :verify_authorized
 
-  DEFAULT_FUNDER_ID = Rails.application.config.default_funder_id
-
   # GET /template_options  (AJAX)
   # Collect all of the templates available for the org+funder combination
-  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def index
     org_hash = plan_params.fetch(:research_org_id, {})
 
     authorize Template.new, :template_options?
 
     org = org_from_params(params_in: { org_id: org_hash.to_json }) if org_hash.present?
-    funder = Org.find(DEFAULT_FUNDER_ID)
 
-    @templates = []
-
-    return unless (org.present? && !org.new_record?) || (funder.present? && !funder.new_record?)
-
-    if org.present? && !org.new_record?
-      # Load the funder's template(s)
-      # (`Template.default` belongs to `funder` and will be fetched as part of this query)
-      @templates = Template.latest_customizable.where(org_id: funder.id).sort_by(&:title).to_a
-      # Wherever possible, replace funder templates with organisational customizations
-      @templates = @templates.map do |tmplt|
-        customization = Template.published
-                                .latest_customized_version(tmplt.family_id,
-                                                           org.id).first
-        # Only provide the customized version if it's still up to date with the funder template
-        if customization.present? && !customization.upgrade_customization?
-          customization
-        else
-          tmplt
-        end
-      end
-      # We are using a default funder to provide with the default templates, but
-      # We still want to provide the organization templates.
-      # Retrieve the Org's templates
-      @templates << Template.published.organisationally_visible.where(org_id: org.id,
-                                                                      customization_of: nil).sort_by(&:title).to_a
-    else
-      # if'No Primary Research Institution' checkbox is checked,
-      # only show publicly available template without customization
-      # (`Template.default` belongs to `funder` and will be fetched as part of this query)
-      @templates << Template.published.publicly_visible.where(org_id: funder.id,
-                                                              customization_of: nil).sort_by(&:title).to_a
-    end
-    @templates = @templates.flatten
+    @templates = Templates::TemplateOptionsService.available_templates(org)
 
     respond_to do |format|
       format.json { render json: build_templates_payload(@templates) }
     end
   end
-  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
-  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
   private
 
@@ -80,7 +41,7 @@ class TemplateOptionsController < ApplicationController
   #   - other_templates: [All non-priority funder templates]
   # - total_templates: Count of all templates
   def build_templates_payload(templates)
-    funder_templates = templates.select { |t| t.org_id == DEFAULT_FUNDER_ID }
+    funder_templates = templates.select { |t| t.org_id == Rails.application.config.default_funder_id }
     simplified = funder_templates.find { |t| t.title == _('Alliance Simplified Template (Funding Application Stage)') }
     default = funder_templates.find(&:is_default)
     priority_templates = [simplified, default].compact

--- a/app/services/templates/template_options_service.rb
+++ b/app/services/templates/template_options_service.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Templates
+  # Service for retrieving templates available to a given organization.
+  class TemplateOptionsService
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    def self.available_templates(org)
+      funder = Org.find(Rails.application.config.default_funder_id)
+
+      @templates = []
+
+      return unless (org.present? && !org.new_record?) || (funder.present? && !funder.new_record?)
+
+      if org.present? && !org.new_record?
+        # Load the funder's template(s)
+        # (`Template.default` belongs to `funder` and will be fetched as part of this query)
+        @templates = Template.latest_customizable.where(org_id: funder.id).sort_by(&:title).to_a
+        # Wherever possible, replace funder templates with organisational customizations
+        @templates = @templates.map do |tmplt|
+          customization = Template.published
+                                  .latest_customized_version(tmplt.family_id,
+                                                             org.id).first
+          # Only provide the customized version if it's still up to date with the funder template
+          if customization.present? && !customization.upgrade_customization?
+            customization
+          else
+            tmplt
+          end
+        end
+        # We are using a default funder to provide with the default templates, but
+        # We still want to provide the organization templates.
+        # Retrieve the Org's templates
+        @templates << Template.published.organisationally_visible.where(org_id: org.id,
+                                                                        customization_of: nil).sort_by(&:title).to_a
+      else
+        # if'No Primary Research Institution' checkbox is checked,
+        # only show publicly available template without customization
+        # (`Template.default` belongs to `funder` and will be fetched as part of this query)
+        @templates << Template.published.publicly_visible.where(org_id: funder.id,
+                                                                customization_of: nil).sort_by(&:title).to_a
+      end
+      @templates = @templates.flatten
+    end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  end
+end

--- a/app/services/templates/template_options_service.rb
+++ b/app/services/templates/template_options_service.rb
@@ -6,7 +6,7 @@ module Templates
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     def self.available_templates(org)
-      funder = Org.find(Rails.application.config.default_funder_id)
+      funder = Org.find_by(id: Rails.application.config.default_funder_id)
 
       templates = []
 

--- a/app/services/templates/template_options_service.rb
+++ b/app/services/templates/template_options_service.rb
@@ -8,16 +8,16 @@ module Templates
     def self.available_templates(org)
       funder = Org.find(Rails.application.config.default_funder_id)
 
-      @templates = []
+      templates = []
 
-      return unless (org.present? && !org.new_record?) || (funder.present? && !funder.new_record?)
+      return templates unless (org.present? && !org.new_record?) || (funder.present? && !funder.new_record?)
 
       if org.present? && !org.new_record?
         # Load the funder's template(s)
         # (`Template.default` belongs to `funder` and will be fetched as part of this query)
-        @templates = Template.latest_customizable.where(org_id: funder.id).sort_by(&:title).to_a
+        templates = Template.latest_customizable.where(org_id: funder.id).sort_by(&:title).to_a
         # Wherever possible, replace funder templates with organisational customizations
-        @templates = @templates.map do |tmplt|
+        templates = templates.map do |tmplt|
           customization = Template.published
                                   .latest_customized_version(tmplt.family_id,
                                                              org.id).first
@@ -31,16 +31,16 @@ module Templates
         # We are using a default funder to provide with the default templates, but
         # We still want to provide the organization templates.
         # Retrieve the Org's templates
-        @templates << Template.published.organisationally_visible.where(org_id: org.id,
-                                                                        customization_of: nil).sort_by(&:title).to_a
+        templates << Template.published.organisationally_visible.where(org_id: org.id,
+                                                                       customization_of: nil).sort_by(&:title).to_a
       else
         # if'No Primary Research Institution' checkbox is checked,
         # only show publicly available template without customization
         # (`Template.default` belongs to `funder` and will be fetched as part of this query)
-        @templates << Template.published.publicly_visible.where(org_id: funder.id,
-                                                                customization_of: nil).sort_by(&:title).to_a
+        templates << Template.published.publicly_visible.where(org_id: funder.id,
+                                                               customization_of: nil).sort_by(&:title).to_a
       end
-      @templates = @templates.flatten
+      templates.flatten
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/spec/requests/plans_controller_spec.rb
+++ b/spec/requests/plans_controller_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'PlansController', type: :request do
-  let(:user) { create(:user) }
+  let(:user_org) { create(:org) }
+  let(:user) { create(:user, org: user_org) }
 
   before { sign_in(user) }
 
@@ -87,41 +88,101 @@ RSpec.describe 'PlansController', type: :request do
   end
 
   describe 'POST /plans' do
-    let(:template) { create(:template, published: true) }
-    let(:unpublished_template) { create(:template) }
+    let(:default_funder) { create(:org, :funder) }
+    let(:default_template) { create(:template, org: default_funder, is_default: true, published: true) }
+    let(:user_org_template) { create(:template, :organisationally_visible, org: user.org, published: true) }
+    let(:other_org) { create(:org) }
+    let(:other_org_template) { create(:template, :organisationally_visible, org: other_org, published: true) }
 
-    it 'creates a plan when only the template_id is provided' do
-      post plans_path, params: {
-        plan: { template_id: template.id }
-      }
-      plan = Plan.last
-      expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(plan_path(plan.id))
-
-      expect(plan.template_id).to eql(template.id)
-      # Ensure plan.title is as expected when none is provided
-      expect(plan.title).to eql("#{user.firstname}'s Plan")
-      # Ensure plan.org_id == user.org_id when none is provided
-      expect(plan.org_id).to eql(user.org_id)
+    before do
+      @original_default_funder_id = Rails.application.config.default_funder_id
+      Rails.application.config.default_funder_id = default_template.org.id
     end
 
-    it 'does not create a plan when the associated template is unpublished' do
-      post plans_path, params: {
-        plan: { template_id: unpublished_template.id }
-      }
-      expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(new_plan_path)
-      follow_redirect!
+    after do
+      Rails.application.config.default_funder_id = @original_default_funder_id
+    end
 
-      # Verify the expected flash message is rendered
-      expect(flash[:alert]).to eq('Unable to identify a suitable template for your plan.')
+    # Our tests reference default_template, rather than Template.default
+    # This test simply ensures that we are correct in doing so.
+    it 'Template.default returns the correct template' do
+      expect(Template.default).to eq(default_template)
+    end
 
-      # Ensure a Plan was not created
-      expect(Plan.count).to be_zero
+    RSpec.shared_examples 'create plan' do |template_key, org_key, should_create|
+      it "#{should_create ? 'creates' : 'does not create'} a plan" do
+        template, org = fetch_template_and_org(template_key, org_key)
+        post plans_path, params: post_plans_payload(template, org)
+
+        if should_create
+          expect(Plan.count).to_not be_zero
+          plan = Plan.last
+
+          expect(response).to have_http_status(:redirect)
+          expect(response).to redirect_to(plan_path(plan.id))
+
+          expect(plan.template_id).to eql(template.id)
+          # Expect the default plan.title when none is specified in POST request
+          expect(plan.title).to eql("#{user.firstname}'s Plan")
+          # `plan.org_id` depends on whether or not `org` was included in POST request payload
+          expect(plan.org_id).to eql(org ? org.id : user.org_id) if plan.respond_to?(:org_id)
+        else
+          expect(response).to have_http_status(:redirect)
+          expect(response).to redirect_to(new_plan_path)
+          follow_redirect!
+          expect(flash[:alert]).to eq('Unable to identify a suitable template for your plan.')
+          expect(Plan.count).to be_zero
+        end
+      end
+    end
+
+    # TODO: Refactor/extract the matrix of template/org availability checks into
+    # spec/services/templates/template_options_service_spec.rb and keep only a small
+    # set of focused controller request specs here.
+    [
+      # POST /plans without `org` sets plan.org = current_user.org
+      { template: :default_template },
+      { template: :user_org_template },
+      { template: :other_org_template, should_create: false },
+
+      # Test plan creation with explicit (template + org) combinations.
+      { template: :default_template, org: :default_funder },
+      { template: :user_org_template, org: :user_org },
+      { template: :other_org_template, org: :other_org },
+      { template: :other_org_template, org: :user_org, should_create: false },
+      { template: :user_org_template, org: :default_funder, should_create: false }
+    ].each do |example|
+      include_examples(
+        'create plan',
+        example[:template],
+        example[:org],
+        example.fetch(:should_create, true)
+      )
     end
   end
 
   private
+
+  # Constructs and returns the POST /plans payload
+  def post_plans_payload(template, org = nil)
+    params = {}
+    params[:plan] = { template_id: template.id }
+    return params unless org
+
+    params[:plan][:org] = {
+      id: { id: org.id, name: org.name, sort_name: org.name }.to_json,
+      org_name: org.name,
+      org_sources: [].to_json,
+      org_crosswalk: [].to_json
+    }
+    params
+  end
+
+  def fetch_template_and_org(template_key, org_key)
+    template = send(template_key)
+    org = org_key ? send(org_key) : nil
+    [template, org]
+  end
 
   def parse_crosswalk_data(html)
     crosswalk_json = html.at_css('#plan_org_org_crosswalk')['value']


### PR DESCRIPTION
# Changes proposed in this PR:
[Refactor plan.org resolution into private helper](https://github.com/portagenetwork/roadmap/pull/1228/commits/005ca54eb92b3850a0efefe11de2d8b7cf931f3d)
Extracts the logic for resolving @plan.org from plan_params into a private method `resolve_plan_org`.

[Refactor template selection logic into TemplateOptionsService](https://github.com/portagenetwork/roadmap/pull/1228/commits/c3b54a06305147e755129e9205899d982b951b42)
Move the template-loading and customization logic from TemplateOptionsController#index into a new service, Templates::TemplateOptionService#available_templates.
- Makes template logic reusable for other controllers (e.g., PlansController#create).
- Removed `DEFAULT_FUNDER_ID` assignment in `TemplateOptionsController`.  After this refactor, `Rails.application.config.default_funder_id` is only needed in that controller's `build_templates_payload` method. It is now called there explicitly.

[Validate plan.template against available templates](https://github.com/portagenetwork/roadmap/pull/1228/commits/e8986f3d9b4d0e5bad9e76502369e9f245dda91b)
Update `PlansController#find_valid_template` to ensure the selected template_id belongs to the set returned by `Templates::TemplateOptionService.available_templates(org)`.

[Update and extend PlansController request specs](https://github.com/portagenetwork/roadmap/pull/1228/commits/990ed808d660a4194516eceee1fabf97bcff6b62)
Update and extend the PlansController request specs to match the new server-side `find_valid_template` behaviour. Tests now explicitly cover:
- Valid vs. invalid template/org combinations using `shared_examples`
- Default org resolution (`plan.org == current_user.org`) when no org param is supplied
- Explicit org param handling for template validation
- Ensuring `Template.default` evaluates to the seeded default template

[Update default funder check / use .find_by()](https://github.com/portagenetwork/roadmap/pull/1228/commits/55a8b3e8b56e765bf750b7630b54702ad1ed1cd6)
The following guard exists on line 13 of this file:
```ruby
return templates unless (org.present? && !org.new_record?) || (funder.present? && !funder.new_record?)
```
Rather than evaluating to nil, `Org.find(Rails.application.config.default_funder_id)` risks raising `ActiveRecord::RecordNotFound`.
`Org.find_by(id: Rails.application.config.default_funder_id)` allows us to use the guard if the funder ever does not resolve to an actual Org.