### PR TITLE
[DRAFT] Enable ROR-Based Org Creation for Funders

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -255,7 +255,7 @@ class PlansController < ApplicationController
                            end
       @plan.guidance_groups = GuidanceGroup.where(id: guidance_group_ids)
 
-      invalid_funder = validate_and_set_funder(plan_params[:funder])
+      valid_funder = validate_and_set_funder(plan_params[:funder])
 
       @plan.grant = plan_params[:grant]
       attrs.delete(:funder)
@@ -267,7 +267,7 @@ class PlansController < ApplicationController
       if saved
         notice = success_message(@plan, _('saved'))
         alert  =
-          (_('The plan was saved, but the funder was not updated because it is invalid.') if invalid_funder)
+          (_('The plan was saved, but the funder was not updated because it is invalid.') unless valid_funder)
 
         format.html do
           redirect_to plan_path(@plan),
@@ -279,7 +279,7 @@ class PlansController < ApplicationController
           render json: {
             code: 1,
             msg: notice,
-            warning: invalid_funder ? _('Invalid funder.') : nil
+            warning: valid_funder ? nil : _('Invalid funder.')
           }
         end
       else
@@ -580,12 +580,12 @@ class PlansController < ApplicationController
         org_from_params(params_in: funder_attrs, allow_create: true)
       end
 
-    invalid_funder = funder_attrs[:org_name].present? && funder.nil?
+    valid_funder = funder_attrs[:org_name].blank? || funder.present?
 
     # Only change funder_id when it is valid OR explicitly cleared
-    @plan.funder_id = funder&.id unless invalid_funder
+    @plan.funder_id = funder&.id if valid_funder
 
-    invalid_funder
+    valid_funder
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -255,17 +255,22 @@ class PlansController < ApplicationController
                            end
       @plan.guidance_groups = GuidanceGroup.where(id: guidance_group_ids)
 
-      # TODO: For some reason the `fields_for` isn't adding the
-      #       appropriate namespace, so org_id represents our funder
       funder_attrs = plan_params[:funder]
-      funder = org_from_params(params_in: funder_attrs, allow_create: true)
-      @plan.funder_id = funder&.id if funder
+
+      funder =
+        if funder_attrs[:org_name].blank?
+          nil # user cleared funder — valid
+        else
+          org_from_params(params_in: funder_attrs, allow_create: true)
+        end
+
+      invalid_funder = funder_attrs[:org_name].present? && funder.nil?
+
+      @plan.funder_id = funder&.id
       @plan.grant = plan_params[:grant]
       attrs.delete(:funder)
       attrs.delete(:grant)
       attrs = remove_org_selection_params(params_in: attrs)
-
-      invalid_funder = invalid_funder?(funder_attrs)
 
       if @plan.update(attrs) && !invalid_funder # _attributes(attrs)
         format.html do
@@ -561,12 +566,6 @@ class PlansController < ApplicationController
              Org.includes(identifiers: :identifier_scheme).institution +
              Org.includes(identifiers: :identifier_scheme).default_orgs)
     @orgs = @orgs.flatten.uniq.sort_by(&:name)
-  end
-
-  def invalid_funder?(funder_attrs)
-    funder_json = funder_attrs[:org_id].present? ? (JSON.parse(funder_attrs[:org_id]) rescue {}) : {} # rubocop:disable Style/RescueModifier
-    # Only returns true when name is present but ror is not, which only occurs when user enters invalid funder
-    funder_json['name'].present? && funder_json['ror'].blank?
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -266,7 +266,9 @@ class PlansController < ApplicationController
 
       invalid_funder = funder_attrs[:org_name].present? && funder.nil?
 
-      @plan.funder_id = funder&.id
+      # Only change funder_id when it is valid OR explicitly cleared
+      @plan.funder_id = funder&.id unless invalid_funder
+
       @plan.grant = plan_params[:grant]
       attrs.delete(:funder)
       attrs.delete(:grant)
@@ -282,7 +284,7 @@ class PlansController < ApplicationController
         end
       else
         failure_msg = failure_message(@plan, _('save'))
-        failure_msg += _(' Invalid funder.') if invalid_funder
+        failure_msg = _(' Invalid funder.') if invalid_funder
         format.html do
           # TODO: Should do a `render :show` here instead but show defines too many
           #       instance variables in the controller

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -255,7 +255,7 @@ class PlansController < ApplicationController
                            end
       @plan.guidance_groups = GuidanceGroup.where(id: guidance_group_ids)
 
-      invalid_funder = assign_funder(plan_params)
+      invalid_funder = invalid_funder?(plan_params)
 
       @plan.grant = plan_params[:grant]
       attrs.delete(:funder)
@@ -572,7 +572,7 @@ class PlansController < ApplicationController
     @orgs = @orgs.flatten.uniq.sort_by(&:name)
   end
 
