### PR TITLE
Upgrade ROR API From V1 to V2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+ - Upgrade ROR API From V1 to V2 [#1247](https://github.com/portagenetwork/roadmap/pull/1247)
+
 ### Dependency Updates
 
  - chore(deps): bump nginx from 1.29.3-alpine to 1.29.4-alpine [#1246](https://github.com/portagenetwork/roadmap/pull/1246)

--- a/app/services/external_apis/ror_service.rb
+++ b/app/services/external_apis/ror_service.rb
@@ -221,10 +221,7 @@ module ExternalApis
       #   ]
       # }
       def org_language(item:)
-        # ROR uses two-letter / ISO 639-1 language codes (e.g. "en")
-        dflt = I18n.default_locale.to_s.split('-').first
-
-        ror_display_entry(item: item)['lang'] || dflt
+        ror_display_entry(item: item)['lang'] || I18n.default_locale.to_s
       end
 
       # Extracts the website domain from the item

--- a/app/services/external_apis/ror_service.rb
+++ b/app/services/external_apis/ror_service.rb
@@ -238,10 +238,9 @@ module ExternalApis
       #   {"type": "SomeOtherID", "preferred": "501100000000", "all": ["501100000000"]}
       # ]
       def fundref_id(item:)
-        external_ids = item['external_ids']
-        return '' unless external_ids.present?
+        external_ids = item['external_ids'] if item
 
-        fundref = external_ids.find { |id| id['type'].to_s.casecmp('fundref').zero? }
+        fundref = external_ids.find { |id| id['type'] == 'fundref' }
         return '' unless fundref.present?
 
         # If a preferred Id was specified then use it
@@ -250,7 +249,7 @@ module ExternalApis
 
         # Otherwise take the first one listed
         all = fundref['all']
-        return all.first if all.present? && all.first.present?
+        return all.first if all.present?
 
         ''
       end

--- a/app/services/external_apis/ror_service.rb
+++ b/app/services/external_apis/ror_service.rb
@@ -142,14 +142,14 @@ module ExternalApis
         return results unless json.present? && json.fetch('items', []).any?
 
         json['items'].each do |item|
-          name = sort_name(item)
+          name = sort_name(item: item)
           next unless item['id'].present? && name.present?
 
           results << {
             ror: item['id'].gsub(/^#{landing_page_url}/, ''),
             name: org_name(item: item),
             sort_name: name,
-            url: org_url(item),
+            url: org_url(item: item),
             language: org_language(item: item),
             fundref: fundref_id(item: item),
             abbreviation: item.fetch('acronyms', []).first
@@ -159,7 +159,7 @@ module ExternalApis
       end
       # rubocop:enable Metrics/AbcSize
 
-      def ror_display_entry(item)
+      def ror_display_entry(item:)
         item['names'].find { |n| n['types'].include?('ror_display') }
       end
 
@@ -168,8 +168,8 @@ module ExternalApis
       #     {"lang": "en", "types": ["ror_display","label"], "value": "Harvard University"},
       #     {"lang": "es","types": ["label"], "value": "Universidad de Harvard"}
       # ]
-      def sort_name(item)
-        ror_display_entry(item).fetch('value')
+      def sort_name(item:)
+        ror_display_entry(item: item).fetch('value')
       end
 
       # Returns the website link value
@@ -177,7 +177,7 @@ module ExternalApis
       #   { "type": "website", "value": "https://example.edu" },
       #   { "type": "Wikipedia", "value": "https://en.wikipedia.org/wiki/Example_University" }
       # ]
-      def org_url(item)
+      def org_url(item:)
         links = item['links']
         # links must not be empty
         return nil unless links.present?
@@ -190,7 +190,7 @@ module ExternalApis
       #    "Example College (example.edu)"
       #    "Example College (Brazil)"
       def org_name(item:)
-        name = sort_name(item)
+        name = sort_name(item: item)
 
         country = item.fetch('country', {}).fetch('country_name', '')
         website = org_website(item: item)
@@ -223,7 +223,7 @@ module ExternalApis
       #   { "type": "Wikipedia", "value": "https://en.wikipedia.org/wiki/Example_University" }
       # ]
       def org_website(item:)
-        link = org_url(item)
+        link = org_url(item: item)
         return nil unless link.present?
 
         # A website was found, so extract just the domain without the www

--- a/app/services/external_apis/ror_service.rb
+++ b/app/services/external_apis/ror_service.rb
@@ -149,7 +149,7 @@ module ExternalApis
             url: org_url(item: item),
             language: org_language(item: item),
             fundref: fundref_id(item: item),
-            abbreviation: item.fetch('acronyms', []).first
+            abbreviation: org_abbreviation(item: item)
           }
         rescue KeyError, NoMethodError => e
           Rails.logger.error(
@@ -191,6 +191,12 @@ module ExternalApis
       def org_country(item:)
         location = item['locations']&.find { |l| l['geonames_details'].present? }
         location&.dig('geonames_details', 'country_name').to_s
+      end
+
+      # Extract acronym/abbreviation from names
+      # "names" : [ { "value" : "UC", "types": ["acronym"], "lang" : "en" } ]
+      def org_abbreviation(item:)
+        item['names'].find { |n| n['types'].include?('acronym') }&.fetch('value')
       end
 
       # Org names are not unique, so include the Org URL if available or

--- a/app/services/external_apis/ror_service.rb
+++ b/app/services/external_apis/ror_service.rb
@@ -235,7 +235,10 @@ module ExternalApis
 
         # A website was found, so extract just the domain without the www
         domain_regex = %r{^(?:http://|www\.|https://)([^/]+)}
-        website = link.scan(domain_regex).last.first
+        matches = link.scan(domain_regex)
+        return nil if matches.empty?
+
+        website = matches.last.first
         website.gsub('www.', '')
       end
 

--- a/app/services/external_apis/ror_service.rb
+++ b/app/services/external_apis/ror_service.rb
@@ -77,7 +77,7 @@ module ExternalApis
 
       private
 
-      # Queries the ROR API for the sepcified name and page
+      # Queries the ROR API for the specified name and page
       def query_ror(term:, page: 1, filters: [])
         return [] unless term.present?
 
@@ -135,6 +135,32 @@ module ExternalApis
       end
       # rubocop:enable Metrics/AbcSize
 
+      # Extracts the org's display name from `names`
+      # "names": [
+      #     {"lang": "en", "types": ["ror_display","label"], "value": "Harvard University"},
+      #     {"lang": "es","types": ["label"], "value": "Universidad de Harvard"}
+      # ]
+      def display_name(item)
+        item['names']
+          &.find { |n| n['types']&.include?('ror_display') }
+          &.fetch('value', nil)
+      end
+
+      # Returns the website link hash
+      # "links": [
+      #   { "type": "website", "value": "https://example.edu" },
+      #   { "type": "Wikipedia", "value": "https://en.wikipedia.org/wiki/Example_University" }
+      # ]
+      def org_url(item)
+        # "links" may be nil, a non‑array, or the whole item may not be a Hash
+        return nil unless item.is_a?(Hash)
+
+        links = item['links']
+        return nil unless links.is_a?(Array)
+
+        links.find { |l| l['type'] == 'website' }
+      end
+
       # Convert the JSON items into a hash
       # rubocop:disable Metrics/AbcSize
       def parse_results(json:)
@@ -142,13 +168,14 @@ module ExternalApis
         return results unless json.present? && json.fetch('items', []).any?
 
         json['items'].each do |item|
-          next unless item['id'].present? && item['name'].present?
+          name = display_name(item)
+          next unless item['id'].present? && name.present?
 
           results << {
             ror: item['id'].gsub(/^#{landing_page_url}/, ''),
             name: org_name(item: item),
-            sort_name: item['name'],
-            url: item.fetch('links', []).first,
+            sort_name: name,
+            url: org_url(item)&.dig('value'),
             language: org_language(item: item),
             fundref: fundref_id(item: item),
             abbreviation: item.fetch('acronyms', []).first

--- a/app/services/external_apis/ror_service.rb
+++ b/app/services/external_apis/ror_service.rb
@@ -159,15 +159,17 @@ module ExternalApis
       end
       # rubocop:enable Metrics/AbcSize
 
+      def ror_display_entry(item)
+        item['names'].find { |n| n['types'].include?('ror_display') }
+      end
+
       # Extracts the org's display name from `names` to be used as sort_name
       # "names": [
       #     {"lang": "en", "types": ["ror_display","label"], "value": "Harvard University"},
       #     {"lang": "es","types": ["label"], "value": "Universidad de Harvard"}
       # ]
       def sort_name(item)
-        item['names']
-          &.find { |n| n['types']&.include?('ror_display') }
-          &.fetch('value', nil)
+        ror_display_entry(item).fetch('value')
       end
 
       # Returns the website link value
@@ -212,8 +214,7 @@ module ExternalApis
         # ROR uses two-letter / ISO 639-1 language codes (e.g. "en")
         dflt = I18n.default_locale.to_s.split('-').first
 
-        display = item['names']&.find { |n| n['types']&.include?('ror_display') }
-        display&.fetch('lang', dflt) || dflt
+        ror_display_entry(item: item)['lang'] || dflt
       end
 
       # Extracts the website domain from the item

--- a/app/services/external_apis/ror_service.rb
+++ b/app/services/external_apis/ror_service.rb
@@ -179,11 +179,7 @@ module ExternalApis
       #   { "type": "Wikipedia", "value": "https://en.wikipedia.org/wiki/Example_University" }
       # ]
       def org_url(item:)
-        links = item['links']
-        # links must not be empty
-        return nil unless links.present?
-
-        links.find { |l| l['type'] == 'website' }&.fetch('value')
+        item['links']&.find { |l| l['type'] == 'website' }&.fetch('value')
       end
 
       # Returns the country name from locations

--- a/app/services/external_apis/ror_service.rb
+++ b/app/services/external_apis/ror_service.rb
@@ -186,6 +186,13 @@ module ExternalApis
         links.find { |l| l['type'] == 'website' }&.fetch('value')
       end
 
+      # Returns the country name from locations
+      # "locations" : [ { "geonames_details" : { "country_name" : "Germany",}, "geonames_id" : 2928810 } ]
+      def org_country(item:)
+        location = item['locations']&.find { |l| l['geonames_details'].present? }
+        location&.dig('geonames_details', 'country_name').to_s
+      end
+
       # Org names are not unique, so include the Org URL if available or
       # the country. For example:
       #    "Example College (example.edu)"
@@ -193,7 +200,7 @@ module ExternalApis
       def org_name(item:)
         name = sort_name(item: item)
 
-        country = item.fetch('country', {}).fetch('country_name', '')
+        country = org_country(item: item)
         website = org_website(item: item)
 
         # If no website or country then just return the name

--- a/app/services/external_apis/ror_service.rb
+++ b/app/services/external_apis/ror_service.rb
@@ -190,15 +190,17 @@ module ExternalApis
       #    "Example College (example.edu)"
       #    "Example College (Brazil)"
       def org_name(item:)
-        return '' unless item.present? && item['name'].present?
+        name = display_name(item)
+        return '' unless name.present?
 
         country = item.fetch('country', {}).fetch('country_name', '')
         website = org_website(item: item)
+
         # If no website or country then just return the name
-        return item['name'] unless website.present? || country.present?
+        return name unless website.present? || country.present?
 
         # Otherwise return the contextualized name
-        "#{item['name']} (#{website || country})"
+        "#{name} (#{website || country})"
       end
 
       # Extracts the org's ISO639 if available

--- a/app/services/external_apis/ror_service.rb
+++ b/app/services/external_apis/ror_service.rb
@@ -220,13 +220,17 @@ module ExternalApis
       end
 
       # Extracts the website domain from the item
+      # "links": [
+      #   { "type": "website", "value": "https://example.edu" },
+      #   { "type": "Wikipedia", "value": "https://en.wikipedia.org/wiki/Example_University" }
+      # ]
       def org_website(item:)
-        return nil unless item.present? && item.fetch('links', [])&.any?
-        return nil if item['links'].first.blank?
+        link = org_url(item)&.fetch('value', nil)
+        return nil unless link.present?
 
         # A website was found, so extract just the domain without the www
         domain_regex = %r{^(?:http://|www\.|https://)([^/]+)}
-        website = item['links'].first.scan(domain_regex).last.first
+        website = link.scan(domain_regex).last.first
         website.gsub('www.', '')
       end
 

--- a/app/services/external_apis/ror_service.rb
+++ b/app/services/external_apis/ror_service.rb
@@ -142,18 +142,19 @@ module ExternalApis
         return results unless json.present? && json.fetch('items', []).any?
 
         json['items'].each do |item|
-          name = sort_name(item: item)
-          next unless item['id'].present? && name.present?
-
           results << {
             ror: item['id'].gsub(/^#{landing_page_url}/, ''),
             name: org_name(item: item),
-            sort_name: name,
+            sort_name: sort_name(item: item),
             url: org_url(item: item),
             language: org_language(item: item),
             fundref: fundref_id(item: item),
             abbreviation: item.fetch('acronyms', []).first
           }
+        rescue KeyError, NoMethodError => e
+          Rails.logger.error(
+            "Invalid ROR record: #{e.class} - #{e.message}, item: #{item.inspect}"
+          )
         end
         results
       end

--- a/app/services/external_apis/ror_service.rb
+++ b/app/services/external_apis/ror_service.rb
@@ -203,13 +203,20 @@ module ExternalApis
         "#{name} (#{website || country})"
       end
 
-      # Extracts the org's ISO639 if available
-      def org_language(item:)
+      # Extracts the org's language
+      # {
+      #   "id": "https://ror.org/012345678",
+      #   "names": [
+      #     { "value": "Université de Montréal", "types": ["ror_display"], "lang": "fr" },
+      #     { "value": "University of Montreal", "types": ["alias"], "lang": "en" }
+      #   ]
+      # }
+      def org_language(item:) # rubocop:disable Metrics/CyclomaticComplexity
         dflt = I18n.default_locale || 'en'
         return dflt unless item.present?
 
-        labels = item.fetch('labels', [{ iso639: dflt }])
-        labels.first&.fetch('iso639', I18n.default_locale) || dflt
+        display = item['names']&.find { |n| n['types']&.include?('ror_display') }
+        display&.fetch('lang', dflt) || dflt
       end
 
       # Extracts the website domain from the item

--- a/app/services/external_apis/ror_service.rb
+++ b/app/services/external_apis/ror_service.rb
@@ -234,17 +234,27 @@ module ExternalApis
         website.gsub('www.', '')
       end
 
-      # Extracts the FundRef Id if available
+      # Extracts the FundRef Id from external ids if available
+      # "external_ids": [
+      #   {"type": "fundref", "preferred": "12345", "all": ["12345", "67890"]},
+      #   {"type": "SomeOtherID", "preferred": "501100000000", "all": ["501100000000"]}
+      # ]
       def fundref_id(item:)
-        return '' unless item.present? && item['external_ids'].present?
-        return '' unless item['external_ids'].fetch('FundRef', {}).any?
+        external_ids = item['external_ids']
+        return '' unless external_ids.present?
+
+        fundref = external_ids.find { |id| id['type'].to_s.casecmp('fundref').zero? }
+        return '' unless fundref.present?
 
         # If a preferred Id was specified then use it
-        ret = item['external_ids'].fetch('FundRef', {}).fetch('preferred', '')
-        return ret if ret.present?
+        preferred = fundref['preferred']
+        return preferred if preferred.present?
 
         # Otherwise take the first one listed
-        item['external_ids'].fetch('FundRef', {}).fetch('all', []).first
+        all = fundref['all']
+        return all.first if all.present? && all.first.present?
+
+        ''
       end
     end
   end

--- a/app/services/external_apis/ror_service.rb
+++ b/app/services/external_apis/ror_service.rb
@@ -135,32 +135,6 @@ module ExternalApis
       end
       # rubocop:enable Metrics/AbcSize
 
-      # Extracts the org's display name from `names`
-      # "names": [
-      #     {"lang": "en", "types": ["ror_display","label"], "value": "Harvard University"},
-      #     {"lang": "es","types": ["label"], "value": "Universidad de Harvard"}
-      # ]
-      def display_name(item)
-        item['names']
-          &.find { |n| n['types']&.include?('ror_display') }
-          &.fetch('value', nil)
-      end
-
-      # Returns the website link hash
-      # "links": [
-      #   { "type": "website", "value": "https://example.edu" },
-      #   { "type": "Wikipedia", "value": "https://en.wikipedia.org/wiki/Example_University" }
-      # ]
-      def org_url(item)
-        # "links" may be nil, a non‑array, or the whole item may not be a Hash
-        return nil unless item.is_a?(Hash)
-
-        links = item['links']
-        return nil unless links.is_a?(Array)
-
-        links.find { |l| l['type'] == 'website' }
-      end
-
       # Convert the JSON items into a hash
       # rubocop:disable Metrics/AbcSize
       def parse_results(json:)
@@ -168,14 +142,14 @@ module ExternalApis
         return results unless json.present? && json.fetch('items', []).any?
 
         json['items'].each do |item|
-          name = display_name(item)
+          name = sort_name(item)
           next unless item['id'].present? && name.present?
 
           results << {
             ror: item['id'].gsub(/^#{landing_page_url}/, ''),
             name: org_name(item: item),
             sort_name: name,
-            url: org_url(item)&.dig('value'),
+            url: org_url(item),
             language: org_language(item: item),
             fundref: fundref_id(item: item),
             abbreviation: item.fetch('acronyms', []).first
@@ -185,12 +159,36 @@ module ExternalApis
       end
       # rubocop:enable Metrics/AbcSize
 
+      # Extracts the org's display name from `names` to be used as sort_name
+      # "names": [
+      #     {"lang": "en", "types": ["ror_display","label"], "value": "Harvard University"},
+      #     {"lang": "es","types": ["label"], "value": "Universidad de Harvard"}
+      # ]
+      def sort_name(item)
+        item['names']
+          &.find { |n| n['types']&.include?('ror_display') }
+          &.fetch('value', nil)
+      end
+
+      # Returns the website link value
+      # "links": [
+      #   { "type": "website", "value": "https://example.edu" },
+      #   { "type": "Wikipedia", "value": "https://en.wikipedia.org/wiki/Example_University" }
+      # ]
+      def org_url(item)
+        links = item['links'] if item
+        # links must be an array
+        return nil unless links.is_a?(Array)
+
+        links.find { |l| l['type'] == 'website' }&.fetch('value', nil)
+      end
+
       # Org names are not unique, so include the Org URL if available or
       # the country. For example:
       #    "Example College (example.edu)"
       #    "Example College (Brazil)"
       def org_name(item:)
-        name = display_name(item)
+        name = sort_name(item)
         return '' unless name.present?
 
         country = item.fetch('country', {}).fetch('country_name', '')
@@ -225,7 +223,7 @@ module ExternalApis
       #   { "type": "Wikipedia", "value": "https://en.wikipedia.org/wiki/Example_University" }
       # ]
       def org_website(item:)
-        link = org_url(item)&.fetch('value', nil)
+        link = org_url(item)
         return nil unless link.present?
 
         # A website was found, so extract just the domain without the www

--- a/app/services/external_apis/ror_service.rb
+++ b/app/services/external_apis/ror_service.rb
@@ -176,11 +176,11 @@ module ExternalApis
       #   { "type": "Wikipedia", "value": "https://en.wikipedia.org/wiki/Example_University" }
       # ]
       def org_url(item)
-        links = item['links'] if item
-        # links must be an array
-        return nil unless links.is_a?(Array)
+        links = item['links']
+        # links must not be empty
+        return nil unless links.present?
 
-        links.find { |l| l['type'] == 'website' }&.fetch('value', nil)
+        links.find { |l| l['type'] == 'website' }&.fetch('value')
       end
 
       # Org names are not unique, so include the Org URL if available or
@@ -189,7 +189,6 @@ module ExternalApis
       #    "Example College (Brazil)"
       def org_name(item:)
         name = sort_name(item)
-        return '' unless name.present?
 
         country = item.fetch('country', {}).fetch('country_name', '')
         website = org_website(item: item)
@@ -209,9 +208,9 @@ module ExternalApis
       #     { "value": "University of Montreal", "types": ["alias"], "lang": "en" }
       #   ]
       # }
-      def org_language(item:) # rubocop:disable Metrics/CyclomaticComplexity
-        dflt = I18n.default_locale || 'en'
-        return dflt unless item.present?
+      def org_language(item:)
+        # ROR uses two-letter / ISO 639-1 language codes (e.g. "en")
+        dflt = I18n.default_locale.to_s.split('-').first
 
         display = item['names']&.find { |n| n['types']&.include?('ror_display') }
         display&.fetch('lang', dflt) || dflt
@@ -238,7 +237,7 @@ module ExternalApis
       #   {"type": "SomeOtherID", "preferred": "501100000000", "all": ["501100000000"]}
       # ]
       def fundref_id(item:)
-        external_ids = item['external_ids'] if item
+        external_ids = item['external_ids']
 
         fundref = external_ids.find { |id| id['type'] == 'fundref' }
         return '' unless fundref.present?

--- a/app/services/org_selection/hash_to_org_service.rb
+++ b/app/services/org_selection/hash_to_org_service.rb
@@ -125,7 +125,15 @@ module OrgSelection
       def language_from_hash(hash:)
         return Language.default unless hash.present? && hash[:language].present?
 
-        Language.where(abbreviation: hash[:language]).first || Language.default
+        # Try exact match first
+        exact = Language.find_by(abbreviation: hash[:language])
+        return exact if exact.present?
+
+        # `hash[:language]` comes from ROR and is a two-char ISO 639-1 language code (e.g., "en").
+        # Language.abbreviation stores BCP 47 tags (e.g., "en-CA").
+        Language.where('abbreviation LIKE ?', "#{hash[:language]}-%")
+                .order(default_language: :desc) # prefer default language if multiple results exist
+                .first || Language.default
       end
 
       def identifier_keys

--- a/app/services/org_selection/hash_to_org_service.rb
+++ b/app/services/org_selection/hash_to_org_service.rb
@@ -123,17 +123,19 @@ module OrgSelection
 
       # Get the language from the hash or use the default
       def language_from_hash(hash:)
-        return Language.default unless hash.present? && hash[:language].present?
+        abbr = hash&.dig(:language)
+        # RorService.org_language returns I18n.default_locale.to_s as a fallback
+        return Language.default if abbr.blank? || abbr == I18n.default_locale.to_s
 
-        # Try exact match first
-        exact = Language.find_by(abbreviation: hash[:language])
-        return exact if exact.present?
+        # ROR provides ISO 639-1 codes (e.g., "en"). Attempt to match against BCP 47 tags (e.g., "en-CA") in db
+        pattern = "#{ActiveRecord::Base.sanitize_sql_like(abbr)}-%"
 
-        # `hash[:language]` comes from ROR and is a two-char ISO 639-1 language code (e.g., "en").
-        # Language.abbreviation stores BCP 47 tags (e.g., "en-CA").
-        Language.where('abbreviation LIKE ?', "#{hash[:language]}-%")
-                .order(default_language: :desc) # prefer default language if multiple results exist
-                .first || Language.default
+        results = Language.where('abbreviation = ?  OR abbreviation LIKE ?', abbr, pattern)
+                          .order(default_language: :desc) # prefer default language if multiple results exist
+                          .to_a
+
+        # Return (in order): exact match || first pattern match || app default language
+        results.find { |lang| lang.abbreviation == abbr } || results.first || Language.default
       end
 
       def identifier_keys

--- a/config/initializers/external_apis/ror.rb
+++ b/config/initializers/external_apis/ror.rb
@@ -5,7 +5,7 @@
 # the API and to verify that your configuration settings are correct,
 # please refer to: https://github.com/ror-community/ror-api
 Rails.configuration.x.ror.landing_page_url = "https://ror.org/"
-Rails.configuration.x.ror.api_base_url = "https://api.ror.org/v1/"
+Rails.configuration.x.ror.api_base_url = "https://api.ror.org/"
 Rails.configuration.x.ror.heartbeat_path = "heartbeat"
 Rails.configuration.x.ror.search_path = "organizations"
 Rails.configuration.x.ror.max_pages = 2

--- a/spec/services/external_apis/ror_service_spec.rb
+++ b/spec/services/external_apis/ror_service_spec.rb
@@ -80,7 +80,15 @@ RSpec.describe ExternalApis::RorService do
               ],
               acronyms: ['EU'],
               status: 'active',
-              country: { country_name: 'United States', country_code: 'US' },
+              locations: [
+                {
+                  geonames_id: 123_456,
+                  geonames_details: {
+                    country_name: 'United States',
+                    country_code: 'US'
+                  }
+                }
+              ],
               external_ids: [
                 { type: 'grid', preferred: 'grid.12345.1', all: ['grid.12345.1'] }
               ]
@@ -93,7 +101,15 @@ RSpec.describe ExternalApis::RorService do
               links: [],
               acronyms: ['EU'],
               status: 'active',
-              country: { country_name: 'Mexico', country_code: 'MX' },
+              locations: [
+                {
+                  geonames_id: 12_345,
+                  geonames_details: {
+                    country_name: 'Mexico',
+                    country_code: 'MX'
+                  }
+                }
+              ],
               external_ids: [
                 { type: 'fundref', preferred: 'fundref.12345', all: ['fundref.12345'] }
               ]
@@ -130,7 +146,15 @@ RSpec.describe ExternalApis::RorService do
           items: [{
             id: Faker::Internet.url,
             names: [{ types: ['ror_display'], value: Faker::Lorem.word }],
-            country: { country_name: Faker::Lorem.word }
+            locations: [
+              {
+                geonames_id: Faker::Number.number(digits: 6),
+                geonames_details: {
+                  country_name: Faker::Lorem.word,
+                  country_code: Faker::Lorem.characters(number: 2).upcase
+                }
+              }
+            ]
           }]
         }
         @term = Faker::Lorem.word
@@ -204,7 +228,15 @@ RSpec.describe ExternalApis::RorService do
           {
             id: Faker::Internet.unique.url,
             names: [{ types: ['ror_display'], value: Faker::Lorem.word }],
-            country: { country_name: Faker::Lorem.word },
+            locations: [
+              {
+                geonames_id: Faker::Number.number(digits: 6),
+                geonames_details: {
+                  country_name: Faker::Lorem.word,
+                  country_code: Faker::Lorem.characters(number: 2).upcase
+                }
+              }
+            ],
             external_ids: []
           }
         end
@@ -224,7 +256,15 @@ RSpec.describe ExternalApis::RorService do
           {
             id: Faker::Internet.unique.url,
             names: [{ types: ['ror_display'], value: Faker::Lorem.word }],
-            country: { country_name: Faker::Lorem.word },
+            locations: [
+              {
+                geonames_id: Faker::Number.number(digits: 6),
+                geonames_details: {
+                  country_name: Faker::Lorem.word,
+                  country_code: Faker::Lorem.characters(number: 2).upcase
+                }
+              }
+            ],
             external_ids: []
           }
         end
@@ -247,7 +287,15 @@ RSpec.describe ExternalApis::RorService do
           {
             id: Faker::Internet.unique.url,
             names: [{ types: ['ror_display'], value: Faker::Lorem.word }],
-            country: { country_name: Faker::Lorem.word },
+            locations: [
+              {
+                geonames_id: Faker::Number.number(digits: 6),
+                geonames_details: {
+                  country_name: Faker::Lorem.word,
+                  country_code: Faker::Lorem.characters(number: 2).upcase
+                }
+              }
+            ],
             external_ids: []
           }
         end
@@ -275,9 +323,20 @@ RSpec.describe ExternalApis::RorService do
       it 'ignores items with no name or id and logs an error' do
         Rails.logger.expects(:error).at_least(1)
 
+        location = {
+          geonames_id: Faker::Number.number(digits: 6),
+          geonames_details: {
+            country_name: 'Nowhere',
+            country_code: Faker::Lorem.characters(number: 2).upcase
+          }
+        }
+
         json = { items: [
-          { id: Faker::Internet.url, names: [{ types: ['ror_display'], value: Faker::Lorem.word }], external_ids: [] },
-          { names: [{ types: ['ror_display'], value: Faker::Lorem.word }], external_ids: [] }
+          { id: Faker::Internet.url,
+            names: [{ types: ['ror_display'], value: Faker::Lorem.word }, { value: 'EU', types: ['acronym'] }],
+            external_ids: [], locations: [location] }
+          { names: [{ types: ['ror_display'], value: Faker::Lorem.word }, { value: 'EU', types: ['acronym'] }],
+            external_ids: [], locations: [location] }
         ] }.to_json
 
         items = described_class.send(:parse_results, json: JSON.parse(json))
@@ -285,9 +344,21 @@ RSpec.describe ExternalApis::RorService do
       end
 
       it 'returns the correct number of results' do
+        location = {
+          geonames_id: Faker::Number.number(digits: 6),
+          geonames_details: {
+            country_name: 'Nowhere',
+            country_code: Faker::Lorem.characters(number: 2).upcase
+          }
+        }
+
         json = { items: [
-          { id: Faker::Internet.url, names: [{ types: ['ror_display'], value: Faker::Lorem.word }], external_ids: [] },
-          { id: Faker::Internet.url, names: [{ types: ['ror_display'], value: Faker::Lorem.word }], external_ids: [] }
+          { id: Faker::Internet.url,
+            names: [{ types: ['ror_display'], value: Faker::Lorem.word }, { value: 'EU', types: ['acronym'] }],
+            external_ids: [], locations: [location] },
+          { id: Faker::Internet.url,
+            names: [{ types: ['ror_display'], value: Faker::Lorem.word }, { value: 'EU', types: ['acronym'] }],
+            external_ids: [], locations: [location] }
         ] }.to_json
 
         items = described_class.send(:parse_results, json: JSON.parse(json))
@@ -300,7 +371,15 @@ RSpec.describe ExternalApis::RorService do
         json = {
           names: [{ types: ['ror_display'], value: 'Example College' }],
           links: [{ 'type' => 'website', 'value' => 'https://example.edu' }],
-          country: { country_name: 'Nowhere' }
+          locations: [
+            {
+              geonames_id: Faker::Number.number(digits: 6),
+              geonames_details: {
+                country_name: 'Nowhere',
+                country_code: Faker::Lorem.characters(number: 2).upcase
+              }
+            }
+          ]
         }.to_json
         expected = 'Example College (example.edu)'
         expect(described_class.send(:org_name, item: JSON.parse(json))).to eql(expected)
@@ -309,7 +388,15 @@ RSpec.describe ExternalApis::RorService do
       it 'properly appends the country if available and no website is available' do
         json = {
           names: [{ types: ['ror_display'], value: 'Example College' }],
-          country: { country_name: 'Nowhere' }
+          locations: [
+            {
+              geonames_id: Faker::Number.number(digits: 6),
+              geonames_details: {
+                country_name: 'Nowhere',
+                country_code: Faker::Lorem.characters(number: 2).upcase
+              }
+            }
+          ]
         }.to_json
         expected = 'Example College (Nowhere)'
         expect(described_class.send(:org_name, item: JSON.parse(json))).to eql(expected)
@@ -319,7 +406,15 @@ RSpec.describe ExternalApis::RorService do
         json = {
           names: [{ types: ['ror_display'], value: 'Example College' }],
           links: [],
-          country: {}
+          locations: [
+            {
+              geonames_id: Faker::Number.number(digits: 6),
+              geonames_details: {
+                country_name: '',
+                country_code: ''
+              }
+            }
+          ]
         }.to_json
         expected = 'Example College'
         expect(described_class.send(:org_name, item: JSON.parse(json))).to eql(expected)

--- a/spec/services/external_apis/ror_service_spec.rb
+++ b/spec/services/external_apis/ror_service_spec.rb
@@ -272,7 +272,9 @@ RSpec.describe ExternalApis::RorService do
         expect(described_class.send(:parse_results, json: nil)).to eql([])
       end
 
-      it 'ignores items with no name or id' do
+      it 'ignores items with no name or id and logs an error' do
+        Rails.logger.expects(:error).at_least(1)
+
         json = { items: [
           { id: Faker::Internet.url, names: [{ types: ['ror_display'], value: Faker::Lorem.word }], external_ids: [] },
           { names: [{ types: ['ror_display'], value: Faker::Lorem.word }], external_ids: [] }

--- a/spec/services/external_apis/ror_service_spec.rb
+++ b/spec/services/external_apis/ror_service_spec.rb
@@ -275,7 +275,6 @@ RSpec.describe ExternalApis::RorService do
       it 'ignores items with no name or id' do
         json = { items: [
           { id: Faker::Internet.url, names: [{ types: ['ror_display'], value: Faker::Lorem.word }], external_ids: [] },
-          { id: Faker::Internet.url, names: [], external_ids: [] },
           { names: [{ types: ['ror_display'], value: Faker::Lorem.word }], external_ids: [] }
         ] }.to_json
 

--- a/spec/services/external_apis/ror_service_spec.rb
+++ b/spec/services/external_apis/ror_service_spec.rb
@@ -72,13 +72,13 @@ RSpec.describe ExternalApis::RorService do
             {
               id: 'https://ror.org/1234567890',
               names: [
-                { value: 'Example University', types: ['ror_display'] }
+                { value: 'Example University', types: ['ror_display'] },
+                { value: 'EU', types: ['acronym'] }
               ],
               types: ['Education'],
               links: [
                 { type: 'website', value: 'http://example.edu/' }
               ],
-              acronyms: ['EU'],
               status: 'active',
               locations: [
                 {
@@ -95,11 +95,11 @@ RSpec.describe ExternalApis::RorService do
             }, {
               id: 'https://ror.org/0987654321',
               names: [
-                { value: 'Universidade de Example', types: ['ror_display'] }
+                { value: 'Universidade de Example', types: ['ror_display'] },
+                { value: 'EU', types: ['acronym'] }
               ],
               types: ['Education'],
               links: [],
-              acronyms: ['EU'],
               status: 'active',
               locations: [
                 {
@@ -145,7 +145,7 @@ RSpec.describe ExternalApis::RorService do
           time_taken: 5,
           items: [{
             id: Faker::Internet.url,
-            names: [{ types: ['ror_display'], value: Faker::Lorem.word }],
+            names: [{ types: ['ror_display'], value: Faker::Lorem.word }, { value: 'EU', types: ['acronym'] }],
             locations: [
               {
                 geonames_id: Faker::Number.number(digits: 6),
@@ -227,7 +227,7 @@ RSpec.describe ExternalApis::RorService do
         items = Array.new(4).map do
           {
             id: Faker::Internet.unique.url,
-            names: [{ types: ['ror_display'], value: Faker::Lorem.word }],
+            names: [{ types: ['ror_display'], value: Faker::Lorem.word }, { value: 'EU', types: ['acronym'] }],
             locations: [
               {
                 geonames_id: Faker::Number.number(digits: 6),
@@ -255,7 +255,7 @@ RSpec.describe ExternalApis::RorService do
         items = Array.new(7).map do
           {
             id: Faker::Internet.unique.url,
-            names: [{ types: ['ror_display'], value: Faker::Lorem.word }],
+            names: [{ types: ['ror_display'], value: Faker::Lorem.word }, { value: 'EU', types: ['acronym'] }],
             locations: [
               {
                 geonames_id: Faker::Number.number(digits: 6),
@@ -286,7 +286,7 @@ RSpec.describe ExternalApis::RorService do
         items = Array.new(12).map do
           {
             id: Faker::Internet.unique.url,
-            names: [{ types: ['ror_display'], value: Faker::Lorem.word }],
+            names: [{ types: ['ror_display'], value: Faker::Lorem.word }, { value: 'EU', types: ['acronym'] }],
             locations: [
               {
                 geonames_id: Faker::Number.number(digits: 6),
@@ -334,7 +334,7 @@ RSpec.describe ExternalApis::RorService do
         json = { items: [
           { id: Faker::Internet.url,
             names: [{ types: ['ror_display'], value: Faker::Lorem.word }, { value: 'EU', types: ['acronym'] }],
-            external_ids: [], locations: [location] }
+            external_ids: [], locations: [location] },
           { names: [{ types: ['ror_display'], value: Faker::Lorem.word }, { value: 'EU', types: ['acronym'] }],
             external_ids: [], locations: [location] }
         ] }.to_json
@@ -369,7 +369,7 @@ RSpec.describe ExternalApis::RorService do
     describe '#org_name' do
       it 'properly appends the website if available' do
         json = {
-          names: [{ types: ['ror_display'], value: 'Example College' }],
+          names: [{ types: ['ror_display'], value: 'Example College' }, { value: 'EU', types: ['acronym'] }],
           links: [{ 'type' => 'website', 'value' => 'https://example.edu' }],
           locations: [
             {
@@ -387,7 +387,7 @@ RSpec.describe ExternalApis::RorService do
 
       it 'properly appends the country if available and no website is available' do
         json = {
-          names: [{ types: ['ror_display'], value: 'Example College' }],
+          names: [{ types: ['ror_display'], value: 'Example College' }, { value: 'EU', types: ['acronym'] }],
           locations: [
             {
               geonames_id: Faker::Number.number(digits: 6),
@@ -404,7 +404,7 @@ RSpec.describe ExternalApis::RorService do
 
       it 'properly handles an item with no website or country' do
         json = {
-          names: [{ types: ['ror_display'], value: 'Example College' }],
+          names: [{ types: ['ror_display'], value: 'Example College' }, { value: 'EU', types: ['acronym'] }],
           links: [],
           locations: [
             {

--- a/spec/services/external_apis/ror_service_spec.rb
+++ b/spec/services/external_apis/ror_service_spec.rb
@@ -293,29 +293,32 @@ RSpec.describe ExternalApis::RorService do
 
     describe '#org_name' do
       it 'returns nil if there is no name' do
-        json = { country: { country_name: 'Nowhere' } }.to_json
+        json = { country: { country_name: 'Nowhere' }, names: [] }.to_json
         expect(described_class.send(:org_name, item: JSON.parse(json))).to eql('')
       end
+
       it 'properly appends the website if available' do
         json = {
-          name: 'Example College',
-          links: ['https://example.edu'],
+          names: [{ types: ['ror_display'], value: 'Example College' }],
+          links: [{ 'type' => 'website', 'value' => 'https://example.edu' }],
           country: { country_name: 'Nowhere' }
         }.to_json
         expected = 'Example College (example.edu)'
         expect(described_class.send(:org_name, item: JSON.parse(json))).to eql(expected)
       end
+
       it 'properly appends the country if available and no website is available' do
         json = {
-          name: 'Example College',
+          names: [{ types: ['ror_display'], value: 'Example College' }],
           country: { country_name: 'Nowhere' }
         }.to_json
         expected = 'Example College (Nowhere)'
         expect(described_class.send(:org_name, item: JSON.parse(json))).to eql(expected)
       end
+
       it 'properly handles an item with no website or country' do
         json = {
-          name: 'Example College',
+          names: [{ types: ['ror_display'], value: 'Example College' }],
           links: [],
           country: {}
         }.to_json
@@ -329,15 +332,18 @@ RSpec.describe ExternalApis::RorService do
         item = JSON.parse({ links: nil }.to_json)
         expect(described_class.send(:org_website, item: item)).to eql(nil)
       end
+
       it 'returns nil if the item is nil' do
         expect(described_class.send(:org_website, item: nil)).to eql(nil)
       end
+
       it 'returns the domain only' do
-        item = JSON.parse({ links: ['https://example.org/path?a=b'] }.to_json)
+        item = JSON.parse({ links: [{ 'type' => 'website', 'value' => 'https://example.org/path?a=b' }] }.to_json)
         expect(described_class.send(:org_website, item: item)).to eql('example.org')
       end
+
       it 'removes the www prefix' do
-        item = JSON.parse({ links: ['www.example.org'] }.to_json)
+        item = JSON.parse({ links: [{ 'type' => 'website', 'value' => 'www.example.org' }] }.to_json)
         expect(described_class.send(:org_website, item: item)).to eql('example.org')
       end
     end
@@ -346,22 +352,32 @@ RSpec.describe ExternalApis::RorService do
       before(:each) do
         @hash = { external_ids: {} }
       end
+
       it 'returns a blank if no external_ids are present' do
         json = JSON.parse(@hash.to_json)
         expect(described_class.send(:fundref_id, item: json)).to eql('')
       end
+
       it 'returns a blank if no FundRef ids are present' do
-        @hash['external_ids'] = { FundRef: {} }
+        @hash['external_ids'] = [
+          { 'type' => 'fundref', 'preferred' => '' }
+        ]
         json = JSON.parse(@hash.to_json)
         expect(described_class.send(:fundref_id, item: json)).to eql('')
       end
+
       it 'returns the preferred id when specified' do
-        @hash['external_ids'] = { FundRef: { preferred: '1', all: %w[2 1] } }
+        @hash['external_ids'] = [
+          { 'type' => 'FundRef', 'preferred' => '1', 'all' => %w[2 1] }
+        ]
         json = JSON.parse(@hash.to_json)
         expect(described_class.send(:fundref_id, item: json)).to eql('1')
       end
-      it 'returns the firstid if no preferred is specified' do
-        @hash['external_ids'] = { FundRef: { preferred: nil, all: %w[2 1] } }
+
+      it 'returns the first id if no preferred is specified' do
+        @hash['external_ids'] = [
+          { 'type' => 'FundRef', 'preferred' => nil, 'all' => %w[2 1] }
+        ]
         json = JSON.parse(@hash.to_json)
         expect(described_class.send(:fundref_id, item: json)).to eql('2')
       end

--- a/spec/services/external_apis/ror_service_spec.rb
+++ b/spec/services/external_apis/ror_service_spec.rb
@@ -71,28 +71,32 @@ RSpec.describe ExternalApis::RorService do
           items: [
             {
               id: 'https://ror.org/1234567890',
-              name: 'Example University',
+              names: [
+                { value: 'Example University', types: ['ror_display'] }
+              ],
               types: ['Education'],
-              links: ['http://example.edu/'],
-              aliases: ['Example'],
+              links: [
+                { type: 'website', value: 'http://example.edu/' }
+              ],
               acronyms: ['EU'],
               status: 'active',
               country: { country_name: 'United States', country_code: 'US' },
-              external_ids: {
-                GRID: { preferred: 'grid.12345.1', all: 'grid.12345.1' }
-              }
+              external_ids: [
+                { type: 'grid', preferred: 'grid.12345.1', all: ['grid.12345.1'] }
+              ]
             }, {
               id: 'https://ror.org/0987654321',
-              name: 'Universidade de Example',
+              names: [
+                { value: 'Universidade de Example', types: ['ror_display'] }
+              ],
               types: ['Education'],
               links: [],
-              aliases: ['Example'],
               acronyms: ['EU'],
               status: 'active',
               country: { country_name: 'Mexico', country_code: 'MX' },
-              external_ids: {
-                GRID: { preferred: 'grid.98765.8', all: 'grid.98765.8' }
-              }
+              external_ids: [
+                { type: 'FundRef', preferred: 'fundref.12345', all: ['fundref.12345'] }
+              ]
             }
           ]
         }
@@ -108,19 +112,11 @@ RSpec.describe ExternalApis::RorService do
       end
 
       it 'includes the website in the name (if available)' do
-        expected = {
-          id: 'https://ror.org/1234567890',
-          name: 'Example University (example.edu)'
-        }
-        expect(@orgs.map { |i| i[:name] }.include?(expected[:name])).to eql(true)
+        expect(@orgs.map { |i| i[:name] }).to include('Example University (example.edu)')
       end
 
       it 'includes the country in the name (if no website is available)' do
-        expected = {
-          id: 'https://ror.org/0987654321',
-          name: 'Universidade de Example (Mexico)'
-        }
-        expect(@orgs.map { |i| i[:name] }.include?(expected[:name])).to eql(true)
+        expect(@orgs.map { |i| i[:name] }).to include('Universidade de Example (Mexico)')
       end
     end
   end

--- a/spec/services/external_apis/ror_service_spec.rb
+++ b/spec/services/external_apis/ror_service_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe ExternalApis::RorService do
           time_taken: 5,
           items: [{
             id: Faker::Internet.url,
-            name: Faker::Lorem.word,
+            names: [{ types: ['ror_display'], value: Faker::Lorem.word }],
             country: { country_name: Faker::Lorem.word }
           }]
         }
@@ -203,7 +203,7 @@ RSpec.describe ExternalApis::RorService do
         items = Array.new(4).map do
           {
             id: Faker::Internet.unique.url,
-            name: Faker::Lorem.word,
+            names: [{ types: ['ror_display'], value: Faker::Lorem.word }],
             country: { country_name: Faker::Lorem.word }
           }
         end
@@ -222,7 +222,7 @@ RSpec.describe ExternalApis::RorService do
         items = Array.new(7).map do
           {
             id: Faker::Internet.unique.url,
-            name: Faker::Lorem.word,
+            names: [{ types: ['ror_display'], value: Faker::Lorem.word }],
             country: { country_name: Faker::Lorem.word }
           }
         end
@@ -244,7 +244,7 @@ RSpec.describe ExternalApis::RorService do
         items = Array.new(12).map do
           {
             id: Faker::Internet.unique.url,
-            name: Faker::Lorem.word,
+            names: [{ types: ['ror_display'], value: Faker::Lorem.word }],
             country: { country_name: Faker::Lorem.word }
           }
         end
@@ -268,20 +268,24 @@ RSpec.describe ExternalApis::RorService do
       it 'returns an empty array if there are no items' do
         expect(described_class.send(:parse_results, json: nil)).to eql([])
       end
+
       it 'ignores items with no name or id' do
         json = { items: [
-          { id: Faker::Internet.url, name: Faker::Lorem.word },
-          { id: Faker::Internet.url },
-          { name: Faker::Lorem.word }
+          { id: Faker::Internet.url, names: [{ types: ['ror_display'], value: Faker::Lorem.word }] },
+          { id: Faker::Internet.url, names: [] },
+          { names: [{ types: ['ror_display'], value: Faker::Lorem.word }] }
         ] }.to_json
+
         items = described_class.send(:parse_results, json: JSON.parse(json))
         expect(items.length).to eql(1)
       end
+
       it 'returns the correct number of results' do
         json = { items: [
-          { id: Faker::Internet.url, name: Faker::Lorem.word },
-          { id: Faker::Internet.url, name: Faker::Lorem.word }
+          { id: Faker::Internet.url, names: [{ types: ['ror_display'], value: Faker::Lorem.word }] },
+          { id: Faker::Internet.url, names: [{ types: ['ror_display'], value: Faker::Lorem.word }] }
         ] }.to_json
+
         items = described_class.send(:parse_results, json: JSON.parse(json))
         expect(items.length).to eql(2)
       end

--- a/spec/services/external_apis/ror_service_spec.rb
+++ b/spec/services/external_apis/ror_service_spec.rb
@@ -295,11 +295,6 @@ RSpec.describe ExternalApis::RorService do
     end
 
     describe '#org_name' do
-      it 'returns nil if there is no name' do
-        json = { country: { country_name: 'Nowhere' }, names: [] }.to_json
-        expect(described_class.send(:org_name, item: JSON.parse(json))).to eql('')
-      end
-
       it 'properly appends the website if available' do
         json = {
           names: [{ types: ['ror_display'], value: 'Example College' }],
@@ -334,10 +329,6 @@ RSpec.describe ExternalApis::RorService do
       it "returns nil if no 'links' are in the json" do
         item = JSON.parse({ links: nil }.to_json)
         expect(described_class.send(:org_website, item: item)).to eql(nil)
-      end
-
-      it 'returns nil if the item is nil' do
-        expect(described_class.send(:org_website, item: nil)).to eql(nil)
       end
 
       it 'returns the domain only' do

--- a/spec/services/external_apis/ror_service_spec.rb
+++ b/spec/services/external_apis/ror_service_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe ExternalApis::RorService do
               status: 'active',
               country: { country_name: 'Mexico', country_code: 'MX' },
               external_ids: [
-                { type: 'FundRef', preferred: 'fundref.12345', all: ['fundref.12345'] }
+                { type: 'fundref', preferred: 'fundref.12345', all: ['fundref.12345'] }
               ]
             }
           ]
@@ -204,7 +204,8 @@ RSpec.describe ExternalApis::RorService do
           {
             id: Faker::Internet.unique.url,
             names: [{ types: ['ror_display'], value: Faker::Lorem.word }],
-            country: { country_name: Faker::Lorem.word }
+            country: { country_name: Faker::Lorem.word },
+            external_ids: []
           }
         end
         results1 = { number_of_results: 4, items: items }
@@ -223,7 +224,8 @@ RSpec.describe ExternalApis::RorService do
           {
             id: Faker::Internet.unique.url,
             names: [{ types: ['ror_display'], value: Faker::Lorem.word }],
-            country: { country_name: Faker::Lorem.word }
+            country: { country_name: Faker::Lorem.word },
+            external_ids: []
           }
         end
         results1 = { number_of_results: 7, items: items[0..4] }
@@ -245,7 +247,8 @@ RSpec.describe ExternalApis::RorService do
           {
             id: Faker::Internet.unique.url,
             names: [{ types: ['ror_display'], value: Faker::Lorem.word }],
-            country: { country_name: Faker::Lorem.word }
+            country: { country_name: Faker::Lorem.word },
+            external_ids: []
           }
         end
         results1 = { number_of_results: 12, items: items[0..4] }
@@ -271,9 +274,9 @@ RSpec.describe ExternalApis::RorService do
 
       it 'ignores items with no name or id' do
         json = { items: [
-          { id: Faker::Internet.url, names: [{ types: ['ror_display'], value: Faker::Lorem.word }] },
-          { id: Faker::Internet.url, names: [] },
-          { names: [{ types: ['ror_display'], value: Faker::Lorem.word }] }
+          { id: Faker::Internet.url, names: [{ types: ['ror_display'], value: Faker::Lorem.word }], external_ids: [] },
+          { id: Faker::Internet.url, names: [], external_ids: [] },
+          { names: [{ types: ['ror_display'], value: Faker::Lorem.word }], external_ids: [] }
         ] }.to_json
 
         items = described_class.send(:parse_results, json: JSON.parse(json))
@@ -282,8 +285,8 @@ RSpec.describe ExternalApis::RorService do
 
       it 'returns the correct number of results' do
         json = { items: [
-          { id: Faker::Internet.url, names: [{ types: ['ror_display'], value: Faker::Lorem.word }] },
-          { id: Faker::Internet.url, names: [{ types: ['ror_display'], value: Faker::Lorem.word }] }
+          { id: Faker::Internet.url, names: [{ types: ['ror_display'], value: Faker::Lorem.word }], external_ids: [] },
+          { id: Faker::Internet.url, names: [{ types: ['ror_display'], value: Faker::Lorem.word }], external_ids: [] }
         ] }.to_json
 
         items = described_class.send(:parse_results, json: JSON.parse(json))
@@ -368,7 +371,7 @@ RSpec.describe ExternalApis::RorService do
 
       it 'returns the preferred id when specified' do
         @hash['external_ids'] = [
-          { 'type' => 'FundRef', 'preferred' => '1', 'all' => %w[2 1] }
+          { 'type' => 'fundref', 'preferred' => '1', 'all' => %w[2 1] }
         ]
         json = JSON.parse(@hash.to_json)
         expect(described_class.send(:fundref_id, item: json)).to eql('1')
@@ -376,7 +379,7 @@ RSpec.describe ExternalApis::RorService do
 
       it 'returns the first id if no preferred is specified' do
         @hash['external_ids'] = [
-          { 'type' => 'FundRef', 'preferred' => nil, 'all' => %w[2 1] }
+          { 'type' => 'fundref', 'preferred' => nil, 'all' => %w[2 1] }
         ]
         json = JSON.parse(@hash.to_json)
         expect(described_class.send(:fundref_id, item: json)).to eql('2')


### PR DESCRIPTION
Fixes [#3588](https://github.com/DMPRoadmap/roadmap/issues/3588).

Changes proposed in this PR:
- Update `ror_service.rb` and `ror_service_spec.rb` to work with V2 of the ROR API as V1 has been officially deprecated.
- The full list of changes from V1 to V2 can be found [here](https://ror.readme.io/docs/schema-v2#/). The main changes that affect DMP Assistant are the changes in how names, languages, websites, locations, acronyms, and external IDs are handled in the schema.