### PR TITLE
Remove unused code and messages after Public DMPs page removal

### DIFF
--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Controller for the Public DMPs and Funder Requirements pages
+# Controller for the Example DMPs and Funder Requirements pages
 class PublicPagesController < ApplicationController
   # GET template_index
   # -----------------------------------------------------
@@ -83,17 +83,10 @@ class PublicPagesController < ApplicationController
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   # GET /plans_index
+  # This is the example DMPs page
   # ------------------------------------------------------------------------------------
   def plan_index
-    @plans = Plan.publicly_visible.includes(:template)
-    render 'plan_index', locals: {
-      query_params: {
-        page: paginable_params.fetch(:page, 1),
-        search: paginable_params.fetch(:search, ''),
-        sort_field: paginable_params.fetch(:sort_field, 'plans.updated_at'),
-        sort_direction: paginable_params.fetch(:sort_direction, 'desc')
-      }
-    }
+    render 'plan_index'
   end
 
   private

--- a/app/views/paginable/plans/_privately_visible.html.erb
+++ b/app/views/paginable/plans/_privately_visible.html.erb
@@ -74,7 +74,7 @@
                 <% end %>
               <% end %>
               <% role = my_plan_roles.first %>
-              <% conf = (role.creator? && plan.publicly_visible?) ? _("Are you sure you wish to remove this public plan? This will remove it from the Public DMPs page but any collaborators will still be able to access it.") : _("Are you sure you wish to remove this plan? Any collaborators will still be able to access it.") %>
+              <% conf = _("Are you sure you wish to remove this plan? Any collaborators will still be able to access it.") %>
               <li><%= link_to _('Remove'), deactivate_role_path(role), 'data-method': 'put', rel: 'nofollow', 'data-confirm': conf %></li>
             </ul>
           </div>

--- a/app/views/plans/_share_form.html.erb
+++ b/app/views/plans/_share_form.html.erb
@@ -34,7 +34,7 @@
           <%= f.radio_button :visibility, :publicly_visible,
                              data: { url: visibility_plan_path(@plan),
                                      remote: true, method: :post }  %>
-          <%= _('Public: anyone can view or download from the Public DMPs page') %>
+          <%= _('Public: anyone with the link has permission to view the contents of your DMP') %>
         <% end %>
       </div>
     </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -89,7 +89,7 @@ module DMPRoadmap
 
     # The default visibility setting for new plans
     #   organisationally_visible  - Any member of the user's org can view, export and duplicate the plan
-    #   publicly_visibile         - (NOT advisable because plans will show up in Public DMPs page by default)
+    #   publicly_visibile         - (NOT advisable because anyone with the link has permission to view the the DMP)
     #   is_test                   - (NOT advisable because test plans are excluded from statistics)
     #   privately_visible         - Only the owner and people they invite can access the plan
     config.default_plan_visibility = 'privately_visible'


### PR DESCRIPTION
Fixes #1304 .

Changes proposed in this PR:
- Edit messages that mention the now removed public DMPs page.
- Edit `plan_index` in `public_pages_controller` to remove unused code.
