### PR TITLE
Add Internal v2 API Access Token Generation for Users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
  - Implement tiered Rack::Attack throttles [#1254](https://github.com/portagenetwork/roadmap/pull/1254)
 
+ - Add Internal v2 API Access Token Generation for Users [#1279](https://github.com/portagenetwork/roadmap/pull/1279)
+
 ### Changed
 
  - Upgrade ROR API From V1 to V2 [#1247](https://github.com/portagenetwork/roadmap/pull/1247)

--- a/app/controllers/api/v2/internal_user_access_tokens_controller.rb
+++ b/app/controllers/api/v2/internal_user_access_tokens_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Api
+  module V2
+    # Controller for managing the current user's internal V2 API access token.
+    # Provides token rotation for authenticated internal users.
+    # See Api::V2::InternalUserAccessTokenService for token implementation details.
+    class InternalUserAccessTokensController < ApplicationController
+      # POST "/api/v2/internal_user_access_token"
+      def create
+        authorize current_user, :internal_user_v2_access_token?
+        @token = Api::V2::InternalUserAccessTokenService.rotate!(current_user)
+        @success = true
+        respond_to do |format|
+          format.js { render 'users/refresh_token' }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/internal_user_access_tokens_controller.rb
+++ b/app/controllers/api/v2/internal_user_access_tokens_controller.rb
@@ -9,7 +9,7 @@ module Api
       # POST "/api/v2/internal_user_access_token"
       def create
         authorize current_user, :internal_user_v2_access_token?
-        @token = Api::V2::InternalUserAccessTokenService.rotate!(current_user)
+        @v2_token = Api::V2::InternalUserAccessTokenService.rotate!(current_user)
         @success = true
         respond_to do |format|
           format.js { render 'users/refresh_token' }

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -55,6 +55,12 @@ class UserPolicy < ApplicationPolicy
       (@user.can_org_admin? && @user.can_use_api?)
   end
 
+  # Safe: only allows the signed-in user to generate/rotate their own token.
+  # These are first-party, user-scoped tokens and do not affect other users.
+  def internal_user_v2_access_token?
+    true
+  end
+
   def merge?
     @user.can_super_admin?
   end

--- a/app/services/api/v2/internal_user_access_token_service.rb
+++ b/app/services/api/v2/internal_user_access_token_service.rb
@@ -21,9 +21,7 @@ module Api
     # This service does NOT support third-party OAuth clients or delegated consent flows.
     class InternalUserAccessTokenService
       READ_SCOPE = 'read'
-      APPLICATION = Doorkeeper::Application.find_by(
-        name: Rails.application.config.x.application.internal_oauth_app_name
-      )
+      INTERNAL_OAUTH_APP_NAME = Rails.application.config.x.application.internal_oauth_app_name
 
       class << self
         def for_user(user)
@@ -46,7 +44,26 @@ module Api
           )
         end
 
+        # Used by views (e.g. devise/registrations/_v2_api_token.html.erb) to safely
+        # gate token UI if the internal OAuth application is missing.
+        def application_present?
+          application!
+          true
+        rescue StandardError => e
+          Rails.logger.error(e.message)
+          false
+        end
+
         private
+
+        def application!
+          Doorkeeper::Application.find_by(name: INTERNAL_OAUTH_APP_NAME) ||
+            raise(
+              StandardError,
+              "Required Doorkeeper application '#{INTERNAL_OAUTH_APP_NAME}' not found. " \
+              'Please ensure the application exists in the database.'
+            )
+        end
 
         def revoke_existing!(user)
           Doorkeeper::AccessToken.revoke_all_for(application!.id, user)

--- a/app/services/api/v2/internal_user_access_token_service.rb
+++ b/app/services/api/v2/internal_user_access_token_service.rb
@@ -24,24 +24,16 @@ module Api
       INTERNAL_OAUTH_APP_NAME = Rails.application.config.x.application.internal_oauth_app_name
 
       class << self
-        def for_user(user)
-          Doorkeeper::AccessToken.find_by(
-            application_id: application!.id,
-            resource_owner_id: user.id,
-            scopes: READ_SCOPE,
-            revoked_at: nil
-          )
-        end
-
         def rotate!(user)
           revoke_existing!(user)
 
-          Doorkeeper::AccessToken.create!(
+          token = Doorkeeper::AccessToken.create!(
             application_id: application!.id,
             resource_owner_id: user.id,
             scopes: READ_SCOPE,
             expires_in: nil # Overrides Doorkeeper's `access_token_expires_in`
           )
+          token.plaintext_token
         end
 
         # Used by views (e.g. devise/registrations/_v2_api_token.html.erb) to safely

--- a/app/services/api/v2/internal_user_access_token_service.rb
+++ b/app/services/api/v2/internal_user_access_token_service.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Api
+  module V2
+    # Service responsible for user-scoped v2 API access tokens, strictly for
+    # internal users of this application.
+    #
+    # Tokens issued by this service are functionally equivalent to Personal Access
+    # Tokens (PATs) for first-party usage. They are minted directly for a user
+    # who is already authenticated in the application, bypassing the standard
+    # OAuth 2.0 authorization_code redirect and consent flow.
+    #
+    # This design is intentional:
+    # - tokens are internal to this application (first-party)
+    # - tokens are owned by a single user and scoped accordingly
+    # - token creation, rotation, and revocation happen entirely within the app UI
+    #
+    # Tokens are stored as Doorkeeper::AccessToken records to leverage existing
+    # scoping, expiry, and revocation mechanisms.
+    #
+    # This service does NOT support third-party OAuth clients or delegated consent flows.
+    class InternalUserAccessTokenService
+      READ_SCOPE = 'read'
+      APPLICATION = Doorkeeper::Application.find_by(
+        name: Rails.application.config.x.application.internal_oauth_app_name
+      )
+
+      class << self
+        def for_user(user)
+          Doorkeeper::AccessToken.find_by(
+            application_id: application!.id,
+            resource_owner_id: user.id,
+            scopes: READ_SCOPE,
+            revoked_at: nil
+          )
+        end
+
+        def rotate!(user)
+          revoke_existing!(user)
+
+          Doorkeeper::AccessToken.create!(
+            application_id: application!.id,
+            resource_owner_id: user.id,
+            scopes: READ_SCOPE,
+            expires_in: nil # Overrides Doorkeeper's `access_token_expires_in`
+          )
+        end
+
+        private
+
+        def revoke_existing!(user)
+          Doorkeeper::AccessToken.revoke_all_for(application!.id, user)
+        end
+      end
+    end
+  end
+end

--- a/app/views/devise/registrations/_api_token.html.erb
+++ b/app/views/devise/registrations/_api_token.html.erb
@@ -1,8 +1,9 @@
 <%# locals: user %>
+<% v2_token ||= nil %>
 
 <div id="api-tokens">
   <%# v2 API token %>
-  <%= render partial: "devise/registrations/v2_api_token", locals: { user: user } %>
+  <%= render partial: "devise/registrations/v2_api_token", locals: { user: user, token: v2_token } %>
 
   <% if user.can_use_api? %>
     <%# v0/v1 API token %>

--- a/app/views/devise/registrations/_api_token.html.erb
+++ b/app/views/devise/registrations/_api_token.html.erb
@@ -1,46 +1,9 @@
 <%# locals: user %>
 
-<% api_wikis = Rails.configuration.x.application.api_documentation_urls %>
-<% v2_token = Api::V2::InternalUserAccessTokenService.for_user(user) %>
-<div id="api-token" class="col-xs-12">
-
+<div id="api-tokens">
   <%# v2 API token %>
-  <div class="form-control mb-3 col-xs-8">
-    <%= label_tag(:api_token, _('Access token'), class: 'form-label') %>
-    <% if v2_token.present? %>
-      <%= v2_token.token %>
-    <% else %>
-      <%= _("Click the button below to generate an API token") %>
-    <% end %>
-  </div>
-
-  <div class="form-control mb-3 col-xs-8">
-    <%= link_to _("Regenerate token"),
-                api_v2_internal_user_access_token_path(format: :js),
-                method: :post,
-                class: 'btn btn-secondary',
-                remote: true %>
-  </div>
+  <%= render partial: "devise/registrations/v2_api_token", locals: { user: user } %>
 
   <%# v0/v1 API token %>
-  <div class="form-control mb-3 col-xs-8">
-    <%= label_tag(:api_token, _('Access token'), class: 'form-label') %>
-    <% if user.api_token.present? %>
-      <%= user.api_token %>
-    <% else %>
-      <%= _("Click the button below to generate an API token") %>
-    <% end %>
-  </div>
-  <div class="form-group col-xs-12">
-    <%= label_tag(:api_information, _('Documentation'), class: 'control-label') %>
-    <br>
-    <%= _('See the <a href="%{api_v0_wiki}">documentation for v0</a> for more details on the original API which includes access to statistics, the full text of plans and the ability to connect users with departments.').html_safe % { api_v0_wiki: api_wikis[:v0] } %></a>
-    <br><br>
-    <%= _('See the <a href="%{api_v1_wiki}">documentation for v1</a> for more details on the API that supports the <a href="%{rda_standard_url}">RDA Common metadata standard for DMPs.</a>').html_safe % { api_v1_wiki: api_wikis[:v1], rda_standard_url: 'https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard' } %></a>
-  </div>
-  <div class="form-group col-xs-8">
-    <%= link_to _("Regenerate token"),
-                refresh_token_user_path(user),
-                class: "btn btn-default", remote: true %>
-  </div>
+  <%= render partial: "devise/registrations/legacy_api_token", locals: { user: user } %>
 </div>

--- a/app/views/devise/registrations/_api_token.html.erb
+++ b/app/views/devise/registrations/_api_token.html.erb
@@ -1,9 +1,30 @@
 <%# locals: user %>
 
 <% api_wikis = Rails.configuration.x.application.api_documentation_urls %>
+<% v2_token = Api::V2::InternalUserAccessTokenService.for_user(user) %>
 <div id="api-token" class="col-xs-12">
-  <div class="form-group col-xs-8">
-    <%= label_tag(:api_token, _('Access token'), class: 'control-label') %>
+
+  <%# v2 API token %>
+  <div class="form-control mb-3 col-xs-8">
+    <%= label_tag(:api_token, _('Access token'), class: 'form-label') %>
+    <% if v2_token.present? %>
+      <%= v2_token.token %>
+    <% else %>
+      <%= _("Click the button below to generate an API token") %>
+    <% end %>
+  </div>
+
+  <div class="form-control mb-3 col-xs-8">
+    <%= link_to _("Regenerate token"),
+                api_v2_internal_user_access_token_path(format: :js),
+                method: :post,
+                class: 'btn btn-secondary',
+                remote: true %>
+  </div>
+
+  <%# v0/v1 API token %>
+  <div class="form-control mb-3 col-xs-8">
+    <%= label_tag(:api_token, _('Access token'), class: 'form-label') %>
     <% if user.api_token.present? %>
       <%= user.api_token %>
     <% else %>

--- a/app/views/devise/registrations/_api_token.html.erb
+++ b/app/views/devise/registrations/_api_token.html.erb
@@ -4,6 +4,8 @@
   <%# v2 API token %>
   <%= render partial: "devise/registrations/v2_api_token", locals: { user: user } %>
 
-  <%# v0/v1 API token %>
-  <%= render partial: "devise/registrations/legacy_api_token", locals: { user: user } %>
+  <% if user.can_use_api? %>
+    <%# v0/v1 API token %>
+    <%= render partial: "devise/registrations/legacy_api_token", locals: { user: user } %>
+  <% end %>
 </div>

--- a/app/views/devise/registrations/_legacy_api_token.html.erb
+++ b/app/views/devise/registrations/_legacy_api_token.html.erb
@@ -1,12 +1,12 @@
 <%# locals: user %>
 
 <% api_wikis = Rails.configuration.x.application.api_documentation_urls %>
-<div id="legacy-api-token" class="card mb-4">
-  <div class="card-heading">
+<div id="legacy-api-token" class="panel mb-4" style="border: 1px solid #0a0a0a">
+  <div class="nav nav-tabs">
     <%= _('Legacy API') %>
   </div>
-  <div class="card-body">
-    <div class="form-control mb-3 col-xs-8">
+  <div class="panel-body">
+    <div class="form-group mb-3 col-xs-8">
       <%= label_tag(:api_token, _('Access token'), class: 'form-label') %>
       <% if user.api_token.present? %>
         <code><%= user.api_token %></code>
@@ -14,17 +14,17 @@
         <%= _("Click the button below to generate an API token") %>
       <% end %>
     </div>
-    <div class="form-control mb-3 col-xs-12">
+    <div class="form-group mb-3 col-xs-12">
       <%= label_tag(:api_information, _('Documentation'), class: 'form-label') %>
       <br>
       <%= _('See the <a href="%{api_v0_wiki}">documentation for v0</a> for more details on the original API which includes access to statistics, the full text of plans and the ability to connect users with departments.').html_safe % { api_v0_wiki: api_wikis[:v0] } %></a>
       <br><br>
       <%= _('See the <a href="%{api_v1_wiki}">documentation for v1</a> for more details on the API that supports the <a href="%{rda_standard_url}">RDA Common metadata standard for DMPs.</a>').html_safe % { api_v1_wiki: api_wikis[:v1], rda_standard_url: 'https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard' } %></a>
     </div>
-    <div class="form-control mb-3 col-xs-8">
+    <div class="form-group mb-3 col-xs-8">
       <%= link_to _("Regenerate token"),
                   refresh_token_user_path(user),
-                  class: "btn btn-secondary", remote: true %>
+                  class: "btn btn-default", remote: true %>
     </div>
   </div>
 </div>

--- a/app/views/devise/registrations/_legacy_api_token.html.erb
+++ b/app/views/devise/registrations/_legacy_api_token.html.erb
@@ -1,0 +1,25 @@
+<%# locals: user %>
+
+<% api_wikis = Rails.configuration.x.application.api_documentation_urls %>
+<div id="legacy-api-token" class="col-xs-12">
+  <div class="form-control mb-3 col-xs-8">
+    <%= label_tag(:api_token, _('Access token'), class: 'form-label') %>
+    <% if user.api_token.present? %>
+      <%= user.api_token %>
+    <% else %>
+      <%= _("Click the button below to generate an API token") %>
+    <% end %>
+  </div>
+  <div class="form-control mb-3 col-xs-12">
+    <%= label_tag(:api_information, _('Documentation'), class: 'form-label') %>
+    <br>
+    <%= _('See the <a href="%{api_v0_wiki}">documentation for v0</a> for more details on the original API which includes access to statistics, the full text of plans and the ability to connect users with departments.').html_safe % { api_v0_wiki: api_wikis[:v0] } %></a>
+    <br><br>
+    <%= _('See the <a href="%{api_v1_wiki}">documentation for v1</a> for more details on the API that supports the <a href="%{rda_standard_url}">RDA Common metadata standard for DMPs.</a>').html_safe % { api_v1_wiki: api_wikis[:v1], rda_standard_url: 'https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard' } %></a>
+  </div>
+  <div class="form-control mb-3 col-xs-8">
+    <%= link_to _("Regenerate token"),
+                refresh_token_user_path(user),
+                class: "btn btn-secondary", remote: true %>
+  </div>
+</div>

--- a/app/views/devise/registrations/_legacy_api_token.html.erb
+++ b/app/views/devise/registrations/_legacy_api_token.html.erb
@@ -3,7 +3,7 @@
 <% api_wikis = Rails.configuration.x.application.api_documentation_urls %>
 <div id="legacy-api-token" class="panel mb-4" style="border: 1px solid #0a0a0a">
   <div class="nav nav-tabs">
-    <%= _('Legacy API') %>
+    <span style="margin-left: 12px;"><%= _('Legacy API') %></span>
   </div>
   <div class="panel-body">
     <div class="form-group mb-3 col-xs-8">

--- a/app/views/devise/registrations/_legacy_api_token.html.erb
+++ b/app/views/devise/registrations/_legacy_api_token.html.erb
@@ -1,25 +1,30 @@
 <%# locals: user %>
 
 <% api_wikis = Rails.configuration.x.application.api_documentation_urls %>
-<div id="legacy-api-token" class="col-xs-12">
-  <div class="form-control mb-3 col-xs-8">
-    <%= label_tag(:api_token, _('Access token'), class: 'form-label') %>
-    <% if user.api_token.present? %>
-      <%= user.api_token %>
-    <% else %>
-      <%= _("Click the button below to generate an API token") %>
-    <% end %>
+<div id="legacy-api-token" class="card mb-4">
+  <div class="card-heading">
+    <%= _('Legacy API') %>
   </div>
-  <div class="form-control mb-3 col-xs-12">
-    <%= label_tag(:api_information, _('Documentation'), class: 'form-label') %>
-    <br>
-    <%= _('See the <a href="%{api_v0_wiki}">documentation for v0</a> for more details on the original API which includes access to statistics, the full text of plans and the ability to connect users with departments.').html_safe % { api_v0_wiki: api_wikis[:v0] } %></a>
-    <br><br>
-    <%= _('See the <a href="%{api_v1_wiki}">documentation for v1</a> for more details on the API that supports the <a href="%{rda_standard_url}">RDA Common metadata standard for DMPs.</a>').html_safe % { api_v1_wiki: api_wikis[:v1], rda_standard_url: 'https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard' } %></a>
-  </div>
-  <div class="form-control mb-3 col-xs-8">
-    <%= link_to _("Regenerate token"),
-                refresh_token_user_path(user),
-                class: "btn btn-secondary", remote: true %>
+  <div class="card-body">
+    <div class="form-control mb-3 col-xs-8">
+      <%= label_tag(:api_token, _('Access token'), class: 'form-label') %>
+      <% if user.api_token.present? %>
+        <code><%= user.api_token %></code>
+      <% else %>
+        <%= _("Click the button below to generate an API token") %>
+      <% end %>
+    </div>
+    <div class="form-control mb-3 col-xs-12">
+      <%= label_tag(:api_information, _('Documentation'), class: 'form-label') %>
+      <br>
+      <%= _('See the <a href="%{api_v0_wiki}">documentation for v0</a> for more details on the original API which includes access to statistics, the full text of plans and the ability to connect users with departments.').html_safe % { api_v0_wiki: api_wikis[:v0] } %></a>
+      <br><br>
+      <%= _('See the <a href="%{api_v1_wiki}">documentation for v1</a> for more details on the API that supports the <a href="%{rda_standard_url}">RDA Common metadata standard for DMPs.</a>').html_safe % { api_v1_wiki: api_wikis[:v1], rda_standard_url: 'https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard' } %></a>
+    </div>
+    <div class="form-control mb-3 col-xs-8">
+      <%= link_to _("Regenerate token"),
+                  refresh_token_user_path(user),
+                  class: "btn btn-secondary", remote: true %>
+    </div>
   </div>
 </div>

--- a/app/views/devise/registrations/_v2_api_token.html.erb
+++ b/app/views/devise/registrations/_v2_api_token.html.erb
@@ -1,0 +1,21 @@
+<%# locals: user %>
+
+<% token = Api::V2::InternalUserAccessTokenService.for_user(user) %>
+<div id="v2-api-token" class="col-xs-12">
+  <div class="form-control mb-3 col-xs-8">
+    <%= label_tag(:api_token, _('Access token'), class: 'form-label') %>
+    <% if token.present? %>
+      <code><%= token.token %></code>
+    <% else %>
+      <%= _("Click the button below to generate an API token") %>
+    <% end %>
+  </div>
+
+  <div class="form-control mb-3 col-xs-8">
+    <%= link_to _("Regenerate token"),
+                api_v2_internal_user_access_token_path(format: :js),
+                method: :post,
+                class: 'btn btn-secondary',
+                remote: true %>
+  </div>
+</div>

--- a/app/views/devise/registrations/_v2_api_token.html.erb
+++ b/app/views/devise/registrations/_v2_api_token.html.erb
@@ -1,21 +1,26 @@
 <%# locals: user %>
 
 <% token = Api::V2::InternalUserAccessTokenService.for_user(user) %>
-<div id="v2-api-token" class="col-xs-12">
-  <div class="form-control mb-3 col-xs-8">
-    <%= label_tag(:api_token, _('Access token'), class: 'form-label') %>
-    <% if token.present? %>
-      <code><%= token.token %></code>
-    <% else %>
-      <%= _("Click the button below to generate an API token") %>
-    <% end %>
+<div id="v2-api-token" class="card mb-4">
+  <div class="card-heading">
+    <%= _('V2 API') %>
   </div>
+  <div class="card-body">
+    <div class="form-control mb-3 col-xs-8">
+      <%= label_tag(:api_token, _('Access token'), class: 'form-label') %>
+      <% if token.present? %>
+        <code><%= token.token %></code>
+      <% else %>
+        <%= _("Click the button below to generate an API token") %>
+      <% end %>
+    </div>
 
-  <div class="form-control mb-3 col-xs-8">
-    <%= link_to _("Regenerate token"),
-                api_v2_internal_user_access_token_path(format: :js),
-                method: :post,
-                class: 'btn btn-secondary',
-                remote: true %>
+    <div class="form-control mb-3 col-xs-8">
+      <%= link_to _("Regenerate token"),
+                  api_v2_internal_user_access_token_path(format: :js),
+                  method: :post,
+                  class: 'btn btn-secondary',
+                  remote: true %>
+    </div>
   </div>
 </div>

--- a/app/views/devise/registrations/_v2_api_token.html.erb
+++ b/app/views/devise/registrations/_v2_api_token.html.erb
@@ -23,11 +23,11 @@
       </div>
 
       <div class="form-group mb-3 col-xs-8">
-        <%= link_to _("Regenerate token"),
-                    api_v2_internal_user_access_token_path,
-                    method: :post,
-                    class: 'btn btn-default',
-                    remote: true %>
+        <%= button_tag _("Regenerate token"),
+              type: :submit,
+              class: "btn btn-default",
+              disabled: token.present?,
+              data: { remote: true, url: api_v2_internal_user_access_token_path, method: :post } %>
       </div>
     <% else %>
       <div class="alert alert-warning">

--- a/app/views/devise/registrations/_v2_api_token.html.erb
+++ b/app/views/devise/registrations/_v2_api_token.html.erb
@@ -1,26 +1,33 @@
 <%# locals: user %>
 
-<% token = Api::V2::InternalUserAccessTokenService.for_user(user) %>
 <div id="v2-api-token" class="card mb-4">
   <div class="card-heading">
     <%= _('V2 API') %>
   </div>
   <div class="card-body">
-    <div class="form-control mb-3 col-xs-8">
-      <%= label_tag(:api_token, _('Access token'), class: 'form-label') %>
-      <% if token.present? %>
-        <code><%= token.token %></code>
-      <% else %>
-        <%= _("Click the button below to generate an API token") %>
-      <% end %>
-    </div>
+    <% if Api::V2::InternalUserAccessTokenService.application_present? %>
+      <% token = Api::V2::InternalUserAccessTokenService.for_user(user) %>
+      <div class="form-control mb-3 col-xs-8">
+        <%= label_tag(:api_token, _('Access token'), class: 'form-label') %>
+        <% if token.present? %>
+          <code><%= token.token %></code>
+        <% else %>
+          <%= _("Click the button below to generate an API token") %>
+        <% end %>
+      </div>
 
-    <div class="form-control mb-3 col-xs-8">
-      <%= link_to _("Regenerate token"),
-                  api_v2_internal_user_access_token_path(format: :js),
-                  method: :post,
-                  class: 'btn btn-secondary',
-                  remote: true %>
-    </div>
+      <div class="form-control mb-3 col-xs-8">
+        <%= link_to _("Regenerate token"),
+                    api_v2_internal_user_access_token_path(format: :js),
+                    method: :post,
+                    class: 'btn btn-secondary',
+                    remote: true %>
+      </div>
+    <% else %>
+      <div class="alert alert-warning">
+        <%= _("V2 API token service is currently unavailable. Please contact us for help.") %>
+        <%= mail_to Rails.application.config.x.organisation.helpdesk_email %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/devise/registrations/_v2_api_token.html.erb
+++ b/app/views/devise/registrations/_v2_api_token.html.erb
@@ -1,13 +1,13 @@
 <%# locals: user %>
 
-<div id="v2-api-token" class="card mb-4">
-  <div class="card-heading">
+<div id="v2-api-token" class="panel mb-4" style="border: 1px solid #0a0a0a">
+  <div class="nav nav-tabs">
     <%= _('V2 API') %>
   </div>
-  <div class="card-body">
+  <div class="panel-body">
     <% if Api::V2::InternalUserAccessTokenService.application_present? %>
       <% token = Api::V2::InternalUserAccessTokenService.for_user(user) %>
-      <div class="form-control mb-3 col-xs-8">
+      <div class="form-group mb-3 col-xs-8">
         <%= label_tag(:api_token, _('Access token'), class: 'form-label') %>
         <% if token.present? %>
           <code><%= token.token %></code>
@@ -16,11 +16,11 @@
         <% end %>
       </div>
 
-      <div class="form-control mb-3 col-xs-8">
+      <div class="form-group mb-3 col-xs-8">
         <%= link_to _("Regenerate token"),
                     api_v2_internal_user_access_token_path,
                     method: :post,
-                    class: 'btn btn-secondary',
+                    class: 'btn btn-default',
                     remote: true %>
       </div>
     <% else %>

--- a/app/views/devise/registrations/_v2_api_token.html.erb
+++ b/app/views/devise/registrations/_v2_api_token.html.erb
@@ -6,13 +6,19 @@
   </div>
   <div class="panel-body">
     <% if Api::V2::InternalUserAccessTokenService.application_present? %>
-      <% token = Api::V2::InternalUserAccessTokenService.for_user(user) %>
       <div class="form-group mb-3 col-xs-8">
         <%= label_tag(:api_token, _('Access token'), class: 'form-label') %>
         <% if token.present? %>
-          <code><%= token.token %></code>
+          <code><%= token %></code>
+          <div class="alert alert-warning">
+            <%= _( "Please copy this token now and store it somewhere safely." ) %><br>
+            <%= _( "It will disappear after you leave or refresh this page." ) %>
+          </div>
         <% else %>
-          <%= _("Click the button below to generate an API token") %>
+          <%= _( "Click the button below to generate an API token" ) %><br>
+          <div class="alert alert-warning">
+            <%= _("If you previously generated and saved a token, please continue using that token.") %>
+          </div>
         <% end %>
       </div>
 

--- a/app/views/devise/registrations/_v2_api_token.html.erb
+++ b/app/views/devise/registrations/_v2_api_token.html.erb
@@ -2,7 +2,7 @@
 
 <div id="v2-api-token" class="panel mb-4" style="border: 1px solid #0a0a0a">
   <div class="nav nav-tabs">
-    <%= _('V2 API') %>
+    <span style="margin-left: 12px;"><%= _('V2 API') %></span>
   </div>
   <div class="panel-body">
     <% if Api::V2::InternalUserAccessTokenService.application_present? %>

--- a/app/views/devise/registrations/_v2_api_token.html.erb
+++ b/app/views/devise/registrations/_v2_api_token.html.erb
@@ -18,7 +18,7 @@
 
       <div class="form-control mb-3 col-xs-8">
         <%= link_to _("Regenerate token"),
-                    api_v2_internal_user_access_token_path(format: :js),
+                    api_v2_internal_user_access_token_path,
                     method: :post,
                     class: 'btn btn-secondary',
                     remote: true %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -18,7 +18,7 @@
         </li>
         <li role="api-details" class="nav-item">
           <a href="#api-details" role="tab" class="nav-link"
-              aria-controls="api-details" data-bs-toggle="tab"><%= _('API Access') %></a>
+              aria-controls="api-details" data-toggle="tab"><%= _('API Access') %></a>
         </li>
         <li role="notification-preferences" class="nav-item">
           <a href="#notification-preferences" role="tab" class="nav-link"
@@ -42,8 +42,8 @@
           </div>
         </div>
         <div id="api-details" role="tabpanel" class="tab-pane">
-          <div class="card card-default">
-            <div class="card-body">
+          <div class="panel panel-default">
+            <div class="panel-body">
               <%= render partial: 'devise/registrations/api_token', locals: { user: @user } %>
             </div>
           </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -16,12 +16,10 @@
           <a href="#password-details" role="tab" class="nav-link"
              aria-controls="password-details" data-toggle="tab"><%= _('Password') %></a>
         </li>
-        <% if @user.can_use_api? %>
-          <li role="api-details" class="nav-item">
-            <a href="#api-details" role="tab" class="nav-link"
-               aria-controls="api-details" data-toggle="tab"><%= _('API Access') %></a>
-          </li>
-        <% end %>
+        <li role="api-details" class="nav-item">
+          <a href="#api-details" role="tab" class="nav-link"
+              aria-controls="api-details" data-bs-toggle="tab"><%= _('API Access') %></a>
+        </li>
         <li role="notification-preferences" class="nav-item">
           <a href="#notification-preferences" role="tab" class="nav-link"
              aria-controls="notification-preferences" data-toggle="tab"><%= _('Notification Preferences') %></a>
@@ -43,15 +41,13 @@
             </div>
           </div>
         </div>
-        <% if @user.can_use_api? %>
-          <div id="api-details" role="tabpanel" class="tab-pane">
-            <div class="panel panel-default">
-              <div class="panel-body">
-                <%= render partial: 'devise/registrations/api_token', locals: { user: @user } %>
-              </div>
+        <div id="api-details" role="tabpanel" class="tab-pane">
+          <div class="card card-default">
+            <div class="card-body">
+              <%= render partial: 'devise/registrations/api_token', locals: { user: @user } %>
             </div>
           </div>
-        <% end %>
+        </div>
         <div id="notification-preferences" role="tabpanel" class="tab-pane">
           <div class="panel panel-default">
             <div class="panel-body">

--- a/app/views/users/refresh_token.js.erb
+++ b/app/views/users/refresh_token.js.erb
@@ -1,6 +1,6 @@
 var msg = '<%= @success ? _("Successfully regenerate your API token.") : _("Unable to regenerate your API token.") %>';
 
-var context = $('#api-token');
+var context = $('#api-tokens');
 context.html('<%= escape_javascript(render partial: "/devise/registrations/api_token", locals: { user: current_user }) %>');
 renderNotice(msg);
 toggleSpinner(false);

--- a/app/views/users/refresh_token.js.erb
+++ b/app/views/users/refresh_token.js.erb
@@ -1,6 +1,8 @@
+// This view is called by both InternalUserAccessTokensController#create (provides @v2_token)
+// and UsersController#refresh_token (does not provide @v2_token).
 var msg = '<%= @success ? _("Successfully regenerated your API token.") : _("Unable to regenerate your API token.") %>';
 
 var context = $('#api-tokens');
-context.html('<%= escape_javascript(render partial: "/devise/registrations/api_token", locals: { user: current_user }) %>');
+context.html('<%= escape_javascript(render partial: "/devise/registrations/api_token", locals: { user: current_user, v2_token: @v2_token }) %>');
 renderNotice(msg);
 toggleSpinner(false);

--- a/app/views/users/refresh_token.js.erb
+++ b/app/views/users/refresh_token.js.erb
@@ -1,4 +1,4 @@
-var msg = '<%= @success ? _("Successfully regenerate your API token.") : _("Unable to regenerate your API token.") %>';
+var msg = '<%= @success ? _("Successfully regenerated your API token.") : _("Unable to regenerate your API token.") %>';
 
 var context = $('#api-tokens');
 context.html('<%= escape_javascript(render partial: "/devise/registrations/api_token", locals: { user: current_user }) %>');

--- a/config/initializers/_dmproadmap.rb
+++ b/config/initializers/_dmproadmap.rb
@@ -64,6 +64,8 @@ module DMPRoadmap
 
     # Used throughout the system via ApplicationService.application_name
     config.x.application.name = 'DMP Assistant'
+    # Name of the internal Doorkeeper OAuth application for v2 API access tokens
+    config.x.application.internal_oauth_app_name = 'Internal v2 API Client'
     # Used as the default domain when 'archiving' (aka anonymizing) a user account
     # for example `jane.doe@uni.edu` becomes `1234@removed_accounts-example.org`
     config.x.application.archived_accounts_email_suffix = '@removed_accounts-example.org'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -216,6 +216,7 @@ Rails.application.routes.draw do
 
       resources :plans, only: %i[index show]
       resources :templates, only: :index
+      resource :internal_user_access_token, only: :create
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -216,7 +216,7 @@ Rails.application.routes.draw do
 
       resources :plans, only: %i[index show]
       resources :templates, only: :index
-      resource :internal_user_access_token, only: :create
+      resource :internal_user_access_token, only: :create, defaults: { format: :js }
     end
   end
 

--- a/lib/tasks/doorkeeper.rake
+++ b/lib/tasks/doorkeeper.rake
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+namespace :doorkeeper do
+  desc 'Ensure internal OAuth application exists'
+  task ensure_internal_app: :environment do
+    app = Doorkeeper::Application.find_or_create_by!(
+      name: Rails.application.config.x.application.internal_oauth_app_name
+    ) do |a|
+      a.scopes = 'read'
+      a.confidential = true
+      # redirect_uri value is only used as a placeholder here (required by Doorkeeper).
+      # Tokens are minted server-side for already-authenticated first-party users.
+      # No redirect, authorization code, or third-party client is involved.
+      a.redirect_uri = "#{Rails.application.routes.url_helpers.root_url}oauth/callback"
+    end
+
+    puts "Internal OAuth app ready (id=#{app.id}, uid=#{app.uid})"
+  end
+end

--- a/lib/tasks/doorkeeper.rake
+++ b/lib/tasks/doorkeeper.rake
@@ -8,10 +8,6 @@ namespace :doorkeeper do
     ) do |a|
       a.scopes = 'read'
       a.confidential = true
-      # redirect_uri value is only used as a placeholder here (required by Doorkeeper).
-      # Tokens are minted server-side for already-authenticated first-party users.
-      # No redirect, authorization code, or third-party client is involved.
-      a.redirect_uri = "#{Rails.application.routes.url_helpers.root_url}oauth/callback"
     end
 
     puts "Internal OAuth app ready (id=#{app.id}, uid=#{app.uid})"

--- a/spec/requests/api/v2/internal_user_access_tokens_controller_spec.rb
+++ b/spec/requests/api/v2/internal_user_access_tokens_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Api::V2::InternalUserAccessTokensController do
 
   describe 'POST #create' do
     def post_create_token
-      post api_v2_internal_user_access_token_path(format: :js)
+      post api_v2_internal_user_access_token_path
     end
 
     context 'when user is not authenticated' do

--- a/spec/requests/api/v2/internal_user_access_tokens_controller_spec.rb
+++ b/spec/requests/api/v2/internal_user_access_tokens_controller_spec.rb
@@ -13,16 +13,19 @@ RSpec.describe Api::V2::InternalUserAccessTokensController do
     end
 
     context 'when user is not authenticated' do
-      # In production, CSRF protection would reject the request with a 422 error
-      # before it reaches Pundit. However, RSpec bypasses CSRF checks, so this
-      # test verifies that Pundit raises NotDefinedError when authorize is called
-      # with nil. This error won't occur in production due to CSRF protection.
-      it 'raises Pundit::NotDefinedError and does not create a token' do
+      before do
+        # Enable CSRF protection for this test
+        allow_any_instance_of(ActionController::Base).to receive(:protect_against_forgery?).and_return(true)
+      end
+
+      # NOTE: In production, CSRF protection will reject unauthenticated
+      #       POST requests before Pundit authorization is reached.
+      # NOTE: When `current_user == nil`, `authorize current_user, :internal_user_v2_access_token?`
+      #       raises a Pundit error. However, the CSRF exception is raised first.
+      it 'rejects the request with 422 due to CSRF' do
         expect do
-          expect do
-            post_create_token
-          end.to raise_error(Pundit::NotDefinedError)
-        end.not_to change { Doorkeeper::AccessToken.count }
+          post_create_token
+        end.to raise_error(ActionController::InvalidAuthenticityToken)
       end
     end
 
@@ -41,11 +44,11 @@ RSpec.describe Api::V2::InternalUserAccessTokensController do
         end.to change { Doorkeeper::AccessToken.count }.by(1)
       end
 
-      it 'assigns the token' do
+      it 'assigns the plaintext token' do
         post_create_token
 
-        expect(assigns(:token)).to be_a(Doorkeeper::AccessToken)
-        expect(assigns(:token).resource_owner_id).to eq(user.id)
+        expect(assigns(:v2_token)).to be_a(String)
+        expect(assigns(:v2_token)).not_to be_blank
       end
 
       it 'renders the refresh_token template' do

--- a/spec/requests/api/v2/internal_user_access_tokens_controller_spec.rb
+++ b/spec/requests/api/v2/internal_user_access_tokens_controller_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V2::InternalUserAccessTokensController do
+  let(:user) { create(:user) }
+  let(:app_name) { Rails.application.config.x.application.internal_oauth_app_name }
+  let!(:oauth_app) { create(:oauth_application, name: app_name) }
+
+  describe 'POST #create' do
+    def post_create_token
+      post api_v2_internal_user_access_token_path(format: :js)
+    end
+
+    context 'when user is not authenticated' do
+      # In production, CSRF protection would reject the request with a 422 error
+      # before it reaches Pundit. However, RSpec bypasses CSRF checks, so this
+      # test verifies that Pundit raises NotDefinedError when authorize is called
+      # with nil. This error won't occur in production due to CSRF protection.
+      it 'raises Pundit::NotDefinedError and does not create a token' do
+        expect do
+          expect do
+            post_create_token
+          end.to raise_error(Pundit::NotDefinedError)
+        end.not_to change { Doorkeeper::AccessToken.count }
+      end
+    end
+
+    context 'when user is authenticated' do
+      before { sign_in(user) }
+
+      it 'rotates the user token' do
+        post_create_token
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'creates a new token' do
+        expect do
+          post_create_token
+        end.to change { Doorkeeper::AccessToken.count }.by(1)
+      end
+
+      it 'assigns the token' do
+        post_create_token
+
+        expect(assigns(:token)).to be_a(Doorkeeper::AccessToken)
+        expect(assigns(:token).resource_owner_id).to eq(user.id)
+      end
+
+      it 'renders the refresh_token template' do
+        post_create_token
+
+        expect(response).to render_template('users/refresh_token')
+      end
+
+      context 'when a token already exists' do
+        let!(:old_token) do
+          create(:oauth_access_token, application: oauth_app, resource_owner_id: user.id, scopes: 'read')
+        end
+
+        it 'revokes the old token' do
+          post_create_token
+
+          old_token.reload
+          expect(old_token.revoked_at).not_to be_nil
+        end
+
+        it 'creates a new token' do
+          post_create_token
+
+          new_token = assigns(:token)
+          expect(new_token).not_to eq(old_token)
+        end
+      end
+    end
+
+    context 'when the internal OAuth application is missing' do
+      before do
+        sign_in(user)
+        oauth_app.destroy
+      end
+
+      it 'raises a StandardError' do
+        expect do
+          post_create_token
+        end.to raise_error(StandardError, /not found/)
+      end
+    end
+  end
+end

--- a/spec/services/api/v2/internal_user_access_token_service_spec.rb
+++ b/spec/services/api/v2/internal_user_access_token_service_spec.rb
@@ -11,56 +11,46 @@ RSpec.describe Api::V2::InternalUserAccessTokenService do
     create(:oauth_access_token, application: oauth_app, resource_owner_id: user.id, scopes: 'read')
   end
 
-  describe '#for_user' do
-    context 'when a token exists for the user' do
-      let!(:access_token) do
-        create_internal_user_access_token
-      end
-
-      it 'returns the access token' do
-        token = described_class.for_user(user)
-        expect(token).to be_present
-        expect(token.resource_owner_id).to eq(user.id)
-      end
-    end
-
-    context 'when no token exists for the user' do
-      it 'returns nil' do
-        token = described_class.for_user(user)
-        expect(token).to be_nil
-      end
-    end
-  end
-
   describe '#rotate!' do
-    def rotate_token_expectations(new_token, old_token = nil) # rubocop:disable Metrics/AbcSize
-      expect(new_token).to be_persisted
+    def rotate_token_expectations(plaintext_token, old_token = nil) # rubocop:disable Metrics/AbcSize
+      # Doorkeeper hashes token via Digest::SHA256
+      hashed = Digest::SHA256.hexdigest(plaintext_token)
+      new_token = Doorkeeper::AccessToken.find_by!(token: hashed)
+      expect(new_token).to be_present
       expect(new_token.resource_owner_id).to eq(user.id)
       expect(new_token.revoked_at).to be_nil
       expect(new_token.scopes.to_s).to include('read')
-      return unless old_token
+      expect(old_token.revoked_at).not_to be_nil if old_token
+    end
 
-      expect(new_token).not_to eq(old_token)
-      expect(old_token.revoked_at).not_to be_nil
+    shared_examples 'token rotation' do |has_old_token|
+      it "#{if has_old_token
+              'revokes the old token and creates a new one'
+            else
+              'creates a new token'
+            end}
+      (returns plaintext)" do
+        plaintext_token = nil
+        # Ensure .rotate!(user) creates a new AccessToken db entry for user
+        expect { plaintext_token = described_class.rotate!(user) }
+          .to change { Doorkeeper::AccessToken.where(resource_owner_id: user.id).count }
+          .by(1)
+        if has_old_token
+          old_token.reload
+          rotate_token_expectations(plaintext_token, old_token)
+        else
+          rotate_token_expectations(plaintext_token)
+        end
+      end
     end
 
     context 'when a token already exists' do
-      let!(:old_token) do
-        create_internal_user_access_token
-      end
-
-      it 'revokes the old token and creates a new one' do
-        new_token = described_class.rotate!(user)
-        old_token.reload
-        rotate_token_expectations(new_token, old_token)
-      end
+      let!(:old_token) { create_internal_user_access_token }
+      include_examples 'token rotation', true
     end
 
     context 'when no token exists' do
-      it 'creates a new token' do
-        token = described_class.rotate!(user)
-        rotate_token_expectations(token)
-      end
+      include_examples 'token rotation', false
     end
   end
 

--- a/spec/services/api/v2/internal_user_access_token_service_spec.rb
+++ b/spec/services/api/v2/internal_user_access_token_service_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V2::InternalUserAccessTokenService do
+  let(:user) { create(:user) }
+  let(:app_name) { Rails.application.config.x.application.internal_oauth_app_name }
+  let!(:oauth_app) { create(:oauth_application, name: app_name) }
+
+  def create_internal_user_access_token
+    create(:oauth_access_token, application: oauth_app, resource_owner_id: user.id, scopes: 'read')
+  end
+
+  describe '#for_user' do
+    context 'when a token exists for the user' do
+      let!(:access_token) do
+        create_internal_user_access_token
+      end
+
+      it 'returns the access token' do
+        token = described_class.for_user(user)
+        expect(token).to be_present
+        expect(token.resource_owner_id).to eq(user.id)
+      end
+    end
+
+    context 'when no token exists for the user' do
+      it 'returns nil' do
+        token = described_class.for_user(user)
+        expect(token).to be_nil
+      end
+    end
+  end
+
+  describe '#rotate!' do
+    def rotate_token_expectations(new_token, old_token = nil) # rubocop:disable Metrics/AbcSize
+      expect(new_token).to be_persisted
+      expect(new_token.resource_owner_id).to eq(user.id)
+      expect(new_token.revoked_at).to be_nil
+      expect(new_token.scopes.to_s).to include('read')
+      return unless old_token
+
+      expect(new_token).not_to eq(old_token)
+      expect(old_token.revoked_at).not_to be_nil
+    end
+
+    context 'when a token already exists' do
+      let!(:old_token) do
+        create_internal_user_access_token
+      end
+
+      it 'revokes the old token and creates a new one' do
+        new_token = described_class.rotate!(user)
+        old_token.reload
+        rotate_token_expectations(new_token, old_token)
+      end
+    end
+
+    context 'when no token exists' do
+      it 'creates a new token' do
+        token = described_class.rotate!(user)
+        rotate_token_expectations(token)
+      end
+    end
+  end
+
+  describe '#application_present?' do
+    context 'when the app exists' do
+      it 'returns true' do
+        expect(described_class.application_present?).to be true
+      end
+    end
+
+    context 'when the app does not exist' do
+      before { oauth_app.destroy }
+
+      it 'returns false' do
+        expect(described_class.application_present?).to be false
+      end
+    end
+  end
+end

--- a/spec/views/devise/registrations/_api_token.html.erb_spec.rb
+++ b/spec/views/devise/registrations/_api_token.html.erb_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'devise/registrations/_api_token.html.erb' do
+  let(:app_name) { Rails.application.config.x.application.internal_oauth_app_name }
+  let!(:oauth_app) { create(:oauth_application, name: app_name) }
+
+  before do
+    # Clear memoization between tests
+    Api::V2::InternalUserAccessTokenService.instance_variable_set(:@application, nil)
+  end
+
+  context 'When a user has the `use_api` permission' do
+    it 'renders both the v2 and legacy API token sections' do
+      user = create(:user, :org_admin)
+
+      render partial: 'devise/registrations/api_token', locals: { user: user }
+
+      expect(rendered).to have_selector('#v2-api-token')
+      expect(rendered).to have_selector('#legacy-api-token')
+    end
+  end
+
+  context 'When a user does not have the `use_api` permission' do
+    it 'renders only the v2 API token section' do
+      user = create(:user)
+
+      render partial: 'devise/registrations/api_token', locals: { user: user }
+
+      expect(rendered).to have_selector('#v2-api-token')
+      expect(rendered).not_to have_selector('#legacy-api-token')
+    end
+  end
+end

--- a/spec/views/devise/registrations/_v2_api_token.html.erb_spec.rb
+++ b/spec/views/devise/registrations/_v2_api_token.html.erb_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'devise/registrations/_v2_api_token.html.erb' do
+  let(:user) { create(:user) }
+  let(:app_name) { Rails.application.config.x.application.internal_oauth_app_name }
+
+  context 'when the OAuth application exists' do
+    let!(:oauth_app) { create(:oauth_application, name: app_name) }
+
+    it 'displays the regenerate button' do
+      render partial: 'devise/registrations/v2_api_token', locals: { user: user }
+
+      expect(rendered).to have_link('Regenerate token',
+                                    href: api_v2_internal_user_access_token_path(format: :js))
+    end
+
+    context 'when user has a token' do
+      let!(:token) do
+        create(:oauth_access_token,
+               application: oauth_app,
+               resource_owner_id: user.id,
+               scopes: 'read')
+      end
+
+      it 'displays the token' do
+        render partial: 'devise/registrations/v2_api_token', locals: { user: user }
+
+        expect(rendered).to have_selector('code', text: token.token)
+        expect(rendered).not_to have_content('Click the button below to generate an API token')
+      end
+    end
+
+    context 'when user does not have a token' do
+      it 'displays the generate message' do
+        render partial: 'devise/registrations/v2_api_token', locals: { user: user }
+
+        expect(rendered).to have_content('Click the button below to generate an API token')
+        expect(rendered).not_to have_selector('code')
+      end
+    end
+  end
+
+  context 'when the OAuth application does not exist' do
+    it 'displays the warning message and helpdesk email link' do
+      render partial: 'devise/registrations/v2_api_token', locals: { user: user }
+
+      expect(rendered).to have_selector('.alert-warning')
+      expect(rendered).to have_content('V2 API token service is currently unavailable')
+      expect(rendered).to have_link(href: "mailto:#{Rails.application.config.x.organisation.helpdesk_email}")
+    end
+
+    it 'does not display the token or regenerate button' do
+      render partial: 'devise/registrations/v2_api_token', locals: { user: user }
+
+      expect(rendered).not_to have_link('Regenerate token')
+      expect(rendered).not_to have_selector('code')
+    end
+  end
+end

--- a/spec/views/devise/registrations/_v2_api_token.html.erb_spec.rb
+++ b/spec/views/devise/registrations/_v2_api_token.html.erb_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'devise/registrations/_v2_api_token.html.erb' do
       render partial: 'devise/registrations/v2_api_token', locals: { user: user }
 
       expect(rendered).to have_link('Regenerate token',
-                                    href: api_v2_internal_user_access_token_path(format: :js))
+                                    href: api_v2_internal_user_access_token_path)
     end
 
     context 'when user has a token' do

