### PR TITLE
API v2: Sanitize user-supplied fields in responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@
 
  - Add copy button next to V2 API Token [#1283](https://github.com/portagenetwork/roadmap/pull/1283)
 
- - Initial v2 API Implementation & Doorkeeper OAuth Integration [#1276](https://github.com/portagenetwork/roadmap/pull/1276) 
+ - Initial v2 API Implementation & Doorkeeper OAuth Integration [#1276](https://github.com/portagenetwork/roadmap/pull/1276)
+
+ - API v2: Sanitize user-supplied fields in responses [#1303](https://github.com/portagenetwork/roadmap/pull/1303)
 
 ### Changed
  - Upgrade ROR API From V1 to V2 [#1247](https://github.com/portagenetwork/roadmap/pull/1247)

--- a/app/presenters/api/v2/research_output_presenter.rb
+++ b/app/presenters/api/v2/research_output_presenter.rb
@@ -4,6 +4,7 @@ module Api
   module V2
     # Helper methods for research outputs
     class ResearchOutputPresenter
+      include ActionView::Helpers::SanitizeHelper
       attr_reader :dataset_id, :preservation_statement, :security_and_privacy, :license_start_date,
                   :data_quality_assurance, :distributions, :metadata, :technical_resources
 
@@ -89,7 +90,8 @@ module Api
       end
 
       def format_q_and_a(question, answer)
-        "<strong>Question:</strong> #{question.text}<br><strong>Answer:</strong> #{answer.text}"
+        "<strong>Question:</strong> #{sanitize(question.text)}<br>" \
+          "<strong>Answer:</strong> #{sanitize(answer.text)}"
       end
     end
   end

--- a/app/views/api/v2/contributors/_show.json.jbuilder
+++ b/app/views/api/v2/contributors/_show.json.jbuilder
@@ -4,7 +4,8 @@
 
 is_contact ||= false
 
-json.name contributor.is_a?(User) ? contributor.name(false) : contributor.name
+name = contributor.is_a?(User) ? contributor.name(false) : contributor.name
+json.name sanitize(name)
 json.mbox contributor.email
 
 if !is_contact && contributor.selected_roles.any?

--- a/app/views/api/v2/datasets/_show.json.jbuilder
+++ b/app/views/api/v2/datasets/_show.json.jbuilder
@@ -6,8 +6,8 @@ if output.is_a?(ResearchOutput)
   presenter = Api::V2::ResearchOutputPresenter.new(output: output)
 
   json.type output.output_type
-  json.title output.title
-  json.description output.description
+  json.title strip_tags(output.title)
+  json.description sanitize(output.description)
   json.personal_data Api::V2::ApiPresenter.boolean_to_yes_no_unknown(value: output.personal_data)
   json.sensitive_data Api::V2::ApiPresenter.boolean_to_yes_no_unknown(value: output.sensitive_data)
   json.issued output.release_date&.to_formatted_s(:iso8601)

--- a/app/views/api/v2/plans/_cost.json.jbuilder
+++ b/app/views/api/v2/plans/_cost.json.jbuilder
@@ -2,7 +2,7 @@
 
 # locals: cost
 
-json.title cost[:title]
+json.title sanitize(cost[:title])
 json.description cost[:description]
 json.currency_code cost[:currency_code]
-json.value cost[:value]
+json.value sanitize(cost[:value])

--- a/app/views/api/v2/plans/_show.json.jbuilder
+++ b/app/views/api/v2/plans/_show.json.jbuilder
@@ -20,7 +20,7 @@ json.created plan.created_at.to_formatted_s(:iso8601)
 json.modified plan.updated_at.to_formatted_s(:iso8601)
 
 json.ethical_issues_exist Api::V2::ConversionService.boolean_to_yes_no_unknown(plan.ethical_issues)
-json.ethical_issues_description plan.ethical_issues_description
+json.ethical_issues_description sanitize(plan.ethical_issues_description)
 json.ethical_issues_report plan.ethical_issues_report
 
 id = presenter.identifier
@@ -65,7 +65,7 @@ unless @minimal
     json.set! :dmproadmap do
       json.template do
         json.id template.id
-        json.title template.title
+        json.title strip_tags(template.title)
       end
     end
 
@@ -77,9 +77,9 @@ unless @minimal
         json.array! q_and_a do |item|
           json.question_id item[:id]
           json.title item[:title]
-          json.section item[:section]
-          json.question item[:question]
-          json.answer item[:answer]
+          json.section strip_tags(item[:section])
+          json.question sanitize(item[:question])
+          json.answer sanitize(item[:answer])
         end
       end
     end

--- a/app/views/api/v2/templates/index.json.jbuilder
+++ b/app/views/api/v2/templates/index.json.jbuilder
@@ -6,8 +6,8 @@ json.items @items do |template|
   presenter = Api::V2::TemplatePresenter.new(template: template)
 
   json.dmp_template do
-    json.title presenter.title
-    json.description template.description
+    json.title strip_tags(presenter.title)
+    json.description sanitize(template.description)
     json.version template.version
     json.created template.created_at.to_formatted_s(:iso8601)
     json.modified template.updated_at.to_formatted_s(:iso8601)

--- a/spec/views/api/v2/plans/_cost.json.jbuilder_spec.rb
+++ b/spec/views/api/v2/plans/_cost.json.jbuilder_spec.rb
@@ -10,7 +10,7 @@ describe 'api/v2/plans/_cost.json.jbuilder' do
       title: Faker::Lorem.sentence,
       description: Faker::Lorem.paragraph,
       currency_code: Faker::Currency.code,
-      value: Faker::Number.decimal(l_digits: 2)
+      value: Faker::Number.decimal(l_digits: 2).to_s
     }.with_indifferent_access
 
     render partial: 'api/v2/plans/cost', locals: { cost: @cost }


### PR DESCRIPTION
# Changes proposed in this PR:

## Apply sanitization to user-supplied fields in API v2 Jbuilder views to reduce XSS risk for downstream consumers.
- `sanitize()` preserves allowed HTML formatting (e.g. TinyMCE output)
- `strip_tags()` strips HTML entirely where plain text is expected

## Fix `api/v2/plans/_cost.json.jbuilder` spec
- `Api::V2::PlanPresenter#plan_costs` assigns `cost[:value] = answer.text`(a String)
- The spec file now matches the actual assigned type.