### PR TITLE
Add v2 API documentation to API Access page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
  - Initial v2 API Implementation & Doorkeeper OAuth Integration [#1276](https://github.com/portagenetwork/roadmap/pull/1276) 
 
+ - Add v2 API documentation to API Access page [#1300](https://github.com/portagenetwork/roadmap/pull/1300) 
+
 ### Changed
  - Upgrade ROR API From V1 to V2 [#1247](https://github.com/portagenetwork/roadmap/pull/1247)
 

--- a/app/views/devise/registrations/_legacy_api_token.html.erb
+++ b/app/views/devise/registrations/_legacy_api_token.html.erb
@@ -17,9 +17,15 @@
     <div class="form-group mb-3 col-xs-12">
       <%= label_tag(:api_information, _('Documentation'), class: 'form-label') %>
       <br>
-      <%= _('See the <a href="%{api_v0_wiki}">documentation for v0</a> for more details on the original API which includes access to statistics, the full text of plans and the ability to connect users with departments.').html_safe % { api_v0_wiki: api_wikis[:v0] } %></a>
+      <%= sanitize(_('See the <a href="%{api_v0_wiki}">documentation for v0</a> for more details on the original API which includes access to statistics, the full text of plans and the ability to connect users with departments.') %
+          { api_v0_wiki: api_wikis[:v0] },
+          attributes: %w[href]
+        )%>
       <br><br>
-      <%= _('See the <a href="%{api_v1_wiki}">documentation for v1</a> for more details on the API that supports the <a href="%{rda_standard_url}">RDA Common metadata standard for DMPs.</a>').html_safe % { api_v1_wiki: api_wikis[:v1], rda_standard_url: 'https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard' } %></a>
+      <%= sanitize(_('See the <a href="%{api_v1_wiki}">documentation for v1</a> for more details on the API that supports the <a href="%{rda_standard_url}">RDA Common metadata standard for DMPs.</a>') %
+          { api_v1_wiki: api_wikis[:v1], rda_standard_url: 'https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard' },
+          attributes: %w[href]
+        )%>
     </div>
     <div class="form-group mb-3 col-xs-8">
       <%= link_to _("Regenerate token"),

--- a/app/views/devise/registrations/_v2_api_token.html.erb
+++ b/app/views/devise/registrations/_v2_api_token.html.erb
@@ -1,4 +1,5 @@
 <%# locals: user %>
+<% api_wikis = Rails.configuration.x.application.api_documentation_urls %>
 
 <div id="v2-api-token" class="panel mb-4" style="border: 1px solid #0a0a0a">
   <div class="nav nav-tabs">
@@ -42,6 +43,14 @@
               class: "btn btn-default",
               disabled: token.present?,
               data: { remote: true, url: api_v2_internal_user_access_token_path, method: :post } %>
+      </div>
+      <div class="form-group mb-3 col-xs-12">
+        <%= label_tag(:api_information, _('Documentation'), class: 'form-label') %>
+        <br>
+        <%= sanitize(_('See the <a href="%{api_v2_wiki}">documentation for v2</a> for more details on the API.') %
+          { api_v2_wiki: api_wikis[:v2] },
+          attributes: %w[href]
+        )%>
       </div>
     <% else %>
       <div class="alert alert-warning">

--- a/config/initializers/_dmproadmap.rb
+++ b/config/initializers/_dmproadmap.rb
@@ -76,7 +76,8 @@ module DMPRoadmap
     # The link to the API documentation - used in emails about the API
     config.x.application.api_documentation_urls = {
       v0: 'https://github.com/DMPRoadmap/roadmap/wiki/API-V0-Documentation',
-      v1: 'https://github.com/DMPRoadmap/roadmap/wiki/API-v1-Documentation'
+      v1: 'https://github.com/DMPRoadmap/roadmap/wiki/API-v1-Documentation',
+      v2: 'https://github.com/portagenetwork/roadmap/wiki/API-v2-Documentation'
     }
     # The links that appear on the home page. Add any number of links
     config.x.application.welcome_links = [


### PR DESCRIPTION
Changes proposed in this PR:
- Add link to V2 API documentation in app.
- Update legacy API documentation links to not use `html_safe`.
