### PR TITLE
API v2: Sanitize user-inputted fields in responses

### DIFF
--- a/app/presenters/api/v2/plan_presenter.rb
+++ b/app/presenters/api/v2/plan_presenter.rb
@@ -4,6 +4,8 @@ module Api
   module V2
     # Helper class for the API V2 project / DMP
     class PlanPresenter
+      include Api::V2::SanitizationService
+
       attr_reader :data_contact, :contributors, :costs, :complete_plan_data
 
       def initialize(plan:, complete: false)
@@ -48,8 +50,8 @@ module Api
 
         answers.map do |answer|
           # TODO: Investigate whether question level guidance should be the description
-          { title: answer.question.text, description: nil,
-            currency_code: 'usd', value: answer.text }
+          { title: rich_text(answer.question.text), description: nil,
+            currency_code: 'usd', value: rich_text(answer.text) }
         end
       end
 
@@ -65,9 +67,9 @@ module Api
           {
             id: q.id,
             title: "Question #{q.number || q.id}",
-            section: q.section&.title,
-            question: q.text.to_s,
-            answer: answer.text.to_s
+            section: plain_text(q.section&.title),
+            question: rich_text(q.text),
+            answer: rich_text(answer.text)
           }
         end
       end

--- a/app/presenters/api/v2/research_output_presenter.rb
+++ b/app/presenters/api/v2/research_output_presenter.rb
@@ -4,6 +4,8 @@ module Api
   module V2
     # Helper methods for research outputs
     class ResearchOutputPresenter
+      include Api::V2::SanitizationService
+
       attr_reader :dataset_id, :preservation_statement, :security_and_privacy, :license_start_date,
                   :data_quality_assurance, :distributions, :metadata, :technical_resources
 
@@ -89,7 +91,9 @@ module Api
       end
 
       def format_q_and_a(question, answer)
-        "<strong>Question:</strong> #{question.text}<br><strong>Answer:</strong> #{answer.text}"
+        question = rich_text(question.text)
+        answer = rich_text(answer.text)
+        "<strong>Question:</strong> #{question}<br><strong>Answer:</strong> #{answer}"
       end
     end
   end

--- a/app/presenters/api/v2/template_presenter.rb
+++ b/app/presenters/api/v2/template_presenter.rb
@@ -4,6 +4,8 @@ module Api
   module V2
     # Helper class for the API V2 template info
     class TemplatePresenter
+      include Api::V2::SanitizationService
+
       def initialize(template:)
         @template = template
       end
@@ -11,9 +13,11 @@ module Api
       # If the plan has a grant number then it has been awarded/granted
       # otherwise it is 'planned'
       def title
-        return @template.title unless @template.customization_of.present?
+        title = plain_text(@template.title)
+        return title unless @template.customization_of.present?
 
-        "#{@template.title} - with additional questions for #{@template.org.name}"
+        org_name = plain_text(@template.org.name)
+        "#{title} - with additional questions for #{org_name}"
       end
     end
   end

--- a/app/services/api/v2/sanitization_service.rb
+++ b/app/services/api/v2/sanitization_service.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Api
+  module V2
+    # Sanitization service for API v2 serializers
+    module SanitizationService
+      # NOTE: We use the Rails::HTML5 sanitizer classes directly instead of the ActionView helpers:
+      #
+      #   sanitize(...)                      # from ActionView::Helpers::SanitizeHelper
+      #   ActionView::Base.full_sanitizer    # strips all HTML
+      #
+      # Those helpers expect to run in an ActionView context and can raise errors when
+      # called from plain Ruby classes (e.g., API presenters). Using Rails::HTML5::* works
+      # consistently in presenters, helpers, and Jbuilder.
+      #
+      # We also pass the ActionView sanitizer config so the API follows the same allowlist
+      # (`sanitized_allowed_tags` / `sanitized_allowed_attributes`) as the rest of the app.
+
+      SAFE_LIST_SANITIZER = Rails::HTML5::SafeListSanitizer.new
+      FULL_SANITIZER      = Rails::HTML5::FullSanitizer.new
+
+      # Sanitizes HTML while preserving allowed formatting (e.g., TinyMCE output)
+      def rich_text(value)
+        return nil if value.nil?
+
+        SAFE_LIST_SANITIZER.sanitize(
+          value,
+          tags: Rails.application.config.action_view.sanitized_allowed_tags,
+          attributes: Rails.application.config.action_view.sanitized_allowed_attributes
+        )
+      end
+
+      # Removes all HTML
+      def plain_text(value)
+        return nil if value.nil?
+
+        FULL_SANITIZER.sanitize(value)
+      end
+    end
+  end
+end

