### PR TITLE
Sanitize questions and answers in V2 API, add link to wiki

### DIFF
--- a/app/presenters/api/v2/plan_presenter.rb
+++ b/app/presenters/api/v2/plan_presenter.rb
@@ -54,7 +54,7 @@ module Api
       end
 
       # Fetch all questions and answers from a plan, regardless of theme
-      def fetch_all_q_and_a
+      def fetch_all_q_and_a # rubocop:disable Metrics/AbcSize
         answers = @plan.answers
         return [] unless answers.present?
 
@@ -66,8 +66,8 @@ module Api
             id: q.id,
             title: "Question #{q.number || q.id}",
             section: q.section&.title,
-            question: q.text.to_s,
-            answer: answer.text.to_s
+            question: ActionView::Base.full_sanitizer.sanitize(q.text.to_s),
+            answer: ActionView::Base.full_sanitizer.sanitize(answer.text.to_s)
           }
         end
       end

--- a/app/views/devise/registrations/_v2_api_token.html.erb
+++ b/app/views/devise/registrations/_v2_api_token.html.erb
@@ -1,4 +1,5 @@
 <%# locals: user %>
+<% api_wikis = Rails.configuration.x.application.api_documentation_urls %>
 
 <div id="v2-api-token" class="panel mb-4" style="border: 1px solid #0a0a0a">
   <div class="nav nav-tabs">
@@ -42,6 +43,11 @@
               class: "btn btn-default",
               disabled: token.present?,
               data: { remote: true, url: api_v2_internal_user_access_token_path, method: :post } %>
+      </div>
+      <div class="form-group mb-3 col-xs-12">
+        <%= label_tag(:api_information, _('Documentation'), class: 'form-label') %>
+        <br>
+        <%= _('See the <a href="%{api_v2_wiki}">documentation for v2</a> for more details on the API.').html_safe % { api_v2_wiki: api_wikis[:v2] } %></a>
       </div>
     <% else %>
       <div class="alert alert-warning">

--- a/config/initializers/_dmproadmap.rb
+++ b/config/initializers/_dmproadmap.rb
@@ -76,7 +76,8 @@ module DMPRoadmap
     # The link to the API documentation - used in emails about the API
     config.x.application.api_documentation_urls = {
       v0: 'https://github.com/DMPRoadmap/roadmap/wiki/API-V0-Documentation',
-      v1: 'https://github.com/DMPRoadmap/roadmap/wiki/API-v1-Documentation'
+      v1: 'https://github.com/DMPRoadmap/roadmap/wiki/API-v1-Documentation',
+      v2: 'https://github.com/portagenetwork/roadmap/wiki/API-v2-Documentation'
     }
     # The links that appear on the home page. Add any number of links
     config.x.application.welcome_links = [


### PR DESCRIPTION
Changes proposed in this PR:
- Sanitize the questions and answers text in the `fetch_all_q_and_a` function for better security and readability.
- Add a link to the V2 API Documentation in the API access tab after the user has generated a token.
