### PR TITLE
Add org cleanup Rake tasks and shared Orgs::AssociationInspector

### DIFF
--- a/app/services/orgs/association_inspector.rb
+++ b/app/services/orgs/association_inspector.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Orgs
+  # Provides helper methods for inspecting and querying Org associations.
+  # Mainly used to find "orphan" orgs and handle special cases,
+  # such as funded plans and polymorphic identifiers.
+  module AssociationInspector
+    # Associations we expect to pass to `where.missing()`
+    EXPECTED_ASSOCIATIONS = %i[tracker guidance_groups plans templates users contributors annotations
+                               departments].freeze
+    HAS_MANY_OR_ONE = %i[has_many has_one].freeze
+    EXCLUDED_ASSOCIATIONS = %i[identifiers funded_plans].freeze
+
+    extend self
+
+    # Returns "true" orphan orgs when `allow_funded_plans_association == false`.
+    # If `allow_funded_plans_association` is true, funded_plans are ignored,
+    # allowing custom queries for orgs that only have funded_plans associations
+    # (e.g., used in `CleanupJunkFundersService`).
+    def orphan_orgs(allow_funded_plans_association: false)
+      base = Org.where.missing(*org_associations)
+                # identifiers is a polymorphic association (identifiable_type + identifiable_id),
+                # so we cannot use `where.missing(:identifiers)`.
+                # Join manually and filter by `identifiable_type = 'Org'`.
+                .joins("LEFT JOIN identifiers i ON i.identifiable_type = 'Org' AND i.identifiable_id = orgs.id")
+                .where('i.id IS NULL')
+      return base if allow_funded_plans_association
+
+      # funded_plans uses a non-standard foreign key (`funder_id`),
+      # so we cannot use `where.missing(:funded_plans)`.
+      # Alias the join as `funded_plans` to avoid colliding with the regular plans join.
+      base.joins('LEFT JOIN plans funded_plans ON funded_plans.funder_id = orgs.id')
+          .where('funded_plans.id IS NULL')
+    end
+
+    private
+
+    # Associations safe for use with `Org.where.missing()` query
+    def org_associations
+      associations = Org.reflect_on_all_associations
+                        .select { |r| HAS_MANY_OR_ONE.include?(r.macro) }
+                        # Exclude associations that cannot be properly handled via `where.missing`:
+                        # - identifiers: polymorphic (requires identifiable_type = 'Org' and identifiable_id = orgs.id))
+                        # - funded_plans: uses funder_id instead of org_id
+                        .reject { |r| EXCLUDED_ASSOCIATIONS.include?(r.name) }
+                        .map(&:name)
+                        .sort
+      verify_expected_associations!(associations)
+      associations
+    end
+
+    # Raises if the actual associations differ from EXPECTED_ASSOCIATIONS.
+    # - Guards against future changes (added or removed associations) that could
+    #   affect the `where.missing` query for orphaned orgs.
+    def verify_expected_associations!(actual)
+      expected = EXPECTED_ASSOCIATIONS.sort
+      return if actual == expected
+
+      raise <<~MSG
+        Orgs::AssociationInspector detected an association mismatch.
+        Expected: #{expected.inspect}
+        Actual:   #{actual.inspect}
+      MSG
+    end
+  end
+end