--- a/spec/views/devise/registrations/_v2_api_token.html.erb_spec.rb
+++ b/spec/views/devise/registrations/_v2_api_token.html.erb_spec.rb
@@ -6,36 +6,32 @@ RSpec.describe 'devise/registrations/_v2_api_token.html.erb' do
   let(:user) { create(:user) }
   let(:app_name) { Rails.application.config.x.application.internal_oauth_app_name }
 
+  def render_token_partial(token: nil)
+    render partial: 'devise/registrations/v2_api_token', locals: { user: user, token: token }
+  end
+
   context 'when the OAuth application exists' do
     let!(:oauth_app) { create(:oauth_application, name: app_name) }
 
-    it 'displays the regenerate button' do
-      render partial: 'devise/registrations/v2_api_token', locals: { user: user }
-
-      expect(rendered).to have_link('Regenerate token',
-                                    href: api_v2_internal_user_access_token_path)
+    it 'displays the regenerate button when no token is present' do
+      render_token_partial(token: nil)
+      expect(rendered).to have_selector('button', text: 'Regenerate token')
     end
 
     context 'when user has a token' do
-      let!(:token) do
-        create(:oauth_access_token,
-               application: oauth_app,
-               resource_owner_id: user.id,
-               scopes: 'read')
-      end
+      let(:plaintext_token) { 'plaintext-token-value' }
 
