### PR TITLE
`bundle update httparty`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 
  - chore(deps): bump nginx from 1.29.4-alpine to 1.29.5-alpine [#1271](https://github.com/portagenetwork/roadmap/pull/1271)
 
- - Revert chore(deps): bump httparty from 0.23.1 to 0.24.0 [#1253](https://github.com/portagenetwork/roadmap/pull/1253)
+ - `bundle update httparty` [#1291](https://github.com/portagenetwork/roadmap/pull/1291)
    - (See [#1288](https://github.com/portagenetwork/roadmap/pull/1288) for more)
 
 ## [4.1.1+portage-4.6.2]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,7 @@ GEM
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
       rouge (>= 1.0.0)
-    bigdecimal (3.2.2)
+    bigdecimal (3.3.1)
     bindata (2.5.0)
     bindex (0.8.1)
     binding_of_caller (1.0.1)
@@ -260,7 +260,7 @@ GEM
       actionpack
       nokogiri
       rubyzip (>= 1.0)
-    httparty (0.23.1)
+    httparty (0.24.2)
       csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)


### PR DESCRIPTION
Fixes #1289

Changes proposed in this PR:
- The following Dependabot security PR was previously applied to `deployment-portage`: https://github.com/portagenetwork/roadmap/security/dependabot/248
- However, the change was lost after merging `deployment-portage` back into `integration` (https://github.com/portagenetwork/roadmap/pull/1288)
- This change bumps `httparty` back up to a patched version