--- a/app/services/orgs/cleanup_junk_funders_service.rb
+++ b/app/services/orgs/cleanup_junk_funders_service.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Orgs
+  # Invoked by the `orgs:cleanup_junk_funders` rake task.
+  # Finds "junk funders" and sets `plan.funder_id = nil` for their associated plans.
+  # - Junk funders are orgs meeting the following criteria:
+  #   1) Have `org.id == plan.funder_id` as their only association
+  #   2) Have a "junk" name (see JUNK_FUNDER_NAMES)'
+  module CleanupJunkFundersService
+    JUNK_FUNDER_NAMES = [
+      '-', '1010-A', '123', '12345', '<Who is funding this project?>', 'All lab funding',
+      'Anonymous foundation', 'Benny', 'Big Money Co.', 'Bill Gates', 'Bruce "Not Batman"Wayne',
+      'Deep Pockets', 'District funded', 'Elon Musk', 'Elon Musk hopefully', 'Funded', 'Funder',
+      'Funder 1', 'Funding Agency #1', 'Funding Organization', 'Grant', 'I highly doubt that',
+      'Idk', 'Info not provided', 'Internal', 'Internal Funding', 'Jeff Bezos', 'Jesus',
+      'Joe Biden', 'John Doe', 'Juniper (cat)', 'Karin', 'Lawsuit', 'LoL project - NASA',
+      'Many...', 'Marcus Closen of the DRAC', 'Me', 'Me, myself and I', 'Michelle Obama', 'Mock',
+      'Mock Funder', 'Mr. Funder Man', 'Multiple sources', 'Myself', 'N', 'N.A.', 'N/', 'N/A',
+      'N/a', 'NA', 'Nancy', 'Nerisa D', 'No Funder', 'No funder', 'No funding', 'No funding.',
+      "No one :'(", 'No one in particular', 'None required', 'Not applicable',
+      'Not applicable at present', 'Not funded', 'Not sure', 'Partner', 'Pending', 'Personal',
+      'Personally', 'Portage with spaces Network', 'Private', 'Self', 'Self Funded',
+      'Self and potential scholarship', 'Self-Funded', 'Self-funded', 'Show Me the Green', 'Sure',
+      'TBA', 'TBD', 'Test', 'The Bank', 'This funder has spaces', 'To be defined', 'Uknown',
+      'Unfunded', 'Unsure', 'Various', 'Zeus', 'abcdef', 'agri', 'aqua chiara', 'asdaddsa',
+      'aucun', 'aucuns', 'christian', 'confidential', 'efwewef', 'fgd', 'financement interne',
+      'free funder', 'funder name', 'funder-name', 'funding number needed', 'hi',
+      'is this organization', 'ma big fat wallet', 'me', 'moi meme', 'mr donator',
+      'myself', 'n/a', 'nil', 'no fund', 'non identified', 'none', 'pev', 'self-funded', 'test',
+      'test funder today', 'unfunded', 'vbp', 'vxzvxvc', 'x', 'xxx'
+    ].freeze
+
+    extend self
+
+    def run(dry_run: false)
+      junk_funder_ids = fetch_junk_funder_ids
+      associated_plans = Plan.where(funder_id: junk_funder_ids)
+
+      puts "Found #{junk_funder_ids.size} junk funder orgs and #{associated_plans.size} associated plans."
+
+      return if dry_run
+
+      updated_count = associated_plans.update_all(funder_id: nil)
+      puts "Updated #{updated_count} of the associated plans to `plan.funder_id = nil`."
+    end
+
+    private
+
+    def fetch_junk_funder_ids
+      # `base` is the base query for orphan orgs with the funded_plans query omitted.
+      base = Orgs::AssociationInspector.orphan_orgs(allow_funded_plans_association: true)
+      # Rather than true orphans, we want orgs that only have the plans.funder association
+      # Of those orgs, we only want the ones whose names are included in JUNK_FUNDER_NAMES
+      base.joins('INNER JOIN plans funded_plans ON funded_plans.funder_id = orgs.id')
+          .where(name: JUNK_FUNDER_NAMES)
+          .distinct
+          .pluck(:id)
+    end
+  end
+end

--- a/app/services/orgs/cleanup_unmanaged_orgs_with_users_service.rb
+++ b/app/services/orgs/cleanup_unmanaged_orgs_with_users_service.rb
@@ -5,7 +5,7 @@ module Orgs
   # Cleanup service for unmanaged orgs having 1 or more users.
   # For each such org:
   # - Reassign associated users and plans to the "default org"
-  # - Attempt deletion of the org
+  # NOTE: Org deletion is handled separately by the `delete_orphan_orgs` task
   module CleanupUnmanagedOrgsWithUsersService
     extend self
 
@@ -13,8 +13,6 @@ module Orgs
       :processed_orgs_count,
       :reassigned_users_count,
       :reassigned_plans_count,
-      :deleted_orgs_count,
-      :failed_deletions_count,
       keyword_init: true
     )
 
@@ -29,8 +27,6 @@ module Orgs
           reassign_users_to_default_org(org, default_org, result)
           reassign_plans_to_default_org(org, default_org, result)
         end
-        # Don't rollback org.users + org.plans reassignment if the org cannot be deleted
-        handle_org_deletion(org, result)
       end
 
       print_summary(result)
@@ -42,9 +38,7 @@ module Orgs
       Result.new(
         processed_orgs_count: 0,
         reassigned_users_count: 0,
-        reassigned_plans_count: 0,
-        deleted_orgs_count: 0,
-        failed_deletions_count: 0
+        reassigned_plans_count: 0
       )
     end
 
