### PR TITLE
Ignore CSRF exceptions in Rollbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@
  - Implement tiered Rack::Attack throttles [#1254](https://github.com/portagenetwork/roadmap/pull/1254)
 
 ### Changed
+
  - Upgrade ROR API From V1 to V2 [#1247](https://github.com/portagenetwork/roadmap/pull/1247)
+
+ - Ignore CSRF exceptions in Rollbar [#1256](https://github.com/portagenetwork/roadmap/pull/1256)
 
 ### Dependency Updates
 

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -47,7 +47,10 @@ if defined?(Rollbar)
     # via the rollbar interface.
     # Valid levels: 'critical', 'error', 'warning', 'info', 'debug', 'ignore'
     # 'ignore' will cause the exception to not be reported at all.
-    # config.exception_level_filters.merge!('MyCriticalException' => 'critical')
+
+    # protect_from_forgery with: :exception is enabled in app/controllers/application_controller.rb.
+    # Due to this configuration, bots can generate a lot of Rollbar noise.
+    config.exception_level_filters['ActionController::InvalidAuthenticityToken'] = 'ignore'
     #
     # You can also specify a callable, which will be called with the exception instance.
     # config.exception_level_filters.merge!('MyCriticalException' => lambda { |e| 'critical' })


### PR DESCRIPTION
# Changes proposed in this PR:

To enforce CSRF protection, Rails uses `protect_from_forgery with: :exception` in `app/controllers/application_controller.rb`. This raises `ActionController::InvalidAuthenticityToken` errors for requests without a valid CSRF token.

Due to this configuration, bots can generate a lot of Rollbar noise. This commit configures Rollbar to ignore these exceptions entirely, reducing noise, while retaining CSRF protection within the app.