### PR TITLE
Allow contributor affiliation to belong to external organisations

### DIFF
--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -129,6 +129,8 @@ class ContributorsController < ApplicationController
     org = org_from_params(params_in: hash,
                           allow_create: allow_create)
 
+    add_fundref_identifier(org, ror_result) if org.present? && allow_create
+
     finalize_org_hash(hash, org)
   end
 
@@ -181,6 +183,20 @@ class ContributorsController < ApplicationController
     org_hash = { name: hash[:org_name] }
     org_hash[:ror] = ror_result[:ror] if ror_result.present?
     hash[:org_id] = org_hash.to_json
+  end
+
+  # Adds fundref identifier if available in ROR result
+  def add_fundref_identifier(org, ror_result)
+    fundref_id = ror_result[:fundref]
+    fundref_scheme = IdentifierScheme.find_by(name: 'fundref')
+    return unless fundref_id.present? && fundref_scheme.present?
+
+    Identifier.find_or_create_by!(
+      identifiable: org,
+      identifier_scheme: fundref_scheme
+    ) do |identifier|
+      identifier.value = "#{fundref_scheme.identifier_prefix}#{fundref_id}"
+    end
   end
 
   # Final clean-up and assignment of org_id

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -111,8 +111,13 @@ class ContributorsController < ApplicationController
 
   # Convert the Org Hash into an Org object (creating it if allowed)
   # and then remove all of the Org args
-  def process_org(hash:)
-    return hash unless hash.present? && hash[:org_id].present?
+  def process_org(hash:) # rubocop:disable Metrics/AbcSize
+    return hash unless hash.present?
+
+    has_org_input = hash[:org_id].present? || hash[:org_name].present?
+    return hash unless has_org_input
+
+    parsed = parse_org_id(hash)
 
     allow = !Rails.configuration.x.application.restrict_orgs
     org = org_from_params(params_in: hash,
@@ -125,6 +130,22 @@ class ContributorsController < ApplicationController
 
     hash[:org_id] = org.id
     hash
+  end
+
+  # Parses org_id JSON and updates hash with parsed name and ror
+  def parse_org_id(hash)
+    parsed = {}
+    # hash[:org_id] may be a number ('62') or JSON ('{"ror":"...","name":"..."}') if picked from dropdown
+    # /\A\d+\z/ : regex meaning "start to end, only digits"
+    # check if org_id is JSON
+    is_json = hash[:org_id].to_s !~ /\A\d+\z/
+    if hash[:org_id].present? && is_json
+      parsed = JSON.parse(hash[:org_id])
+      hash[:org_name] = parsed['name']
+      # org_crosswalk = all of the info about each Org returned by the OrgsController # search action
+      hash[:org_crosswalk] = parsed['ror'] if parsed['ror'].present?
+    end
+    parsed
   end
 
   # When creating, just remove the ORCID if it was left blank

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -111,7 +111,7 @@ class ContributorsController < ApplicationController
 
   # Convert the Org Hash into an Org object (creating it if allowed)
   # and then remove all of the Org args
-  def process_org(hash:)
+  def process_org(hash:) # rubocop:disable Metrics/AbcSize
     return hash unless hash.present?
 
     has_org_input = hash[:org_id].present? || hash[:org_name].present?

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -111,7 +111,7 @@ class ContributorsController < ApplicationController
 
   # Convert the Org Hash into an Org object (creating it if allowed)
   # and then remove all of the Org args
-  def process_org(hash:) # rubocop:disable Metrics/AbcSize
+  def process_org(hash:)
     return hash unless hash.present?
 
     has_org_input = hash[:org_id].present? || hash[:org_name].present?
@@ -122,9 +122,12 @@ class ContributorsController < ApplicationController
 
     return finalize_org_hash(hash, existing_org) if existing_org.present?
 
-    allow = !Rails.configuration.x.application.restrict_orgs
+    ror_result = fetch_ror_result(hash)
+    allow_create = ror_result
+
+    prepare_org_json_for_params(hash, ror_result)
     org = org_from_params(params_in: hash,
-                          allow_create: allow)
+                          allow_create: allow_create)
 
     finalize_org_hash(hash, org)
   end
@@ -156,6 +159,28 @@ class ContributorsController < ApplicationController
     elsif hash[:org_name].present?
       Org.find_by(name: hash[:org_name])
     end
+  end
+
+  # Make external API call to ROR (only if there is an ROR field in hash) to ensure ROR is valid
+  def fetch_ror_result(hash)
+    return unless hash[:org_crosswalk].present?
+
+    ror_result = nil
+    begin
+      ror_result = ExternalApis::RorService.search(term: hash[:org_crosswalk])&.first
+    rescue StandardError => e
+      Rails.logger.warn("ROR lookup failed: #{e.message}")
+    end
+    ror_result
+  end
+
+  # Updates org_id JSON with org_name and ror for org_from_params
+  def prepare_org_json_for_params(hash, ror_result)
+    return unless hash[:org_name].present?
+
+    org_hash = { name: hash[:org_name] }
+    org_hash[:ror] = ror_result[:ror] if ror_result.present?
+    hash[:org_id] = org_hash.to_json
   end
 
   # Final clean-up and assignment of org_id

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -118,18 +118,15 @@ class ContributorsController < ApplicationController
     return hash unless has_org_input
 
     parsed = parse_org_id(hash)