@@ -74,35 +68,12 @@ module Orgs
       puts "✅ Reassigned #{reassigned_count} plan(s) from '#{org.name}'."
     end
 
-    def handle_org_deletion(org, result)
-      if org.destroy
-        increment_successful_org_deletions(org, result)
-      else
-        msg = org.errors.full_messages.presence || ["Unknown deletion error (org inspect: #{org.inspect})"]
-        increment_failed_org_deletions(org, result, msg)
-      end
-    rescue StandardError => e
-      increment_failed_org_deletions(org, result, ["Exception: #{e.message}"])
-    end
-
-    def increment_successful_org_deletions(org, result)
-      result.deleted_orgs_count += 1
-      puts "✅ Deleted unmanaged org: #{org.id} - #{org.name}"
-    end
-
-    def increment_failed_org_deletions(org, result, messages)
-      result.failed_deletions_count += 1
-      puts "⚠️ Failed to delete unmanaged org: #{org.id} - #{org.name}: #{messages.join(', ')}"
-    end
-
     def print_summary(result)
       puts <<~MSG
         ----- Summary -----
         Unmanaged orgs processed: #{result.processed_orgs_count}
         Users reassigned: #{result.reassigned_users_count}
         Plans reassigned: #{result.reassigned_plans_count}
-        Successfully deleted orgs: #{result.deleted_orgs_count}
-        Failed org deletions: #{result.failed_deletions_count}
       MSG
     end
   end

--- a/app/services/orgs/cleanup_unmanaged_orgs_with_users_service.rb
+++ b/app/services/orgs/cleanup_unmanaged_orgs_with_users_service.rb
@@ -16,12 +16,18 @@ module Orgs
       keyword_init: true
     )
 
-    def run
+    def run(dry_run: false)
       result = initial_result
 
       default_org = fetch_default_org
+      orgs_to_process = unmanaged_orgs_with_users
 
-      unmanaged_orgs_with_users.find_each do |org|
+      if dry_run
+        handle_dry_run(orgs: orgs_to_process, result: result)
+        return
+      end
+
+      orgs_to_process.find_each do |org|
         result.processed_orgs_count += 1
         Org.transaction do
           reassign_users_to_default_org(org, default_org, result)
@@ -68,12 +74,33 @@ module Orgs
       puts "✅ Reassigned #{reassigned_count} plan(s) from '#{org.name}'."
     end
 
+    def handle_dry_run(orgs:, result:)
+      handle_dry_run_result(orgs: orgs, result: result)
+      print_dry_run_summary(result)
+    end
+
+    def handle_dry_run_result(orgs:, result:)
+      org_ids = orgs.pluck(:id)
+      result.processed_orgs_count = org_ids.size
+      result.reassigned_users_count = User.where(org_id: org_ids).count
+      result.reassigned_plans_count = Plan.where(org_id: org_ids).count
+    end
+
+    def print_dry_run_summary(result)
+      puts <<~MSG
+        ----- DRY RUN Summary -----
+        Unmanaged orgs with users:  #{result.processed_orgs_count}
+        Users to be reassigned:     #{result.reassigned_users_count}
+        Plans to be reassigned:     #{result.reassigned_plans_count}
+      MSG
+    end
+
     def print_summary(result)
       puts <<~MSG
         ----- Summary -----
         Unmanaged orgs processed: #{result.processed_orgs_count}
-        Users reassigned: #{result.reassigned_users_count}
-        Plans reassigned: #{result.reassigned_plans_count}
+        Users reassigned:         #{result.reassigned_users_count}
+        Plans reassigned:         #{result.reassigned_plans_count}
       MSG
     end
   end

--- a/app/services/orgs/delete_junk_trackers_service.rb
+++ b/app/services/orgs/delete_junk_trackers_service.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Orgs
+  # Invoked by the `orgs:delete_junk_trackers` Rake task.
+  # This service deletes all "junk" trackers (i.e. `Tracker.where(code: '')`)
+  # Partly addresses https://github.com/portagenetwork/roadmap/issues/1260
+  module DeleteJunkTrackersService
+    module_function
+
+    def run
+      junk_trackers = Tracker.where(code: '')
+      puts "Found #{junk_trackers.count} junk trackers ( i.e. `Tracker.where(code: '')` )"
+      destroy_result = junk_trackers.destroy_all
+      puts "Deleted #{destroy_result.count} of these junk trackers."
+    end
+  end
+end