-      it 'displays the token' do
-        render partial: 'devise/registrations/v2_api_token', locals: { user: user }
-
-        expect(rendered).to have_selector('code', text: token.token)
+      it 'displays the token and disables the regenerate button' do
+        render_token_partial(token: plaintext_token)
+        expect(rendered).to have_selector('code', text: plaintext_token)
         expect(rendered).not_to have_content('Click the button below to generate an API token')
+        expect(rendered).to have_selector('button[disabled]', text: 'Regenerate token')
       end
     end
 
     context 'when user does not have a token' do
       it 'displays the generate message' do
-        render partial: 'devise/registrations/v2_api_token', locals: { user: user }
-
+        render_token_partial(token: nil)
         expect(rendered).to have_content('Click the button below to generate an API token')
         expect(rendered).not_to have_selector('code')
       end
@@ -44,17 +40,15 @@ RSpec.describe 'devise/registrations/_v2_api_token.html.erb' do
 
   context 'when the OAuth application does not exist' do
     it 'displays the warning message and helpdesk email link' do
-      render partial: 'devise/registrations/v2_api_token', locals: { user: user }
-
+      render_token_partial(token: nil)
       expect(rendered).to have_selector('.alert-warning')
       expect(rendered).to have_content('V2 API token service is currently unavailable')
       expect(rendered).to have_link(href: "mailto:#{Rails.application.config.x.organisation.helpdesk_email}")
     end
 
     it 'does not display the token or regenerate button' do
