### PR TITLE
Update plan json export to use V2 API Complete plan endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 ### Changed
  - Upgrade ROR API From V1 to V2 [#1247](https://github.com/portagenetwork/roadmap/pull/1247)
 
+ - Update plan json export to use V2 API complete plan endpoint [#1293](https://github.com/portagenetwork/roadmap/pull/1293)
+
 ### Dependency Updates
 
  - chore(deps): bump nginx from 1.29.3-alpine to 1.29.4-alpine [#1246](https://github.com/portagenetwork/roadmap/pull/1246)

--- a/app/controllers/plan_exports_controller.rb
+++ b/app/controllers/plan_exports_controller.rb
@@ -114,8 +114,11 @@ class PlanExportsController < ApplicationController
   end
 
   def show_json
-    json = render_to_string(partial: '/api/v1/plans/show', locals: { plan: @plan })
-    render json: "{\"dmp\":#{json}}"
+    @complete = true
+    @plan = Plan.for_api_v2(current_user.id)
+                .find_by(id: @plan.id)
+    @items = [@plan]
+    render '/api/v2/plans/index', formats: :json
   end
 
   def file_name


### PR DESCRIPTION
Changes proposed in this PR:
- Edit plan json export to use V2 API Complete plan endpoint.