--- a/app/services/orgs/delete_orphan_orgs_service.rb
+++ b/app/services/orgs/delete_orphan_orgs_service.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Orgs
+  # Invoked by the `orgs:delete_orphan_orgs` rake task.
+  # Deletes all orphan orgs from the db
+  module DeleteOrphanOrgsService
+    require 'csv'
+
+    DRY_RUN_CSV = Rails.root.join('tmp', 'orphan_orgs.csv')
+    DELETED_CSV = Rails.root.join('tmp', 'deleted_orphan_orgs.csv')
+
+    extend self
+
+    def run(dry_run: false)
+      orphan_orgs = Orgs::AssociationInspector.orphan_orgs
+
+      puts "Found #{orphan_orgs.size} orphan orgs"
+
+      if dry_run
+        write_dry_run_to_csv(orphan_orgs)
+      else
+        results = handle_deletion_of_orgs(orphan_orgs)
+        write_deleted_to_csv(results)
+      end
+    end
+
+    private
+
+    def handle_deletion_of_orgs(orgs)
+      results = []
+
+      orgs.find_each do |org|
+        org.destroy!
+        results << { id: org.id, name: org.name, deletion_outcome: 'success' }
+      rescue ActiveRecord::RecordNotDestroyed => e
+        results << { id: org.id, name: org.name, deletion_outcome: 'failure', error: e.message }
+        puts "Failed to destroy Org #{org.id}: #{e.message}"
+      end
+
+      results
+    end
+
+    def write_dry_run_to_csv(orgs)
+      CSV.open(DRY_RUN_CSV, 'w') do |csv|
+        csv << %w[id name]
+        orgs.find_each do |org|
+          csv << [org.id, org.name]
+        end
+      end
+      puts "CSV written to #{DRY_RUN_CSV}"
+    end
+
+    def write_deleted_to_csv(results)
+      CSV.open(DELETED_CSV, 'w') do |csv|
+        csv << %w[id name deletion_outcome error]
+        results.each do |row|
+          csv << [row[:id], row[:name], row[:deletion_outcome], row[:error]]
+        end
+      end
+      puts "CSV written to #{DELETED_CSV}"
+    end
+  end
+end

--- a/lib/tasks/orgs.rake
+++ b/lib/tasks/orgs.rake
@@ -10,6 +10,10 @@ namespace :orgs do
         For each such org:
         - Reassign associated users and plans to the "default org"'
   task cleanup_unmanaged_orgs_with_users: :environment do
-    Orgs::CleanupUnmanagedOrgsWithUsersService.run
+    # Passing `DRY_RUN=true` bypasses db updates,
+    # and simply updates how many unmanaged_orgs with users were found
+    # as well as how many users and plans will be reassigned to the default org.
+    dry_run = ENV['DRY_RUN'] == 'true'
+    Orgs::CleanupUnmanagedOrgsWithUsersService.run(dry_run: dry_run)
   end
 end

--- a/lib/tasks/orgs.rake
+++ b/lib/tasks/orgs.rake
@@ -6,6 +6,30 @@ namespace :orgs do
     Orgs::UpdateRorService.run
   end
 
+  # IMPORTANT:
+  # Recommended execution order for org cleanup tasks:
+  #
+  # 1. Take a full database dump for audit and rollback purposes.
+  #
+  # 2. Run cleanup tasks that may free additional orphan orgs **before** deleting orphans:
+  #    - delete_junk_trackers (does NOT support DRY_RUN)
+  #    - cleanup_unmanaged_orgs_with_users (supports DRY_RUN)
+  #    - cleanup_junk_funders (supports DRY_RUN)
+  #
+  #    The tasks that support DRY_RUN output counts of the changes they would make.
+  #    These outputs can be compared against the local DB dump to verify expected
+  #    changes before performing any mutations.
+  #
+  # 3. Run delete_orphan_orgs LAST.
+  #    - Supports DRY_RUN and outputs a CSV of to-be-deleted orgs (orphan_orgs.csv).
+  #    - Performs irreversible deletes; only run after other cleanup tasks are complete.
+  #    - Outputs a CSV after deletion completes (deleted_orphan_orgs.csv).
+
+  desc 'Deletes "junk trackers" from the DB (i.e. Tracker.where(code: ""))'
+  task delete_junk_trackers: :environment do
+    Orgs::DeleteJunkTrackersService.run
+  end
+
   desc 'Cleans up unmanaged orgs having 1 or more users.
         For each such org:
         - Reassign associated users and plans to the "default org"'
