### PR TITLE
refactor: restrict loading of passwordChecklist.js

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -61,7 +61,6 @@ import './src/publicTemplates/show';
 import './src/researchOutputs/form';
 import './src/roles/edit';
 import './src/shared/createAccountForm';
-import './src/shared/passwordChecklist';
 import './src/shared/signInForm';
 import './src/usage/index';
 import './src/users/adminGrantPermissions';

--- a/app/javascript/packs/passwordChecklist.js
+++ b/app/javascript/packs/passwordChecklist.js
@@ -1,0 +1,1 @@
+import '../src/shared/passwordChecklist';

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -1,3 +1,4 @@
+<%= javascript_include_tag 'passwordChecklist', defer: true %>
 <% title _('Create an account to view the plan') %>
 <div class="row">
   <div class="col-md-12">

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,3 +1,4 @@
+<%= javascript_include_tag 'passwordChecklist', defer: true %>
 <% title _('Change your password') %>
 <div class="row">
   <div class="col-md-12">

--- a/app/views/devise/registrations/_password_details.html.erb
+++ b/app/views/devise/registrations/_password_details.html.erb
@@ -1,3 +1,4 @@
+<%= javascript_include_tag 'passwordChecklist', defer: true %>
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: {method: :put, id: "password_details_registration_form" }) do |f| %>
 
   <p class="form-control-static"><%= _('If you would like to change your password please complete the following fields.') %></p>

--- a/app/views/shared/_create_account_form.html.erb
+++ b/app/views/shared/_create_account_form.html.erb
@@ -1,3 +1,4 @@
+<%= javascript_include_tag 'passwordChecklist', defer: true %>
 <%= form_for resource, namespace: 'new', url: registration_path("user"), html: {autocomplete: "on", id: "create_account_form"} do |f| %>
 
   <div class="form-group">

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -18,6 +18,7 @@ module.exports = {
   },
   entry: {
     application: './app/javascript/application.js',
+    passwordChecklist: './app/javascript/packs/passwordChecklist.js',
   },
   optimization: {
     moduleIds: 'deterministic',


### PR DESCRIPTION
Fixes # (Initial addressment of https://github.com/portagenetwork/roadmap/issues/711)

# Changes proposed in this PR:

This change only loads `passwordChecklist.js` where needed, improving performance and maintainability.
- Removed global import of `passwordChecklist.js` from `application.js` to reduce bundle size.
- Created a dedicated entry point (`packs/passwordChecklist.js`) for `passwordChecklist`.
- Updated `config/webpack/webpack.config.js` to build `passwordChecklist.js` as a separate asset.
- Added `<%= javascript_include_tag 'passwordChecklist', defer: true %>` to the following files:
  - `app/views/devise/invitations/edit.html.erb`
  - `app/views/devise/passwords/edit.html.erb`
  - `app/views/devise/registrations/_password_details.html.erb`
  - `app/views/shared/_create_account_form.html.erb`