+    existing_org = find_existing_org(parsed, hash)
+
+    return finalize_org_hash(hash, existing_org) if existing_org.present?
 
     allow = !Rails.configuration.x.application.restrict_orgs
     org = org_from_params(params_in: hash,
                           allow_create: allow)
 
-    hash = remove_org_selection_params(params_in: hash)
-
-    return hash if org.blank? && !allow
-    return hash unless org.present?
-
-    hash[:org_id] = org.id
-    hash
+    finalize_org_hash(hash, org)
   end
 
   # Parses org_id JSON and updates hash with parsed name and ror
@@ -146,6 +143,26 @@ class ContributorsController < ApplicationController
       hash[:org_crosswalk] = parsed['ror'] if parsed['ror'].present?
     end
     parsed
+  end
+
+  # Try to find existing Org in DB using parsed values or org_name
+  def find_existing_org(parsed, hash)
+    if parsed['id'].present?
+      Org.find_by(id: parsed['id'])
+    elsif parsed['ror'].present?
+      ror_id = parsed['ror'].split('/').last
+      ror_scheme = IdentifierScheme.find_by(name: 'ror')
+      Identifier.find_by(value: ror_id, identifier_scheme: ror_scheme)&.identifiable
+    elsif hash[:org_name].present?
+      Org.find_by(name: hash[:org_name])
+    end
+  end
+
+  # Final clean-up and assignment of org_id
+  def finalize_org_hash(hash, org)
+    hash = remove_org_selection_params(params_in: hash)
+    hash[:org_id] = org.id if org.present?
+    hash
   end
 
   # When creating, just remove the ORCID if it was left blank

--- a/app/views/contributors/_form.html.erb
+++ b/app/views/contributors/_form.html.erb
@@ -56,9 +56,8 @@ roles_tooltip = _("Select each role that applies to the contributor.")
 
 <div class="form-group row" id="contributor-org-controls"><!-- org -->
   <div class="col-md-8">
-    <%= render partial: org_partial,
+    <%= render partial: 'shared/org_selectors/combined',
                locals: { form: form,
-                         orgs: orgs,
                          default_org: contributor.org,
                          required: false,
                          label: _("Affiliation") } %>

--- a/spec/controllers/contributors_controller_spec.rb
+++ b/spec/controllers/contributors_controller_spec.rb
@@ -4,6 +4,15 @@ require 'rails_helper'
 
 RSpec.describe ContributorsController, type: :controller do
   before(:each) do
+    # Stub external ROR heartbeat or search endpoint
+    # %r{https://api\.ror\.org/v1/.*} matches any ROR API URL starting with https://api.ror.org/v1/
+    stub_request(:get, %r{https://api\.ror\.org/v1/.*})
+      .with(headers: {
+              'Accept' => 'application/json',
+              'Content-Type' => 'application/json'
+            })
+      .to_return(status: 200, body: '[]', headers: { 'Content-Type' => 'application/json' })
+
     @scheme = create(:identifier_scheme, name: 'orcid')
     @org = create(:org, managed: true)
     @plan = create(:plan, :creator, org: @org)
@@ -159,6 +168,10 @@ RSpec.describe ContributorsController, type: :controller do
       end
       it 'sets the org_id to the idea of the org' do
         new_org = create(:org)
+        # Clear name, id, and ror to prevent matching any existing org
+        @params_hash[:contributor][:org_name] = nil
+        @params_hash[:contributor][:org_id] = { id: nil, name: nil, ror: nil }.to_json
+
         @controller.stubs(:org_from_params).returns(new_org)
         hash = @controller.send(:process_org, hash: @params_hash[:contributor])
         expect(hash[:org_id]).to eql(new_org.id)


### PR DESCRIPTION
Fixes #926.

Changes proposed in this PR:
- Edit contributor affiliation dropdown partial to allow for search for orgs external to DMP Assistant DB.
- Edit `contributions_controller` to process orgs that are external to DMP Assistant DB by validating ROR.
- The workflow is as follows after a user enters an affiliation for a contributor:
    - If the affiliation already exists in the orgs table, the existing entry is used.
    - If the affiliation does not exist in the orgs table, an external API request to ROR is made. If a matching result is found, the new organisation is added to the orgs table along with the ror and fundref identifiers.
    - If the affiliation neither exists in the orgs table or on ROR, then there is no change made to the affiliation.