@@ -15,5 +39,26 @@ namespace :orgs do
     # as well as how many users and plans will be reassigned to the default org.
     dry_run = ENV['DRY_RUN'] == 'true'
     Orgs::CleanupUnmanagedOrgsWithUsersService.run(dry_run: dry_run)
+  end
+
+  desc 'Finds "junk funders" and sets `plan.funder_id = nil` for their associated plans
+        - Junk funders are orgs meeting the following criteria:
+          1) Have `org.id == plan.funder_id` as their only association
+          2) Have a "junk" name (see JUNK_FUNDER_NAMES in CleanupJunkFundersService)'
+  task cleanup_junk_funders: :environment do
+    # Passing `DRY_RUN=true` bypasses db updates,
+    # and simply updates how many junk funders were found as well as
+    # how many plans will be updated by the task.
+    dry_run = ENV['DRY_RUN'] == 'true'
+    Orgs::CleanupJunkFundersService.run(dry_run: dry_run)
+  end
+
+  desc 'Deletes all "orphan" orgs from the db.
+        - (Orphan = org with no entries in any `has_many` or HABTM associations.)'
+  task delete_orphan_orgs: :environment do
+    # Passing `DRY_RUN=true` bypasses destruction,
+    # and outputs a csv of which orgs this task will delete.
+    dry_run = ENV['DRY_RUN'] == 'true'
+    Orgs::DeleteOrphanOrgsService.run(dry_run: dry_run)
   end
 end

--- a/lib/tasks/orgs.rake
+++ b/lib/tasks/orgs.rake
@@ -8,8 +8,7 @@ namespace :orgs do
 
   desc 'Cleans up unmanaged orgs having 1 or more users.
         For each such org:
-        - Reassign associated users and plans to the "default org"
-        - Attempt deletion of the org'
+        - Reassign associated users and plans to the "default org"'
   task cleanup_unmanaged_orgs_with_users: :environment do
     Orgs::CleanupUnmanagedOrgsWithUsersService.run
   end


### PR DESCRIPTION
# Changes proposed in this PR:

1. **Remove org deletion from `CleanupUnmanagedOrgsWithUsersService`**  
   - Org deletion is now handled by `orgs:delete_orphan_orgs` to reduce redundancy.  
   - Added DRY_RUN support for safe preview of changes.

2. **New Rake tasks:**  
   - `orgs:delete_junk_trackers`  
     - Deletes Tracker records with blank codes.  
     - Partly addresses #1260.  
   - `orgs:cleanup_junk_funders`  
     - Finds "junk funders" (orgs with only `plans.funder` associations and a "junk" name) and sets `plan.funder_id = nil`.  
     - Supports `DRY_RUN=true`, outputs counts without mutating data. 
   - `orgs:delete_orphan_orgs`  
     - Deletes orphan orgs (no entries in any has_many, has_one, or HABTM associations).  
     - Handles non-standard (`funded_plans`) and polymorphic (`identifiers`) associations.  
     - Supports `DRY_RUN=true`, outputs `orphan_orgs.csv` and `deleted_orphan_orgs.csv`.

3. **`Orgs::AssociationInspector`**  
   - Shared service for orphan org queries.  
   - Provides `orphan_orgs(allow_funded_plans_association: false)` to construct the base query.  
   - Includes `verify_expected_associations!` to guard against DB schema changes.  
   - Used by `delete_junk_trackers` and `cleanup_junk_funders` to prevent duplicate logic.

**Execution notes / recommendations:**  
- Take a full DB dump before running cleanup tasks for audit and rollback.  
- Recommended order:  
  1. `delete_junk_trackers`  
  2. `cleanup_unmanaged_orgs_with_users`  
  3. `cleanup_junk_funders`  
  4. `delete_orphan_orgs` (last)  
- DRY_RUN outputs can be compared against the DB dump to verify expected changes before mutation.
- **JUNK_FUNDER_NAMES** (in `app/services/orgs/cleanup_junk_funders_service.rb`) contains the list of known "junk" funder names.  
  - This list should be reviewed and verified before running cleanup tasks.
