### PR TITLE
Enable ROR-Based Org Creation for Contributors

### DIFF
--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -114,11 +114,11 @@ class ContributorsController < ApplicationController
   def process_org(hash:)
     return hash unless hash.present? && hash[:org_id].present?
 
-    hash, allow = OrgSelection::HashToOrgService.process_org(hash: hash)
+    hash, allow, existing_org = OrgSelection::HashToOrgService.process_org(hash: hash)
 
     # If org ROR cannot be validated, then contributor org is invalid
     # Only trigger flash during a real request (tests calling this method directly have no request object)
-    if !allow && request.present?
+    if !allow && !existing_org && request.present?
       flash[:alert] =
         _('Invalid contributor affiliation. Please double check that your organisation does not appear in the list ' \
           'in a slightly different form.')

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -114,26 +114,22 @@ class ContributorsController < ApplicationController
   def process_org(hash:)
     return hash unless hash.present? && hash[:org_id].present?
 
-    hash, allow, existing_org = OrgSelection::HashToOrgService.process_org(hash: hash)
+    org = org_from_params(params_in: hash, allow_create: true)
 
-    # If org ROR cannot be validated, then contributor org is invalid
     # Only trigger flash during a real request (tests calling this method directly have no request object)
-    if !allow && !existing_org && request.present?
+    if org.nil? && request.present?
       flash[:alert] =
         _('Invalid contributor affiliation. Please double check that your organisation does not appear in the list ' \
           'in a slightly different form.')
     end
 
-    org = org_from_params(params_in: hash,
-                          allow_create: allow)
-
-    finalize_org_hash(hash, org, allow)
+    finalize_org_hash(hash, org)
   end
 
-  def finalize_org_hash(hash, org, allow)
+  def finalize_org_hash(hash, org)
     hash = remove_org_selection_params(params_in: hash)
 
-    return hash if org.blank? && !allow
+    return hash if org.blank?
     return hash unless org.present?
 
     hash[:org_id] = org.id

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -116,17 +116,12 @@ class ContributorsController < ApplicationController
 
     org = org_from_params(params_in: hash, allow_create: true)
 
-    # Only trigger flash during a real request (tests calling this method directly have no request object)
-    if org.nil? && request.present?
+    if org.nil?
       flash[:alert] =
         _('Invalid contributor affiliation. Please double check that your organisation does not appear in the list ' \
           'in a slightly different form.')
     end
 
-    finalize_org_hash(hash, org)
-  end
-
-  def finalize_org_hash(hash, org)
     hash = remove_org_selection_params(params_in: hash)
 
     return hash if org.blank?

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -118,8 +118,8 @@ class ContributorsController < ApplicationController
 
     if org.nil?
       flash[:alert] =
-        _('Invalid contributor affiliation. Please double check that your organisation does not appear in the list ' \
-          'in a slightly different form.')
+        _('Contributor saved without affiliation. If you intended to add an affiliation, please check ' \
+          'if the organisation appears in the list in a different form.')
     end
 
     hash = remove_org_selection_params(params_in: hash)

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -122,6 +122,15 @@ class ContributorsController < ApplicationController
     # Check if entered org has a valid ROR
     # If so, allow creation
     allow = validate_ror(hash)
+
+    # If org ROR cannot be validated, then contributor org is invalid
+    # Only trigger flash during a real request (tests calling this method directly have no request object)
+    if !allow && request.present?
+      flash[:alert] =
+        _('Invalid contributor affiliation. Please double check that your organisation does not appear in the list ' \
+          'in a slightly different form.')
+    end
+
     org = org_from_params(params_in: hash,
                           allow_create: allow)
 

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -114,10 +114,34 @@ class ContributorsController < ApplicationController
   def process_org(hash:)
     return hash unless hash.present? && hash[:org_id].present?
 
+    # Check if org already exists in the DB
+    existing_org = existing_org_from_hash(hash)
+
+    return finalize_org_hash(hash, existing_org, false) if existing_org.present?
+
     allow = !Rails.configuration.x.application.restrict_orgs
     org = org_from_params(params_in: hash,
                           allow_create: allow)
 