--- a/app/views/api/v2/contributors/_show.json.jbuilder
+++ b/app/views/api/v2/contributors/_show.json.jbuilder
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 # locals: contributor, is_contact
-
+@sanitizer ||= Object.new.extend(Api::V2::SanitizationService)
 is_contact ||= false
 
-json.name contributor.is_a?(User) ? contributor.name(false) : contributor.name
+name = contributor.is_a?(User) ? contributor.name(false) : contributor.name
+json.name @sanitizer.plain_text(name)
 json.mbox contributor.email
 
 if !is_contact && contributor.selected_roles.any?

--- a/app/views/api/v2/datasets/_show.json.jbuilder
+++ b/app/views/api/v2/datasets/_show.json.jbuilder
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 # locals: output
+@sanitizer ||= Object.new.extend(Api::V2::SanitizationService)
 
 if output.is_a?(ResearchOutput)
   presenter = Api::V2::ResearchOutputPresenter.new(output: output)
 
   json.type output.output_type
-  json.title output.title
-  json.description output.description
+  json.title @sanitizer.plain_text(output.title)
+  json.description @sanitizer.rich_text(output.description)
   json.personal_data Api::V2::ApiPresenter.boolean_to_yes_no_unknown(value: output.personal_data)
   json.sensitive_data Api::V2::ApiPresenter.boolean_to_yes_no_unknown(value: output.sensitive_data)
   json.issued output.release_date&.to_formatted_s(:iso8601)

--- a/app/views/api/v2/plans/_show.json.jbuilder
+++ b/app/views/api/v2/plans/_show.json.jbuilder
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # locals: plan
+@sanitizer ||= Object.new.extend(Api::V2::SanitizationService)
 
 json.schema 'https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard/tree/master/examples/JSON/JSON-schema/1.0'
 
@@ -20,7 +21,7 @@ json.created plan.created_at.to_formatted_s(:iso8601)
 json.modified plan.updated_at.to_formatted_s(:iso8601)
 
 json.ethical_issues_exist Api::V2::ConversionService.boolean_to_yes_no_unknown(plan.ethical_issues)
-json.ethical_issues_description plan.ethical_issues_description
+json.ethical_issues_description @sanitizer.rich_text(plan.ethical_issues_description)
 json.ethical_issues_report plan.ethical_issues_report
 
 id = presenter.identifier
@@ -65,7 +66,7 @@ unless @minimal
     json.set! :dmproadmap do
       json.template do
         json.id template.id
-        json.title template.title
+        json.title @sanitizer.plain_text(template.title)
       end
     end
 

--- a/app/views/api/v2/templates/index.json.jbuilder
+++ b/app/views/api/v2/templates/index.json.jbuilder
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
+@sanitizer ||= Object.new.extend(Api::V2::SanitizationService)
+
 json.partial! 'api/v2/standard_response', total_items: @total_items
 
 json.items @items do |template|
   presenter = Api::V2::TemplatePresenter.new(template: template)
 
   json.dmp_template do
-    json.title presenter.title
-    json.description template.description
+    json.title @sanitizer.plain_text(presenter.title)
+    json.description @sanitizer.rich_text(template.description)
     json.version template.version
     json.created template.created_at.to_formatted_s(:iso8601)
     json.modified template.updated_at.to_formatted_s(:iso8601)


### PR DESCRIPTION
Introduce `Api::V2::SanitizationService` and apply it to user-supplied / free-text fields across API v2 JSON responses.

- Add `Api::V2::SanitizationService` with:
- `rich_text`: allowlist-based HTML sanitization (preserves permitted formatting)
- `plain_text`: strips all HTML
- Use `Rails::HTML5::SafeListSanitizer` and `Rails::HTML5::FullSanitizer` rather than `ActionView` sanitization helpers, so sanitization works consistently outside a view context (e.g., presenters).
- Reuse the app’s `ActionView` allowlist configuration (`sanitized_allowed_tags` / `sanitized_allowed_attributes`) to match existing sanitization rules.
- Make the sanitizer available to Jbuilder templates
- Specifically, added `@sanitizer = Object.new.extend(Api::V2::SanitizationService)` in `app/views/api/v2/plans/_show.json.jbuilder`.
- Update API v2 presenters and serializers to consistently choose rich_text vs plain_text depending on the field.