### PR TITLE
Fix long template titles extending past dropdown

### DIFF
--- a/app/assets/stylesheets/dmp-assistant/blocks/_template_dropdown_menu.scss
+++ b/app/assets/stylesheets/dmp-assistant/blocks/_template_dropdown_menu.scss
@@ -1,5 +1,11 @@
 @use '../../dmp-assistant/variables/colours' as *;
 
+#template-dropdown {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 #template-dropdown-menu {
   overflow-y: auto;
   overflow-x: hidden;


### PR DESCRIPTION
Changes proposed in this PR:
- Edit CSS to increase size of dropdown to work with long template titles.

Previous behaviour:
<img width="595" height="142" alt="image" src="https://github.com/user-attachments/assets/32588e50-4a9d-4430-8a4c-cd68244d80f8" />

After this PR:
<img width="758" height="179" alt="Screenshot from 2025-11-17 12-32-50" src="https://github.com/user-attachments/assets/860c71ce-6982-4656-8822-b04dfc8e53f2" />