+    finalize_org_hash(hash, org, allow)
+  end
+
+  def existing_org_from_hash(hash)
+    # hash[:org_id] is a JSON string like:
+    # "{\"id\":1200,\"name\":\"Some Org\",\"ror\":\"https://ror.org/123\"}"
+    # So it must be parsed into a Ruby hash for HashToOrgService
+    parsed = JSON.parse(hash[:org_id]) rescue {} # rubocop:disable Style/RescueModifier
+
+    return nil unless parsed.present?
+
+    # Returns org in DB if it exists
+    OrgSelection::HashToOrgService.to_org(
+      hash: parsed.to_h,
+      allow_create: false
+    )
+  end
+
+  def finalize_org_hash(hash, org, allow)
     hash = remove_org_selection_params(params_in: hash)
 
     return hash if org.blank? && !allow

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -114,14 +114,7 @@ class ContributorsController < ApplicationController
   def process_org(hash:)
     return hash unless hash.present? && hash[:org_id].present?
 
-    # Check if org already exists in the DB
-    existing_org = existing_org_from_hash(hash)
-
-    return finalize_org_hash(hash, existing_org, false) if existing_org.present?
-
-    # Check if entered org has a valid ROR
-    # If so, allow creation
-    allow = validate_ror(hash)
+    hash, allow = OrgSelection::HashToOrgService.process_org(hash: hash)
 
     # If org ROR cannot be validated, then contributor org is invalid
     # Only trigger flash during a real request (tests calling this method directly have no request object)
@@ -137,25 +130,6 @@ class ContributorsController < ApplicationController
     finalize_org_hash(hash, org, allow)
   end
 
-  def parse_org_json(hash)
-    JSON.parse(hash[:org_id]) rescue nil # rubocop:disable Style/RescueModifier
-  end
-
-  def existing_org_from_hash(hash)
-    # hash[:org_id] is a JSON string like:
-    # "{\"id\":1200,\"name\":\"Some Org\",\"ror\":\"https://ror.org/123\"}"
-    # So it must be parsed into a Ruby hash for HashToOrgService
-    parsed = parse_org_json(hash)
-
-    return nil unless parsed.present?
-
-    # Returns org in DB if it exists
-    OrgSelection::HashToOrgService.to_org(
-      hash: parsed.to_h,
-      allow_create: false
-    )
-  end
-
   def finalize_org_hash(hash, org, allow)
     hash = remove_org_selection_params(params_in: hash)
 
@@ -164,20 +138,6 @@ class ContributorsController < ApplicationController
 
     hash[:org_id] = org.id
     hash
-  end
-
-  def validate_ror(hash)
-    # Make external API call to ROR to find org with entered name
-    ror_result = ExternalApis::RorService.search(term: hash[:org_name]).first
-
-    # Find ROR value in org hash
-    parsed_ror = parse_org_json(hash)['ror']
-
-    # If org hash ROR and external ROR values are the same
-    # The org is valid and has the correct ROR
-    return ror_result[:ror] == parsed_ror if ror_result.present? && parsed_ror.present?
-
-    false
   end
 
   # When creating, just remove the ORCID if it was left blank

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -128,11 +128,15 @@ class ContributorsController < ApplicationController
     finalize_org_hash(hash, org, allow)
   end
 
+  def parse_org_json(hash)
+    JSON.parse(hash[:org_id]) rescue nil # rubocop:disable Style/RescueModifier
+  end
+
   def existing_org_from_hash(hash)
     # hash[:org_id] is a JSON string like:
     # "{\"id\":1200,\"name\":\"Some Org\",\"ror\":\"https://ror.org/123\"}"
     # So it must be parsed into a Ruby hash for HashToOrgService
-    parsed = JSON.parse(hash[:org_id]) rescue nil # rubocop:disable Style/RescueModifier
+    parsed = parse_org_json(hash)
 
     return nil unless parsed.present?
 
@@ -158,8 +162,7 @@ class ContributorsController < ApplicationController
     ror_result = ExternalApis::RorService.search(term: hash[:org_name]).first
 
     # Find ROR value in org hash
-    parsed = JSON.parse(hash[:org_id]) rescue nil # rubocop:disable Style/RescueModifier
-    parsed_ror = parsed['ror']
+    parsed_ror = parse_org_json(hash)['ror']
 
     # If org hash ROR and external ROR values are the same
     # The org is valid and has the correct ROR

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -124,7 +124,6 @@ class ContributorsController < ApplicationController
 
     hash = remove_org_selection_params(params_in: hash)
 
