### PR TITLE
Edit combined partial to not return unmanaged organizations

### DIFF
--- a/app/services/org_selection/search_service.rb
+++ b/app/services/org_selection/search_service.rb
@@ -11,7 +11,7 @@ module OrgSelection
       def search_combined(search_term:)
         return [] unless search_term.present? && search_term.length > 2
 
-        orgs = local_search(search_term: search_term)
+        orgs = local_search(search_term: search_term, managed_orgs_only: true)
         orgs = [] unless orgs.present?
         # If we got an exact match out of the database then skip the
         # external searches
@@ -65,12 +65,14 @@ module OrgSelection
         expiration.present? ? expiration : 1.day
       end
 
-      def local_search(search_term:)
+      def local_search(search_term:, managed_orgs_only: false)
         return [] unless search_term.present?
 
-        Rails.cache.fetch(['org_selection-local', search_term], expires_in: expiry) do
-          Org.includes(identifiers: :identifier_scheme)
-             .search(name_without_alias(name: search_term)).to_a
+        cache_key = ['org_selection-local', search_term, managed_orgs_only]
+        Rails.cache.fetch(cache_key, expires_in: expiry) do
+          scope = Org.includes(identifiers: :identifier_scheme)
+          scope = scope.where(managed: true) if managed_orgs_only
+          scope.search(name_without_alias(name: search_term)).to_a
         end
       end
 

--- a/app/services/org_selection/search_service.rb
+++ b/app/services/org_selection/search_service.rb
@@ -62,7 +62,7 @@ module OrgSelection
 
       def expiry
         expiration = Rails.configuration.x.cache.org_selection_expiration
-        expiration.present? ? expiration : 1.day
+        expiration.present? ? expiration : 1.hour
       end
 
       def local_search(search_term:, managed_orgs_only: false)

--- a/config/initializers/_dmproadmap.rb
+++ b/config/initializers/_dmproadmap.rb
@@ -222,7 +222,7 @@ module DMPRoadmap
     # ---------------------------------------------------- #
 
     # Determines how long to cache results for OrgSelection::SearchService
-    config.x.cache.org_selection_expiration = 86_400
+    config.x.cache.org_selection_expiration = 3600
     # Determines how long to cache results for the ResearchProjectsController
     config.x.cache.research_projects_expiration = 86_400
 


### PR DESCRIPTION
Changes proposed in this PR:
- Edit `local_search` in `search_service` such that it contains an optional parameter that can be set to true to remove unmanaged organizations from the results.
- Set `managed_orgs_only` to `true` in `search_combined` so the combined org partial does not return unmanaged organizations.
- Edit org selection cache expiration from 1 day to 1 hour.