-  def assign_funder(plan_params)
+  def invalid_funder?(plan_params)
     funder_attrs = plan_params[:funder]
 
     funder =

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -255,19 +255,7 @@ class PlansController < ApplicationController
                            end
       @plan.guidance_groups = GuidanceGroup.where(id: guidance_group_ids)
 
-      funder_attrs = plan_params[:funder]
-
-      funder =
-        if funder_attrs[:org_name].blank?
-          nil # user cleared funder — valid
-        else
-          org_from_params(params_in: funder_attrs, allow_create: true)
-        end
-
-      invalid_funder = funder_attrs[:org_name].present? && funder.nil?
-
-      # Only change funder_id when it is valid OR explicitly cleared
-      @plan.funder_id = funder&.id unless invalid_funder
+      invalid_funder = assign_funder(plan_params)
 
       @plan.grant = plan_params[:grant]
       attrs.delete(:funder)
@@ -568,6 +556,24 @@ class PlansController < ApplicationController
              Org.includes(identifiers: :identifier_scheme).institution +
              Org.includes(identifiers: :identifier_scheme).default_orgs)
     @orgs = @orgs.flatten.uniq.sort_by(&:name)
+  end
+
+  def assign_funder(plan_params)
+    funder_attrs = plan_params[:funder]
+
+    funder =
+      if funder_attrs[:org_name].blank?
+        nil # user cleared funder — valid
+      else
+        org_from_params(params_in: funder_attrs, allow_create: true)
+      end
+
+    invalid_funder = funder_attrs[:org_name].present? && funder.nil?
+
+    # Only change funder_id when it is valid OR explicitly cleared
+    @plan.funder_id = funder&.id unless invalid_funder
+
+    invalid_funder
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -265,7 +265,9 @@ class PlansController < ApplicationController
       attrs.delete(:grant)
       attrs = remove_org_selection_params(params_in: attrs)
 
-      if @plan.update(attrs) && funder.present? # _attributes(attrs)
+      invalid_funder = invalid_funder?(funder_attrs)
+
+      if @plan.update(attrs) && !invalid_funder # _attributes(attrs)
         format.html do
           redirect_to plan_path(@plan),
                       notice: success_message(@plan, _('saved'))
@@ -275,14 +277,14 @@ class PlansController < ApplicationController
         end
       else
         failure_msg = failure_message(@plan, _('save'))
-        failure_msg += _(' Invalid funder.') if funder.nil?
+        failure_msg += _(' Invalid funder.') if invalid_funder
         format.html do
           # TODO: Should do a `render :show` here instead but show defines too many
           #       instance variables in the controller
           redirect_to plan_path(@plan).to_s, alert: failure_msg
         end
         format.json do
-          render json: { code: 0, msg: failure_message }
+          render json: { code: 0, msg: failure_msg }
         end
       end
     rescue StandardError => e
@@ -559,6 +561,12 @@ class PlansController < ApplicationController
              Org.includes(identifiers: :identifier_scheme).institution +
              Org.includes(identifiers: :identifier_scheme).default_orgs)
     @orgs = @orgs.flatten.uniq.sort_by(&:name)
+  end
+
+  def invalid_funder?(funder_attrs)
+    funder_json = funder_attrs[:org_id].present? ? (JSON.parse(funder_attrs[:org_id]) rescue {}) : {} # rubocop:disable Style/RescueModifier
+    # Only returns true when name is present but ror is not, which only occurs when user enters invalid funder
+    funder_json['name'].present? && funder_json['ror'].blank?
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -255,7 +255,7 @@ class PlansController < ApplicationController
                            end
       @plan.guidance_groups = GuidanceGroup.where(id: guidance_group_ids)
 
-      invalid_funder = invalid_funder?(plan_params)
+      invalid_funder = validate_and_set_funder(plan_params[:funder])
 
       @plan.grant = plan_params[:grant]
       attrs.delete(:funder)
@@ -572,9 +572,7 @@ class PlansController < ApplicationController
     @orgs = @orgs.flatten.uniq.sort_by(&:name)
   end
 
-  def invalid_funder?(plan_params)
-    funder_attrs = plan_params[:funder]
-
+  def validate_and_set_funder(funder_attrs)
     funder =
       if funder_attrs[:org_name].blank?
         nil # user cleared funder — valid

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -262,34 +262,48 @@ class PlansController < ApplicationController
       attrs.delete(:grant)
       attrs = remove_org_selection_params(params_in: attrs)
 
-      if @plan.update(attrs) && !invalid_funder # _attributes(attrs)
+      saved = @plan.update(attrs)
+
+      if saved
+        notice = success_message(@plan, _('saved'))
+        alert  =
+          (_('The plan was saved, but the funder was not updated because it is invalid.') if invalid_funder)
+
         format.html do
           redirect_to plan_path(@plan),
-                      notice: success_message(@plan, _('saved'))
+                      notice: notice,
+                      alert: alert
         end
+
         format.json do