-    return hash if org.blank?
     return hash unless org.present?
 
     hash[:org_id] = org.id

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -119,7 +119,9 @@ class ContributorsController < ApplicationController
 
     return finalize_org_hash(hash, existing_org, false) if existing_org.present?
 
-    allow = !Rails.configuration.x.application.restrict_orgs
+    # Check if entered org has a valid ROR
+    # If so, allow creation
+    allow = validate_ror(hash)
     org = org_from_params(params_in: hash,
                           allow_create: allow)
 
@@ -130,7 +132,7 @@ class ContributorsController < ApplicationController
     # hash[:org_id] is a JSON string like:
     # "{\"id\":1200,\"name\":\"Some Org\",\"ror\":\"https://ror.org/123\"}"
     # So it must be parsed into a Ruby hash for HashToOrgService
-    parsed = JSON.parse(hash[:org_id]) rescue {} # rubocop:disable Style/RescueModifier
+    parsed = JSON.parse(hash[:org_id]) rescue nil # rubocop:disable Style/RescueModifier
 
     return nil unless parsed.present?
 
@@ -149,6 +151,21 @@ class ContributorsController < ApplicationController
 
     hash[:org_id] = org.id
     hash
+  end
+
+  def validate_ror(hash)
+    # Make external API call to ROR to find org with entered name
+    ror_result = ExternalApis::RorService.search(term: hash[:org_name]).first
+
+    # Find ROR value in org hash
+    parsed = JSON.parse(hash[:org_id]) rescue nil # rubocop:disable Style/RescueModifier
+    parsed_ror = parsed['ror']
+
+    # If org hash ROR and external ROR values are the same
+    # The org is valid and has the correct ROR
+    return ror_result[:ror] == parsed_ror if ror_result.present? && parsed_ror.present?
+
+    false
   end
 
   # When creating, just remove the ORCID if it was left blank

--- a/app/javascript/src/utils/autoComplete.js
+++ b/app/javascript/src/utils/autoComplete.js
@@ -1,6 +1,7 @@
 import 'jquery-ui/ui/widgets/autocomplete';
 import getConstant from './constants';
 import { isObject, isString, isArray } from './isType';
+import debounce from '../utils/debounce';
 
 // Updates the ARIA help text that lets the user know how many suggestions
 const updateAriaHelper = (autocomplete, suggestionCount) => {
@@ -94,6 +95,12 @@ const toggleWarning = (autocomplete, displayIt) => {
   }
 };
 
