### PR TITLE
Implement tiered Rack::Attack throttles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
  - Add rake task to clean up unmanaged orgs w/ users [#1250](https://github.com/portagenetwork/roadmap/pull/1250)
 
+ - Implement tiered Rack::Attack throttles [#1254](https://github.com/portagenetwork/roadmap/pull/1254)
+
 ### Changed
  - Upgrade ROR API From V1 to V2 [#1247](https://github.com/portagenetwork/roadmap/pull/1247)
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -2,25 +2,40 @@
 
 # NB: `req` is a Rack::Request object (basically an env hash with friendly accessor methods)
 
+# Progressive login throttling by IP.
+# - Each throttle has its own counter and time window.
+# - All matching throttles increment on every request.
+# - A request is blocked if any throttle exceeds its limit.
+LEVELS = [
+  ['lowest', 5, 3.minutes],
+  ['low', 10, 15.minutes],
+  ['medium', 20, 2.hours],
+  ['high', 50, 10.hours],
+  ['highest', 100, 72.hours]
+].freeze
+
+# All paths that we will apply throttling to
+PATHS = ['/users/sign_in', '/users/password'].freeze
+
 # Enable/disable Rack::Attack
 Rack::Attack.enabled = true
 
 # Cache store required to work.
 Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new # defaults to Rails.cache
 
-# Throttle should send a 429 Error responsec code and display public/429.html
+# Throttle should send a 429 Error response code and display public/429.html
 Rack::Attack.throttled_responder = lambda do |_env|
   html = ActionView::Base.empty.render(file: 'public/429.html')
   [429, { 'Content-Type' => 'text/html' }, [html]]
 end
 
-# Throttle attempts to a particular path. 2 POSTs to /users/password every 30 seconds
-Rack::Attack.throttle "password_resets/ip", limit: 2, period: 30.seconds do |req|
-  req.post? && req.path == "/users/password" && req.ip
-end
-
-# Throttle attempts to a particular path. 4 POSTs to /users/sign_in every 30 seconds
-Rack::Attack.throttle "logins/ip", limit: 4, period: 30.seconds do |req|
-  # Don't apply sign-in rate-limiting to test environment
-  req.post? && req.path == "/users/sign_in" && req.ip unless Rails.env.test?
+unless Rails.env.test?
+  # Create a throttle for each (path, level) pairing
+  PATHS.each do |path|
+    LEVELS.each do |name, limit, period|
+      Rack::Attack.throttle("#{path} #{name}", limit: limit, period: period) do |req|
+        req.post? && req.path == path && req.ip
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Changes proposed in this PR:
Added logic to apply progressively aggressive Rack::Attack throttles by creating a separate throttle for each (path × level) combination.

- PATHS defines all authentication endpoints subject to throttling
- LEVELS defines the throttle name, limit, and period for each tier
- Each throttle has its own counter and period
- All matching throttles increment on every request
- A request is blocked if any throttle exceeds its limit

NOTE: With `Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new`, counts reset on server restart and aren’t shared across Puma workers. Use Redis for consistent throttling across processes.
