### PR TITLE
Add `orgs:delete_junk_trackers` rake task

### DIFF
--- a/app/services/orgs/delete_junk_trackers_service.rb
+++ b/app/services/orgs/delete_junk_trackers_service.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Orgs
+  # Invoked by the `orgs:delete_junk_trackers` Rake task.
+  # This service deletes all "junk" trackers (i.e. `Tracker.where(code: '')`)
+  # Partly addresses https://github.com/portagenetwork/roadmap/issues/1260
+  module DeleteJunkTrackersService
+    module_function
+
+    def run
+      junk_trackers = Tracker.where(code: '')
+      puts "Found #{junk_trackers.count} junk trackers ( i.e. `Tracker.where(code: '')` )"
+      destroy_result = junk_trackers.destroy_all
+      puts "Deleted #{destroy_result.count} of these junk trackers."
+    end
+  end
+end

--- a/lib/tasks/orgs.rake
+++ b/lib/tasks/orgs.rake
@@ -13,4 +13,9 @@ namespace :orgs do
   task cleanup_unmanaged_orgs_with_users: :environment do
     Orgs::CleanupUnmanagedOrgsWithUsersService.run
   end
+
+  desc 'Deletes junk trackers from the DB (i.e. Tracker.where(code: ""))'
+  task delete_junk_trackers: :environment do
+    Orgs::DeleteJunkTrackersService.run
+  end
 end


### PR DESCRIPTION
Partly addresses https://github.com/portagenetwork/roadmap/issues/1260

# Changes proposed in this PR:

Adds `orgs:delete_junk_trackers` rake task and service to remove Tracker records with blank codes.

This cleans up junk data in the trackers table and unblocks deletion of otherwise orphaned orgs (see https://github.com/portagenetwork/roadmap/pull/1259).