### PR TITLE
Edit unpublished template change messages

### DIFF
--- a/app/views/org_admin/templates/_row.html.erb
+++ b/app/views/org_admin/templates/_row.html.erb
@@ -9,7 +9,7 @@
     <% if template.published? %>
       <%= _('Published') %>
     <% elsif template.draft? %>
-      <% tooltip = _('This template is published changes but has unpublished changes!') %>
+      <% tooltip = _('This template is published, but now contains unpublished changes!') %>
       <%= _('Published') %> <em class="sr-only"><%= tooltip %></em>
     &nbsp;&nbsp;<i class="fas fa-pencil-square" aria-hidden="true" data-toggle="tooltip" title="<%= tooltip %>"></i>
     <% else %>

--- a/app/views/org_admin/templates/index.html.erb
+++ b/app/views/org_admin/templates/index.html.erb
@@ -32,6 +32,18 @@
       <%= _('If you wish to add an organisational template for a Data Management Plan, use the \'create template\' button. You can create more than one template if desired e.g. one for researchers and one for PhD students. Your template will be presented to users within your organisation when no funder templates apply. If you want to add questions to funder templates use the \'customise template\' options below.') %>
     </p>
   </div>
+
+  <% if @unpublished_count > 0 %>
+  <div class="col-md-12">
+    <div class="alert alert-info" role="alert">
+      <%= (_('A template marked with %{icon} means it has unpublished changes.') % {
+          icon: '<i class="fas fa-pencil-square" aria-hidden="true"></i>'
+        }
+      ).html_safe %>
+    </div>
+  </div>
+  <% end %>
+
 </div>
 
 <div class="row">


### PR DESCRIPTION
Fixes #1261.

Changes proposed in this PR:
- Fix the typo in the message alerting users that their published templates now have unpublished changes.
- Add a message in the Templates section explaining what the pencil icon means on published templates now have unpublished changes.
