### PR TITLE
Prevent unmanaged organisations from being assigned in profile editing and creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
  - Update outdated organisation-related config values [#1237](https://github.com/portagenetwork/roadmap/pull/1237)
+ - Prevent unmanaged organisations from being assigned in profile editing and creation [#1242](https://github.com/portagenetwork/roadmap/pull/1242)
 
 ### Dependency Updates
  - chore(deps): bump nginx from 1.29.2-alpine to 1.29.3-alpine

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -154,6 +154,11 @@ class RegistrationsController < Devise::RegistrationsController
 
   private
 
+  def org_from_params_is_user_org?
+    org = org_from_params(params_in: update_params)
+    org.is_a?(Org) && org == current_user.org
+  end
+
   # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   # rubocop:disable Style/OptionalBooleanParameter
@@ -171,8 +176,8 @@ class RegistrationsController < Devise::RegistrationsController
       message += _('Please enter a Last name. ')
       mandatory_params &&= false
     end
-    if restrict_orgs && update_params[:org_id]['id'].blank?
-      message += _("Please select an organisation from the list, or enter your organisation's name.")
+    if restrict_orgs && update_params[:org_id]['id'].blank? && !org_from_params_is_user_org?
+      message += _('Please select an organisation from the list.')
       mandatory_params &&= false
     end
     # has the user entered all the details

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -275,7 +275,7 @@ class RegistrationsController < Devise::RegistrationsController
 
     # Remove the extraneous Org Selector hidden fields
     attrs = remove_org_selection_params(params_in: attrs)
-    return attrs unless org.present?
+    return attrs unless org.present? && org.managed?
 
     # reattach the org_id but with the Org id instead of the hash
     attrs[:org_id] = org.id


### PR DESCRIPTION
Changes proposed in this PR:
- Edit `handle_org` in `registrations_controller.rb` to block unmanaged organisations.
- Edit `do_update` in `registrations_controller.rb` to fix the bug of users of unmanaged organisations not being able to edit their profile.
