### PR TITLE
Fix template translation issue in `template_options_controller`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
  - Edit footer logos [#1203](https://github.com/portagenetwork/roadmap/pull/1203)
 
- - Reorganize template dropdown menu and refactor TemplateOptionsController [#1199](https://github.com/portagenetwork/roadmap/pull/1199)
+ - Reorganize template dropdown menu and refactor TemplateOptionsController [#1199](https://github.com/portagenetwork/roadmap/pull/1199), [#1229](https://github.com/portagenetwork/roadmap/pull/1229)
 
  - Refactor: Consolidate repeated custom colour variables across stylesheets [#1218](https://github.com/portagenetwork/roadmap/pull/1218)
 

--- a/app/controllers/template_options_controller.rb
+++ b/app/controllers/template_options_controller.rb
@@ -81,8 +81,8 @@ class TemplateOptionsController < ApplicationController
   # - total_templates: Count of all templates
   def build_templates_payload(templates)
     funder_templates = templates.select { |t| t.org_id == DEFAULT_FUNDER_ID }
-    simplified = funder_templates.find { |t| t.title.start_with?('Alliance Simplified Template') }
-    default    = funder_templates.find(&:is_default)
+    simplified = funder_templates.find { |t| t.title == _('Alliance Simplified Template (Funding Application Stage)') }
+    default = funder_templates.find(&:is_default)
     priority_templates = [simplified, default].compact
 
     { templates: { org_templates: templates - funder_templates,


### PR DESCRIPTION
- The previous behaviour was including the Alliance Simplified Template by only checking for the English template name, thus missing the template when the language was set to French.
- This was corrected by checking for both the English and French titles.

<img width="2434" height="1356" alt="image" src="https://github.com/user-attachments/assets/6d597222-308f-4e6d-a277-858df534e52b" />

<img width="2586" height="1376" alt="image" src="https://github.com/user-attachments/assets/de19308b-7f98-47f0-a864-970a0e279858" />

