### PR TITLE
Update outdated organisation-related config values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+ - Update outdated organisation-related config values [#1237](https://github.com/portagenetwork/roadmap/pull/1237)
+
+
 ## [4.1.1+portage-4.6.0]
 
 ### Added

--- a/config/branding.yml
+++ b/config/branding.yml
@@ -4,9 +4,9 @@ defaults: &defaults
   # Warning: The abbreviation here should match the org.abbreviation value registered in your database!
   organisation: &organization_defaults
     name: 'Digital Research Alliance of Canada'
-    abbreviation: 'Portage'  # This value is used to identify the default guidance that get auto-selected when a new plan is created
+    abbreviation: 'Alliance'  # This value is used to identify the default guidance that get auto-selected when a new plan is created
     url: 'https://alliancecan.ca'
-    copywrite_name: 'Portage Network'
+    copywrite_name: 'Digital Research Alliance of Canada'
     email: 'dmp-assistant@tech.alliancecan.ca'
     helpdesk_email: 'dmp-assistant@tech.alliancecan.ca'
     # XXX Need to update the welcome links

--- a/config/initializers/_dmproadmap.rb
+++ b/config/initializers/_dmproadmap.rb
@@ -24,7 +24,7 @@ module DMPRoadmap
     # Your organisation name, used in various places throught the application
     config.x.organisation.name = 'Digital Research Alliance of Canada'
     # Your organisation's abbreviation
-    config.x.organisation.abbreviation = 'Portage'
+    config.x.organisation.abbreviation = 'Alliance'
     # Your organisation's homepage, used in some of the public facing pages
     config.x.organisation.url = 'https://alliancecan.ca/'
     # Your organisation's legal (official) name - used in the copyright portion of the footer


### PR DESCRIPTION
# Changes proposed in this PR:

```ruby
  app/models/org.rb
  # The default Org is the one whose guidance is auto-attached to
  # plans when a plan is created
  def self.default_orgs
    where(abbreviation: Rails.configuration.x.organisation.abbreviation)
  end
```
- From the above code snippet, we can see that the value of `Rails.configuration.x.organisation.abbreviation` is central to `Org.default_orgs`, which is called several times throughout the codebase.
- `Org.default_orgs` appears to only pertain to GuidanceGroup-related logic.
- However, updating `Rails.configuration.x.organisation.abbreviation` should have no effect, because the only "Alliance" GuidanceGroup was, and remains unpublished.
- "Portage" was the previous abbreviation of the org that now has the abbreviation "Alliance".

- `copywrite_name` does not appear to be referenced in the codebase.
