### PR TITLE
Update expiry time of v2 API internal access token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 
  - Redesign and Edit Welcome, Help, and About pages and Remove Public DMPs Page [#1299](https://github.com/portagenetwork/roadmap/pull/1299)
 
+ - Update expiry time of v2 API internal access token [#1308](https://github.com/portagenetwork/roadmap/pull/1308)
+
 ### Dependency Updates
 
  - chore(deps): bump nginx from 1.29.3-alpine to 1.29.4-alpine [#1246](https://github.com/portagenetwork/roadmap/pull/1246)

--- a/app/services/api/v2/internal_user_access_token_service.rb
+++ b/app/services/api/v2/internal_user_access_token_service.rb
@@ -31,7 +31,7 @@ module Api
             application_id: application!.id,
             resource_owner_id: user.id,
             scopes: READ_SCOPE,
-            expires_in: nil # Overrides Doorkeeper's `access_token_expires_in`
+            expires_in: 24.hours # Overrides Doorkeeper's `access_token_expires_in`
           )
           token.plaintext_token
         end

--- a/app/views/devise/registrations/_v2_api_token.html.erb
+++ b/app/views/devise/registrations/_v2_api_token.html.erb
@@ -26,13 +26,15 @@
                 class: 'btn btn-default'
           ) %>
           <div class="alert alert-warning">
-            <%= _( "Please copy this token now and store it somewhere safely." ) %><br>
+            <%= _( "This token will expire after 24 hours." ) %><br>
+            <%= _( "Please copy it now and store it somewhere safely." ) %><br>
             <%= _( "It will disappear after you leave or refresh this page." ) %>
           </div>
         <% else %>
           <%= _( "Click the button below to generate an API token" ) %><br>
           <div class="alert alert-warning">
-            <%= _("If you previously generated and saved a token, please continue using that token.") %>
+            <%= _("Tokens expire after 24 hours.") %><br>
+            <%= _("If you previously generated and saved a valid token, please continue using it.") %>
           </div>
         <% end %>
       </div>

--- a/spec/services/api/v2/internal_user_access_token_service_spec.rb
+++ b/spec/services/api/v2/internal_user_access_token_service_spec.rb
@@ -20,7 +20,15 @@ RSpec.describe Api::V2::InternalUserAccessTokenService do
       expect(new_token.resource_owner_id).to eq(user.id)
       expect(new_token.revoked_at).to be_nil
       expect(new_token.scopes.to_s).to include('read')
-      expect(old_token.revoked_at).not_to be_nil if old_token
+      # Verify new_token expires in 24 hours
+      expected_expires_at = new_token.created_at + 24.hours
+      actual_expires_at = new_token.created_at + new_token.expires_in.seconds
+      expect(actual_expires_at).to be_within(1.second).of(expected_expires_at)
+      return unless old_token
+
+      # Verify old_token was revoked shortly before new_token was created
+      expect(old_token.revoked_at).to be <= new_token.created_at
+      expect(old_token.revoked_at).to be_within(1.second).of(new_token.created_at)
     end
 
     shared_examples 'token rotation' do |has_old_token|


### PR DESCRIPTION
# Changes proposed in this PR:

[Set internal v2 API access token expiry (24h)](https://github.com/portagenetwork/roadmap/commit/19e02773bc89c0df9c3d09956bee4da75d8aa92b)
- Also added rSpec tests to verify:
  - the internal v2 access token expiry
  - verify `old_token` is revoked prior to `new_token` creation

[Update v2 token helper text within API Access tab](https://github.com/portagenetwork/roadmap/commit/25d6822db76aeea4e2a088b431047fb9978006a6)
- Updated text so that it also communicates expiry time of v2 access token.