+// Delayed warning display (fires only after typing pauses)
+const debouncedToggleWarning = debounce((autocomplete, displayIt) => {
+  toggleWarning(autocomplete, displayIt);
+}, 1000);
+
+
 // Looks up the value in the crosswalk
 const findInCrosswalk = (selection, crosswalk) => {
   // Default to the name only
@@ -123,7 +130,11 @@ const warnableSelection = (selection) => {
 const handleSelection = (autocomplete, hidden, crosswalk, selection) => {
   const out = findInCrosswalk(selection, crosswalk);
 
-  toggleWarning(autocomplete, warnableSelection(out));
+  // When user types, 'displayIt = false' hides warning initially
+  toggleWarning(autocomplete, false);
+
+  // After user pauses for 1 second, show warning
+  debouncedToggleWarning(autocomplete, warnableSelection(out));
 
   // Set the ID and trigger the onChange event for any view specific
   // JS to trigger events

--- a/app/services/org_selection/hash_to_org_service.rb
+++ b/app/services/org_selection/hash_to_org_service.rb
@@ -61,40 +61,24 @@ module OrgSelection
       end
       # rubocop:enable Metrics/AbcSize
 
-      # Returns [hash, allow_create, existing_org]
-      def process_org(hash:)
-        # Check if org already exists in the DB
-        parsed = parse_org_json(hash)
-
-        return nil unless parsed.present?
-
-        # Returns org in DB if it exists
-        existing_org = to_org(
-          hash: parsed.to_h,
-          allow_create: false
-        )
-
-        return [hash, false, true] if existing_org.present?
-
-        # If org does not exist in local DB, search for external org through ROR
-        ror_result = OrgSelection::SearchService
-                     .search_externally(search_term: hash[:org_name])
-                     .first
-        parsed_ror = parsed['ror']
-
-        # Ensure that external search result matches entered org
-        allow =
-          ror_result.present? &&
-          parsed_ror.present? &&
-          ror_result[:ror] == parsed_ror
-
-        [hash, allow, false]
-      end
-
       private
 
-      def parse_org_json(hash)
-        JSON.parse(hash[:org_id]) rescue nil # rubocop:disable Style/RescueModifier
+      def match_hash_to_ror_org(hash:)
+        return nil unless hash.present?
+        return nil unless hash[:name].present?
+
+        ror_results =
+          OrgSelection::SearchService.search_externally(
+            search_term: hash[:name]
+          )
+
+        return nil unless ror_results.present?
+
+        # If ROR is provided, require it to match
+        correct_org = ror_results.find { |r| r[:ror] == hash[:ror] } if hash[:ror].present?
+        return correct_org if correct_org
+
+        nil
       end
 
       # Lookup the Org by it's :id and return if the name matches the search
@@ -126,14 +110,18 @@ module OrgSelection
       def initialize_org(hash:)
         return nil unless hash.present? && hash[:name].present?
 
+        # Attempt to find an ROR match to the hash
+        ror_hash = match_hash_to_ror_org(hash: hash)
+        return nil unless ror_hash
+
         Org.new(
-          name: hash[:name],
-          links: links_from_hash(name: hash[:name], website: hash[:url]),
-          language: language_from_hash(hash: hash),
-          target_url: hash[:url],
+          name: ror_hash[:name],
+          links: links_from_hash(name: ror_hash[:name], website: ror_hash[:url]),
+          language: language_from_hash(hash: ror_hash),
+          target_url: ror_hash[:url],
           institution: true,
           is_other: false,
-          abbreviation: abbreviation_from_hash(hash: hash)
+          abbreviation: abbreviation_from_hash(hash: ror_hash)
         )
       end
 

--- a/app/services/org_selection/hash_to_org_service.rb
+++ b/app/services/org_selection/hash_to_org_service.rb
@@ -64,21 +64,10 @@ module OrgSelection
       private
 
       def match_hash_to_ror_org(hash:)
-        return nil unless hash.present?
-        return nil unless hash[:name].present?
+        return nil unless hash[:ror].present?
 
-        ror_results =
-          OrgSelection::SearchService.search_externally(
-            search_term: hash[:name]
-          )
-
-        return nil unless ror_results.present?
-
-        # If ROR is provided, require it to match
-        correct_org = ror_results.find { |r| r[:ror] == hash[:ror] } if hash[:ror].present?
-        return correct_org if correct_org
-
-        nil
+        ror_results = OrgSelection::SearchService.search_externally(search_term: hash[:name])
+        ror_results&.find { |r| r[:ror] == hash[:ror] }
       end
 
       # Lookup the Org by it's :id and return if the name matches the search

--- a/app/services/org_selection/hash_to_org_service.rb
+++ b/app/services/org_selection/hash_to_org_service.rb
@@ -61,6 +61,7 @@ module OrgSelection
       end
       # rubocop:enable Metrics/AbcSize
 
+      # Returns [hash, allow_create, existing_org]
       def process_org(hash:)
         # Check if org already exists in the DB
         parsed = parse_org_json(hash)
@@ -73,30 +74,24 @@ module OrgSelection
           allow_create: false
         )
 
-        return [hash, false] if existing_org.present?
+        return [hash, false, true] if existing_org.present?
 
-        # Check if entered org has a valid ROR
-        # If so, allow creation
-        allow = validate_ror(hash)
+        # If org does not exist in local DB, search for external org through ROR
+        ror_result = OrgSelection::SearchService
+                     .search_externally(search_term: hash[:org_name])
+                     .first
+        parsed_ror = parsed['ror']
 
-        [hash, allow]
+        # Ensure that external search result matches entered org
+        allow =
+          ror_result.present? &&
+          parsed_ror.present? &&
+          ror_result[:ror] == parsed_ror
+
+        [hash, allow, false]
       end
 
       private
-
-      def validate_ror(hash)
-        # Make external API call to ROR to find org with entered name
-        ror_result = ExternalApis::RorService.search(term: hash[:org_name]).first
-
-        # Find ROR value in org hash
-        parsed_ror = parse_org_json(hash)['ror']
-
-        # If org hash ROR and external ROR values are the same
-        # The org is valid and has the correct ROR
-        return ror_result[:ror] == parsed_ror if ror_result.present? && parsed_ror.present?
-
-        false
-      end
 
       def parse_org_json(hash)
         JSON.parse(hash[:org_id]) rescue nil # rubocop:disable Style/RescueModifier

--- a/app/services/org_selection/hash_to_org_service.rb
+++ b/app/services/org_selection/hash_to_org_service.rb
@@ -61,7 +61,46 @@ module OrgSelection
       end
       # rubocop:enable Metrics/AbcSize
 
+      def process_org(hash:)
+        # Check if org already exists in the DB
+        parsed = parse_org_json(hash)
+
+        return nil unless parsed.present?
+
+        # Returns org in DB if it exists
+        existing_org = to_org(
+          hash: parsed.to_h,
+          allow_create: false
+        )
+
+        return [hash, false] if existing_org.present?
+
+        # Check if entered org has a valid ROR
+        # If so, allow creation
+        allow = validate_ror(hash)
+
+        [hash, allow]
+      end
+
       private
+
+      def validate_ror(hash)
+        # Make external API call to ROR to find org with entered name
+        ror_result = ExternalApis::RorService.search(term: hash[:org_name]).first
+
+        # Find ROR value in org hash
+        parsed_ror = parse_org_json(hash)['ror']
+
+        # If org hash ROR and external ROR values are the same
+        # The org is valid and has the correct ROR
+        return ror_result[:ror] == parsed_ror if ror_result.present? && parsed_ror.present?
+
+        false
+      end
+
+      def parse_org_json(hash)
+        JSON.parse(hash[:org_id]) rescue nil # rubocop:disable Style/RescueModifier
+      end
 
       # Lookup the Org by it's :id and return if the name matches the search
       def lookup_org_by_id(hash:)

--- a/app/views/contributors/_form.html.erb
+++ b/app/views/contributors/_form.html.erb
@@ -56,9 +56,8 @@ roles_tooltip = _("Select each role that applies to the contributor.")
 
 <div class="form-group row" id="contributor-org-controls"><!-- org -->
   <div class="col-md-8">
-    <%= render partial: org_partial,
+    <%= render partial:'shared/org_selectors/combined',
                locals: { form: form,
-                         orgs: orgs,
                          default_org: contributor.org,
                          required: false,
                          label: _("Affiliation") } %>

--- a/app/views/shared/org_selectors/_combined.html.erb
+++ b/app/views/shared/org_selectors/_combined.html.erb
@@ -47,5 +47,5 @@ placeholder = _("Begin typing to see a list of suggestions.")
                                class: "autocomplete-result" %>
 
 <p class="autocomplete-warning red hide">
-  <%= _("A new entry will be created for the organisation you have named above. Please double check that your organisation does not appear in the list in a slightly different form.").html_safe %>
+  <%= _("Please double check that your organisation does not appear in the list in a slightly different form.").html_safe %>
 </p>

--- a/spec/controllers/contributors_controller_spec.rb
+++ b/spec/controllers/contributors_controller_spec.rb
@@ -134,6 +134,12 @@ RSpec.describe ContributorsController, type: :controller do
     end
 
     describe '#process_org(hash:)' do
+      before do
+        @request = ActionDispatch::TestRequest.create
+        @response = ActionDispatch::TestResponse.create
+        @controller.request = @request
+        @controller.response = @response
+      end
       it 'returns the hash as is if no :org_id is present' do
         @params_hash[:contributor].delete(:org_id)
         hash = @controller.send(:process_org, hash: @params_hash[:contributor])

--- a/spec/controllers/contributors_controller_spec.rb
+++ b/spec/controllers/contributors_controller_spec.rb
@@ -159,6 +159,10 @@ RSpec.describe ContributorsController, type: :controller do
       end
       it 'sets the org_id to the idea of the org' do
         new_org = create(:org)
+        # Clear name, id, and ror to prevent matching any existing org
+        @params_hash[:contributor][:org_name] = nil
+        @params_hash[:contributor][:org_id] = { id: nil, name: nil, ror: nil }.to_json
+
         @controller.stubs(:org_from_params).returns(new_org)
         hash = @controller.send(:process_org, hash: @params_hash[:contributor])
         expect(hash[:org_id]).to eql(new_org.id)

--- a/spec/services/org_selection/hash_to_org_service_spec.rb
+++ b/spec/services/org_selection/hash_to_org_service_spec.rb
@@ -45,6 +45,20 @@ RSpec.describe OrgSelection::HashToOrgService do
       expect(described_class.to_org(hash: @hash)).to eql(org)
     end
     it 'returns a new Org instance' do
+      fake_ror = {
+        ror: Faker::Alphanumeric.alphanumeric(number: 9),
+        name: "#{@name} (#{@abbrev})",
+        sort_name: @name,
+        url: @url,
+        language: @lang.abbreviation,
+        fundref: '',
+        abbreviation: @abbrev,
+        score: @hash[:score],
+        weight: @hash[:weight]
+      }
+      # Stub the ROR matcher to return the fake ROR hash
+      # As valid ROR hash is needed for new org creation
+      described_class.stubs(:match_hash_to_ror_org).returns(fake_ror)
       expect(described_class.to_org(hash: @hash).new_record?).to eql(true)
     end
   end
@@ -95,6 +109,21 @@ RSpec.describe OrgSelection::HashToOrgService do
         expect(rslt).to eql(nil)
       end
       it 'returns a new instance of Org' do
+        fake_ror = {
+          ror: Faker::Alphanumeric.alphanumeric(number: 9),
+          name: "#{@name} (#{@abbrev})",
+          sort_name: @name,
+          url: @url,
+          language: @lang.abbreviation,
+          fundref: '',
+          abbreviation: @abbrev,
+          score: @hash[:score],
+          weight: @hash[:weight]
+        }
+        # Stub the ROR matcher to return the fake ROR hash
+        # As valid ROR hash is needed for new org creation
+        described_class.stubs(:match_hash_to_ror_org).returns(fake_ror)
+
         rslt = described_class.send(:initialize_org, hash: @hash)
         nm = "#{@name} (#{@abbrev})"
         lnks = JSON.parse({ org: [{ link: @url, text: nm }] }.to_json)

--- a/spec/services/org_selection/hash_to_org_service_spec.rb
+++ b/spec/services/org_selection/hash_to_org_service_spec.rb
@@ -140,10 +140,6 @@ RSpec.describe OrgSelection::HashToOrgService do
 
   context 'private methods' do
     describe '#match_hash_to_ror_org' do
-      it 'returns nil if the hash is blank' do
-        expect(described_class.send(:match_hash_to_ror_org, hash: nil)).to be_nil
-      end
-
       it 'returns nil if no ROR results are found' do
         OrgSelection::SearchService.stubs(:search_externally)
                                    .with(search_term: @hash[:name])

--- a/spec/services/org_selection/hash_to_org_service_spec.rb
+++ b/spec/services/org_selection/hash_to_org_service_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe OrgSelection::HashToOrgService do
       org = create(:org, name: @name)
       expect(described_class.to_org(hash: @hash)).to eql(org)
     end
-    it 'Ensures a successful response from the ROR API' do
+    it 'returns a new Org instance when no existing DB matches exist but an ROR match does' do
       ror_id = Faker::Alphanumeric.alphanumeric(number: 9)
 
       hash_with_ror = @hash.merge(ror: ror_id)
@@ -101,23 +101,6 @@ RSpec.describe OrgSelection::HashToOrgService do
 
       expect(org).not_to be_nil
       expect(org).to be_new_record
-    end
-    it 'returns a new Org instance' do
-      fake_ror = {
-        ror: Faker::Alphanumeric.alphanumeric(number: 9),
-        name: "#{@name} (#{@abbrev})",
-        sort_name: @name,
-        url: @url,
-        language: @lang.abbreviation,
-        fundref: '',
-        abbreviation: @abbrev,
-        score: @hash[:score],
-        weight: @hash[:weight]
-      }
-      # Stub the ROR matcher to return the fake ROR hash
-      # As valid ROR hash is needed for new org creation
-      described_class.stubs(:match_hash_to_ror_org).returns(fake_ror)
-      expect(described_class.to_org(hash: @hash).new_record?).to eql(true)
     end
   end
 

--- a/spec/services/org_selection/hash_to_org_service_spec.rb
+++ b/spec/services/org_selection/hash_to_org_service_spec.rb
@@ -44,6 +44,64 @@ RSpec.describe OrgSelection::HashToOrgService do
       org = create(:org, name: @name)
       expect(described_class.to_org(hash: @hash)).to eql(org)
     end
+    it 'Ensures a successful response from the ROR API' do
+      ror_id = Faker::Alphanumeric.alphanumeric(number: 9)
+
+      hash_with_ror = @hash.merge(ror: ror_id)
+
+      # heartbeat
+      stub_request(
+        :get,
+        "#{ExternalApis::RorService.api_base_url}#{ExternalApis::RorService.heartbeat_path}"
+      ).with(headers: ExternalApis::RorService.headers)
+        .to_return(status: 200, body: '', headers: {})
+
+      # search
+      search_uri =
+        "#{ExternalApis::RorService.api_base_url}" \
+        "#{ExternalApis::RorService.search_path}" \
+        "?page=1&query=#{URI.encode_www_form_component(hash_with_ror[:name])}"
+
+      ror_response = {
+        number_of_results: 1,
+        time_taken: 1,
+        items: [
+          {
+            id: ror_id,
+            names: [
+              { value: hash_with_ror[:name], types: ['ror_display'] },
+              { value: hash_with_ror[:abbreviation], types: ['acronym'] }
+            ],
+            links: [{ type: 'website', value: hash_with_ror[:url] }],
+            types: ['Education'],
+            status: 'active',
+            locations: [
+              {
+                geonames_id: 123,
+                geonames_details: {
+                  country_name: 'United States',
+                  country_code: 'US'
+                }
+              }
+            ],
+            external_ids: []
+          }
+        ]
+      }
+
+      stub_request(:get, search_uri)
+        .with(headers: ExternalApis::RorService.headers)
+        .to_return(
+          status: 200,
+          body: ror_response.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      org = described_class.to_org(hash: hash_with_ror)
+
+      expect(org).not_to be_nil
+      expect(org).to be_new_record
+    end
     it 'returns a new Org instance' do
       fake_ror = {
         ror: Faker::Alphanumeric.alphanumeric(number: 9),
@@ -98,6 +156,43 @@ RSpec.describe OrgSelection::HashToOrgService do
   end
 
   context 'private methods' do
+    describe '#match_hash_to_ror_org' do
+      it 'returns nil if the hash is blank' do
+        expect(described_class.send(:match_hash_to_ror_org, hash: nil)).to be_nil
+      end
+
+      it 'returns nil if no ROR results are found' do
+        OrgSelection::SearchService.stubs(:search_externally)
+                                   .with(search_term: @hash[:name])
+                                   .returns([])
+
+        result = described_class.send(:match_hash_to_ror_org, hash: @hash)
+        expect(result).to be_nil
+      end
+
+      it 'returns the ROR-matching result when ror is present' do
+        ror_id = Faker::Alphanumeric.alphanumeric(number: 9)
+
+        ror_results = [{
+          ror: ror_id,
+          name: "#{@name} (#{@abbrev})",
+          sort_name: @name,
+          url: @url,
+          language: @lang.abbreviation,
+          fundref: '',
+          abbreviation: @abbrev,
+          score: @hash[:score],
+          weight: @hash[:weight]
+        }]
+
+        OrgSelection::SearchService.stubs(:search_externally).returns(ror_results)
+        hash_with_ror = @hash.merge(ror: ror_id)
+        result = described_class.send(:match_hash_to_ror_org, hash: hash_with_ror)
+
+        expect(result).to eq(ror_results.first)
+      end
+    end
+
     describe '#initialize_org(hash:)' do
       it 'returns nil if the hash is nil' do
         rslt = described_class.send(:initialize_org, hash: nil)


### PR DESCRIPTION
Fixes https://github.com/portagenetwork/roadmap/issues/926.

Changes proposed in this PR:

- Edit contributor affiliation dropdown partial to allow for search for orgs external to DMP Assistant DB.
- Edit contributions_controller to process orgs that are external to DMP Assistant DB by validating ROR.
- The workflow is as follows after a user enters an affiliation for a contributor:
     - If the affiliation already exists in the orgs table, the existing entry is used.
     - If the affiliation does not exist in the orgs table, an external API request to ROR is made. If a matching result is found, the new organisation is added to the orgs table along with the ror and fundref identifiers.
     - If the affiliation neither exists in the orgs table or on ROR, then there is no change made to the affiliation and an error message is displayed.