-          render json: { code: 1, msg: success_message(@plan, _('saved')) }
+          render json: {
+            code: 1,
+            msg: notice,
+            warning: invalid_funder ? _('Invalid funder.') : nil
+          }
         end
       else
         failure_msg = failure_message(@plan, _('save'))
-        failure_msg = _(' Invalid funder.') if invalid_funder
         format.html do
           # TODO: Should do a `render :show` here instead but show defines too many
           #       instance variables in the controller
           redirect_to plan_path(@plan).to_s, alert: failure_msg
         end
+
         format.json do
           render json: { code: 0, msg: failure_msg }
         end
       end
     rescue StandardError => e
-      flash[:alert] = failure_message(@plan, _('save'))
+      Rails.logger.error "Unable to save plan #{@plan&.id} - #{e.message}"
+      alert = failure_message(@plan, _('save'))
+
       format.html do
-        Rails.logger.error "Unable to save plan #{@plan&.id} - #{e.message}"
-        redirect_to plan_path(@plan).to_s, alert: failure_message(@plan, _('save'))
+        redirect_to plan_path(@plan).to_s, alert: alert
       end
+
       format.json do
-        render json: { code: 0, msg: flash[:alert] }
+        render json: { code: 0, msg: alert }
       end
     end
     # rubocop:enable Metrics/BlockLength

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -262,9 +262,7 @@ class PlansController < ApplicationController
       attrs.delete(:grant)
       attrs = remove_org_selection_params(params_in: attrs)
 
-      saved = @plan.update(attrs)
-
-      if saved
+      if @plan.update(attrs)
         notice = success_message(@plan, _('saved'))
         alert  =
           (_('The plan was saved, but the funder was not updated because it is invalid.') unless valid_funder)

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -239,7 +239,7 @@ class PlansController < ApplicationController
 
   # PUT /plans/1
   # rubocop:disable Metrics/MethodLength, Metrics/PerceivedComplexity
-  def update
+  def update # rubocop:disable Metrics/CyclomaticComplexity
     @plan = Plan.find(params[:id])
     authorize @plan
     attrs = plan_params
@@ -258,15 +258,14 @@ class PlansController < ApplicationController
       # TODO: For some reason the `fields_for` isn't adding the
       #       appropriate namespace, so org_id represents our funder
       funder_attrs = plan_params[:funder]
-      funder_attrs[:org_id] = plan_params[:funder][:id]
       funder = org_from_params(params_in: funder_attrs, allow_create: true)
-      @plan.funder_id = funder&.id
+      @plan.funder_id = funder&.id if funder
       @plan.grant = plan_params[:grant]
       attrs.delete(:funder)
       attrs.delete(:grant)
       attrs = remove_org_selection_params(params_in: attrs)
 
-      if @plan.update(attrs) # _attributes(attrs)
+      if @plan.update(attrs) && funder.present? # _attributes(attrs)
         format.html do
           redirect_to plan_path(@plan),
                       notice: success_message(@plan, _('saved'))
@@ -275,13 +274,15 @@ class PlansController < ApplicationController
           render json: { code: 1, msg: success_message(@plan, _('saved')) }
         end
       else
+        failure_msg = failure_message(@plan, _('save'))
+        failure_msg += _(' Invalid funder.') if funder.nil?
         format.html do
           # TODO: Should do a `render :show` here instead but show defines too many
           #       instance variables in the controller
-          redirect_to plan_path(@plan).to_s, alert: failure_message(@plan, _('save'))
+          redirect_to plan_path(@plan).to_s, alert: failure_msg
         end
         format.json do
-          render json: { code: 0, msg: failure_message(@plan, _('save')) }
+          render json: { code: 0, msg: failure_message }
         end
       end
     rescue StandardError => e

--- a/app/views/plans/_project_details.html.erb
+++ b/app/views/plans/_project_details.html.erb
@@ -150,7 +150,7 @@ ethics_report_tooltip = _("Link to a protocol from a meeting with an ethics comm
   <div id="funder-org-controls" class="form-group">
     <div class="col-md-8">
       <%= form.fields_for :funder, Org.new do |funder_fields| %>
-        <%= render partial: "shared/org_selectors/text_only",
+        <%= render partial: "shared/org_selectors/combined",
                     locals: {
                       form: funder_fields,
                       id_field: :id,


### PR DESCRIPTION
Changes proposed in this PR:
- Change the funder selection field in a plan from a text field to a dropdown that includes orgs in the DMP Assistant DB and external orgs validated by ROR.
- Funder attributes are set in the `update` function of the `PlansController`, so the following changes are made there:
      - Set funder id in the plan only if a funder is available.
      - Add the `invalid_funder?` helper function, which returns true when a funder organization is entered and is invalid (does not have a valid ROR or exist in the local DB).
      - Edit the failure message to include 'Invalid funder' when an invalid funder is entered.
- These changes will prevent the creation of junk orgs from the funder tab, as any funder organization that is entered must have a valid ROR.
