### PR TITLE
Add `bundle exec rails db:migrate` to entrypoint.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
  - Implement tiered Rack::Attack throttles [#1254](https://github.com/portagenetwork/roadmap/pull/1254)
 
+ - Add `bundle exec rails db:migrate` to entrypoint.sh [#1278](https://github.com/portagenetwork/roadmap/pull/1278)
+
 ### Changed
 
  - Upgrade ROR API From V1 to V2 [#1247](https://github.com/portagenetwork/roadmap/pull/1247)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,10 @@ done
 echo "Database is ready."
 
 
+echo "==> Running database migrations..."
+bundle exec rails db:migrate
+
+
 echo "==> Executing translation:sync..."
 if ! bundle exec rake translation:sync; then
   echo "ERROR: translation:sync failed, continuing anyway."


### PR DESCRIPTION
### Changes proposed in this PR:
- Add `bundle exec rails db:migrate` to entrypoint.sh
  - This saves us from having to execute the command manually after deploying new releases.