-      render partial: 'devise/registrations/v2_api_token', locals: { user: user }
-
-      expect(rendered).not_to have_link('Regenerate token')
+      render_token_partial(token: nil)
+      expect(rendered).not_to have_selector('button', text: 'Regenerate token')
       expect(rendered).not_to have_selector('code')
     end
   end


### PR DESCRIPTION
# NOTE:
This PR is based off of the following: https://github.com/DMPRoadmap/roadmap/pull/3597. However, that codebase uses Bootstrap 5, whereas this codebase uses Bootstrap 3. To fit the changes to our codebase, the commit [Update API Access UI to BS3 (revert after BS5 upgrade)](https://github.com/portagenetwork/roadmap/pull/1279/commits/b5e9c43adbbdbae33d90c64698f63364e21f5281) was added.

# Changes proposed in this PR:

## Summary
This PR introduces support for issuing internal, user-scoped v2 API access tokens, managed entirely within the application (first-party tokens) for internal users.

## Key Changes
[Create internal Doorkeeper app via rake task](https://github.com/DMPRoadmap/roadmap/pull/3597/commits/e46519f5f36ba1631e8d0381d902dd9ec75649cb)
- Executed via `bundle exec rake doorkeeper:ensure_internal_app`
- Creates a first-party Doorkeeper client for issuing internal v2 API tokens
- Ensures the internal application exists in all environments before token service is used

[Create Api::V2::InternalUserAccessTokenService](https://github.com/DMPRoadmap/roadmap/pull/3597/commits/ccf0f928847631dd985f4f38286158ab2974d6b5)
- This service manages user-scoped v2 API access tokens for internal app users.
  - Tokens are equivalent to first-party Personal Access Tokens (PATs) and are issued directly to authenticated users, bypassing the full OAuth 2.0 authorization_code flow.
  - Supports token creation, rotation, and revocation.
  - Uses Doorkeeper::AccessToken records for consistent scoping, expiry, and revocation handling.
  - Designed strictly for internal usage; third-party OAuth clients are not supported.

[Add "POST /api/v2/internal_user_access_token" action & route](https://github.com/DMPRoadmap/roadmap/pull/3597/commits/797aeb619af043bb4190872b03c5cd176544ee26)
- Adds `Api::V2::InternalUserAccessTokensController#create` with Pundit authorization and routing. Also reuses the existing `users/refresh_token.js.erb` response to update the UI via JS.

- `@success` is read by `app/views/users/refresh_token.js.erb` (similar approach as `UsersController#refresh_token`)

[Add API v2 section to /users/edit#api-details](https://github.com/DMPRoadmap/roadmap/pull/3597/commits/965896b9c2f8ec197a395e2f6d3127795b84d781)
- This change updates `app/views/devise/registrations/_api_token.html.erb` to include support for the v2 API access token. Existing v0/v1 token support is retained.
  - Introduce V2 token lookup via `Api::V2::InternalUserAccessTokenService`
  - Display a dedicated V2 API access token section with its own regeneration action

[Expose API Access tab to all users / restrict legacy token rendering](https://github.com/DMPRoadmap/roadmap/pull/3597/commits/3782f0268fcdc597139c08e221e53696d88a4173)
- The API Access tab is now visible to all users to support the new v2 API token,
which is accessible to everyone.

[Add test coverage for internal v2 token generation](https://github.com/DMPRoadmap/roadmap/pull/3597/commits/8ef06e2c10f8cd1e436d9dde1a5af1e39d7e4d2c)
- Add request specs for InternalUserAccessTokensController
  - Include both authenticated & unauthenticated user scenarios
  - Include both present & absent internal OAuth app scenarios

- Add service specs for InternalUserAccessTokenService
  - Test token retrieval, rotation, and OAuth app presence
  - Verify old token revocation when rotating

- Add view specs for API token partials
  - Test legacy partial rendering based on `user.can_use_api?`
  - Test OAuth application availability scenarios
