### PR TITLE
feat(oauth): allow users with `manage_oauth_apps` to manage Doorkeeper OAuth applications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+ - feat(oauth): allow users with `manage_oauth_apps` to manage Doorkeeper OAuth applications [#1320](https://github.com/portagenetwork/roadmap/pull/1320)
+
 ### Fixed
 
  - fix(api-v1): Address breaking tests and dropped `api_client_id` column [#1327](https://github.com/portagenetwork/roadmap/pull/1327)

--- a/app/assets/stylesheets/rebranding-animation.scss
+++ b/app/assets/stylesheets/rebranding-animation.scss
@@ -7,6 +7,7 @@
 
 /* General styling for link visibility/accessibility */
 a,
+a.btn.btn-link, input.btn-link, // "Edit" & "Destroy" buttons for /oauth/applications
 .btn.btn-link.dropdown-toggle, // "Actions" dropdown buttons
 .dropdown-menu > li > a {
   text-decoration: underline;
@@ -25,7 +26,7 @@ a,
   text-decoration: none;
   color: $color-alliance-digital-grey;
 }
-  
+
 a.btn,
 .nav > li > a:not(#org-navbar-menu .nav > li > a) {
   text-decoration: none;

--- a/app/controllers/oauth_applications_controller.rb
+++ b/app/controllers/oauth_applications_controller.rb
@@ -6,6 +6,9 @@ class OauthApplicationsController < Doorkeeper::ApplicationsController
   REGEN_SECRET_SUCCESS_MSG = _('Application secret has been regenerated. ' \
                                'Please copy it now and store it somewhere safely. ' \
                                'It will disappear after you leave or refresh this page.')
+  # Defining this small helper in this controller allows the views to share it,
+  # but without having to introduce a Doorkeeper::Application class to the codebase.
+  helper_method :application_owned_by_current_user?
 
   # NOTE: Doorkeeper config's `admin_authenticator` controls access to the admin
   # interface at a higher level
@@ -46,7 +49,7 @@ class OauthApplicationsController < Doorkeeper::ApplicationsController
     return if action_name == 'show' && current_user.can_super_admin?
 
     # Otherwise, current_user must own the app they are accessing
-    handle_unauthorized_user unless user_is_app_owner?
+    handle_unauthorized_user unless application_owned_by_current_user?(@application)
   end
 
   # Merges `user_id` with the default permitted fields (:name, :redirect_uri, etc.)
@@ -55,8 +58,8 @@ class OauthApplicationsController < Doorkeeper::ApplicationsController
     super.merge(user_id: current_user.id)
   end
 
-  def user_is_app_owner?
-    @application.user_id == current_user.id
+  def application_owned_by_current_user?(application)
+    application.user_id == current_user.id
   end
 
   def handle_unauthorized_user

--- a/app/controllers/oauth_applications_controller.rb
+++ b/app/controllers/oauth_applications_controller.rb
@@ -3,9 +3,18 @@
 # Custom controller to extend Doorkeeper::ApplicationsController
 # https://github.com/doorkeeper-gem/doorkeeper/blob/main/app/controllers/doorkeeper/applications_controller.rb
 class OauthApplicationsController < Doorkeeper::ApplicationsController
+  REGEN_SECRET_SUCCESS_MSG = _('Application secret has been regenerated. ' \
+                               'Please copy it now and store it somewhere safely. ' \
+                               'It will disappear after you leave or refresh this page.')
+
   # NOTE: Doorkeeper config's `admin_authenticator` controls access to the admin
   # interface at a higher level
-  before_action :authorize_application_access!, only: %i[show edit update destroy]
+
+  # `set_application` exists in the controller we are extending from
+  # - Skip actions that do not utilize application_id
+  before_action :set_application, except: %i[index new create]
+  # Index filters within action; new/create do not have persisted applications to authorize
+  before_action :authorize_application_access!, except: %i[index new create]
 
   # GET /oauth/applications
   def index
@@ -16,16 +25,28 @@ class OauthApplicationsController < Doorkeeper::ApplicationsController
     @applications = @applications.where(user_id: current_user.id)
   end
 
+  # POST /oauth/applications/:id/regenerate_secret
+  def regenerate_secret
+    @application.renew_secret
+    @application.save!
+
+    flash[:notice] = REGEN_SECRET_SUCCESS_MSG
+    flash[:application_secret] = @application.plaintext_secret
+
+    redirect_to oauth_application_path(@application)
+  rescue StandardError => e
+    flash[:alert] = format(_('Failed to regenerate secret: %{error}'), error: e.message)
+    redirect_to oauth_application_path(@application)
+  end
+
   private
 
   def authorize_application_access!
-    case action_name
-    when 'show'
-      handle_unauthorized_user unless current_user.can_super_admin? || user_is_app_owner?
-    when 'edit', 'update', 'destroy'
-      # Actions restricted to app owner
-      handle_unauthorized_user unless user_is_app_owner?
-    end
+    # Super admins can access show action for any app
+    return if action_name == 'show' && current_user.can_super_admin?
+
+    # Otherwise, current_user must own the app they are accessing
+    handle_unauthorized_user unless user_is_app_owner?
   end
 
   # Merges `user_id` with the default permitted fields (:name, :redirect_uri, etc.)

--- a/app/controllers/oauth_applications_controller.rb
+++ b/app/controllers/oauth_applications_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Custom controller to extend Doorkeeper::ApplicationsController
+# https://github.com/doorkeeper-gem/doorkeeper/blob/main/app/controllers/doorkeeper/applications_controller.rb
+class OauthApplicationsController < Doorkeeper::ApplicationsController
+  # NOTE: Doorkeeper config's `admin_authenticator` controls access to the admin
+  # interface at a higher level
+  before_action :authorize_application_access!, only: %i[show edit update destroy]
+
+  # GET /oauth/applications
+  def index
+    super
+    return if current_user.can_super_admin?
+
+    # Non-super admins with `manage_oauth_apps` can only view their own apps
+    @applications = @applications.where(user_id: current_user.id)
+  end
+
+  private
+
+  def authorize_application_access!
+    case action_name
+    when 'show'
+      handle_unauthorized_user unless current_user.can_super_admin? || user_is_app_owner?
+    when 'edit', 'update', 'destroy'
+      # Actions restricted to app owner
+      handle_unauthorized_user unless user_is_app_owner?
+    end
+  end
+
+  # Merges `user_id` with the default permitted fields (:name, :redirect_uri, etc.)
+  # (application_params is used by the default controller's create and update actions)
+  def application_params
+    super.merge(user_id: current_user.id)
+  end
+
+  def user_is_app_owner?
+    @application.user_id == current_user.id
+  end
+
+  def handle_unauthorized_user
+    redirect_to root_path,
+                alert: _('You are not authorized to perform this action.')
+  end
+end

--- a/app/models/perm.rb
+++ b/app/models/perm.rb
@@ -77,4 +77,8 @@ class Perm < ApplicationRecord
   def self.review_plans
     lazy_load('review_org_plans')
   end
+
+  def self.manage_oauth_apps
+    lazy_load('manage_oauth_apps')
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -392,6 +392,10 @@ class User < ApplicationRecord
     perms.include? Perm.review_plans
   end
 
+  def can_manage_oauth_apps?
+    perms.include? Perm.manage_oauth_apps
+  end
+
   # Removes the api_token from the user
   #
   # Returns nil

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -141,6 +141,17 @@ class User < ApplicationRecord
   # needs rethought
   # default_scope { includes(:org, :perms) }
 
+  scope :super_admins, lambda {
+    joins(:perms)
+      # Reuses the `can_super_admin?` definition
+      .where(perms: { name: %w[
+               add_organisations
+               grant_api_to_orgs
+               change_org_affiliation
+             ] })
+      .distinct
+  }
+
   # Retrieves all of the org_admins for the specified org
   scope :org_admins, lambda { |org_id|
     joins(:perms).where('users.org_id = ? AND perms.name IN (?) AND ' \

--- a/app/views/doorkeeper/applications/_form.html.erb
+++ b/app/views/doorkeeper/applications/_form.html.erb
@@ -18,6 +18,9 @@
       <%= doorkeeper_errors_for application, :scopes %>
       <span class="form-text text-secondary">
         <%= "Separate multiple scopes with spaces." %>
+        <br>
+        <%= _('Available scopes are') %> 
+        [<%= safe_join(Doorkeeper.configuration.scopes.to_a.map { |s| content_tag(:strong, s) }, ' ') %>]
       </span>
     </div>
   </div>

--- a/app/views/doorkeeper/applications/index.html.erb
+++ b/app/views/doorkeeper/applications/index.html.erb
@@ -23,12 +23,12 @@
         <%= simple_format(application.redirect_uri) %>
       </td>
       <td class="align-middle">
-        <% if application.user_id == current_user.id %>
+        <% if application_owned_by_current_user?(application) %>
           <%= link_to t('doorkeeper.applications.buttons.edit'), edit_oauth_application_path(application), class: 'btn btn-link' %>
         <% end %>
       </td>
       <td class="align-middle">
-        <% if application.user_id == current_user.id %>
+        <% if application_owned_by_current_user?(application) %>
           <%= render 'delete_form', application: application %>
         <% end %>
       </td>

--- a/app/views/doorkeeper/applications/index.html.erb
+++ b/app/views/doorkeeper/applications/index.html.erb
@@ -23,10 +23,14 @@
         <%= simple_format(application.redirect_uri) %>
       </td>
       <td class="align-middle">
-        <%= link_to t('doorkeeper.applications.buttons.edit'), edit_oauth_application_path(application), class: 'btn btn-link' %>
+        <% if application.user_id == current_user.id %>
+          <%= link_to t('doorkeeper.applications.buttons.edit'), edit_oauth_application_path(application), class: 'btn btn-link' %>
+        <% end %>
       </td>
       <td class="align-middle">
-        <%= render 'delete_form', application: application %>
+        <% if application.user_id == current_user.id %>
+          <%= render 'delete_form', application: application %>
+        <% end %>
       </td>
     </tr>
   <% end %>

--- a/app/views/doorkeeper/applications/show.html.erb
+++ b/app/views/doorkeeper/applications/show.html.erb
@@ -58,6 +58,14 @@
 
     <p><%= link_to t('doorkeeper.applications.buttons.edit'), edit_oauth_application_path(@application), class: 'btn btn-primary' %></p>
 
+    <p>
+      <%= button_to t('doorkeeper.applications.buttons.regenerate_secret'),
+          regenerate_oauth_secret_path(@application),
+          method: :post,
+          class: 'btn btn-warning',
+          data: { confirm: t('doorkeeper.applications.buttons.regenerate_secret_confirm') } %>
+    </p>
+
     <p><%= render 'delete_form', application: @application, submit_btn_css: 'btn btn-danger' %></p>
   </div>
 </div>

--- a/app/views/doorkeeper/applications/show.html.erb
+++ b/app/views/doorkeeper/applications/show.html.erb
@@ -1,42 +1,63 @@
-<%= fields_for @application,  as: :doorkeeper_application, html: { role: 'form' } do |f| %>
-  <div class="form-group row mb-3">
-    <%= f.label :name, class: 'col-sm-2 col-form-label font-weight-bold' %>
-    <div class="col-sm-10">
-      <%= f.text_field :name, class: "form-control", required: true, style: "border: 1px solid #ced4da;", readonly: true %>
-    </div>
+<div class="border-bottom mb-4">
+  <h1><%= t('.title', name: @application.name) %></h1>
+</div>
+
+<div class="row">
+  <div class="col-md-8">
+    <h4><%= t('.application_id') %>:</h4>
+    <p><code class="bg-light" id="application_id"><%= @application.uid %></code></p>
+
+    <h4><%= t('.secret') %>:</h4>
+    <p>
+      <code class="bg-light" id="secret">
+        <% secret = flash[:application_secret].presence || @application.plaintext_secret %>
+        <% if secret.blank? && Doorkeeper.config.application_secret_hashed? %>
+          <span class="bg-light font-italic text-uppercase text-muted"><%= t('.secret_hashed') %></span>
+        <% else %>
+          <%= secret %>
+        <% end %>
+      </code>
+    </p>
+
+    <h4><%= t('.scopes') %>:</h4>
+    <p>
+      <code class="bg-light" id="scopes">
+        <% if @application.scopes.present? %>
+          <%= @application.scopes %>
+        <% else %>
+          <span class="bg-light font-italic text-uppercase text-muted"><%= t('.not_defined') %></span>
+        <% end %>
+      </code>
+    </p>
+
+    <h4><%= t('.confidential') %>:</h4>
+    <p><code class="bg-light" id="confidential"><%= @application.confidential? %></code></p>
+
+    <h4><%= t('.callback_urls') %>:</h4>
+
+    <% if @application.redirect_uri.present? %>
+      <table>
+        <% @application.redirect_uri.split.each do |uri| %>
+          <tr>
+            <td>
+              <code class="bg-light"><%= uri %></code>
+            </td>
+            <td>
+              <%= link_to t('doorkeeper.applications.buttons.authorize'), oauth_authorization_path(client_id: @application.uid, redirect_uri: uri, response_type: 'code', scope: @application.scopes), class: 'btn btn-success', target: '_blank' %>
+            </td>
+          </tr>
+        <% end %>
+      </table>
+    <% else %>
+      <span class="bg-light font-italic text-uppercase text-muted"><%= t('.not_defined') %></span>
+    <% end %>
   </div>
 
-  <div class="form-group row mb-3">
-    <%= f.label nil, "Client ID".html_safe, class: 'col-sm-2 col-form-label font-weight-bold' %>
-    <div class="col-sm-10">
-      <%= f.text_field :uid, class: "form-control", required: true, style: "border: 1px solid #ced4da;", readonly: true %>
-    </div>
-  </div>
+  <div class="col-md-4">
+    <h3><%= t('.actions') %></h3>
 
-  <div class="form-group row mb-3">
-    <%= f.label nil, "Client secret".html_safe, class: 'col-sm-2 col-form-label font-weight-bold' %>
-    <div class="col-sm-10">
-      <%= f.text_field :secret, class: "form-control", required: true, style: "border: 1px solid #ced4da;", readonly: true %>
-    </div>
-  </div>
+    <p><%= link_to t('doorkeeper.applications.buttons.edit'), edit_oauth_application_path(@application), class: 'btn btn-primary' %></p>
 
-  <div class="form-group row mb-3">
-    <%= f.label "Scope(s)", class: 'col-sm-2 col-form-label font-weight-bold' %>
-    <div class="col-sm-10">
-      <%= f.text_field :scopes, class: "form-control", style: "border: 1px solid #ced4da;", readonly: true %>
-    </div>
+    <p><%= render 'delete_form', application: @application, submit_btn_css: 'btn btn-danger' %></p>
   </div>
-
-  <div class="form-group row mb-3">
-    <%= f.label nil, 'Redirect URI(s)'.html_safe, class: 'col-sm-2 col-form-label font-weight-bold' %>
-    <div class="col-sm-10">
-      <%= f.text_area :redirect_uri, class: "form-control", style: "border: 1px solid #ced4da;", readonly: true %>
-    </div>
-  </div>
-
-  <div class="form-group">
-    <div class="col-sm-offset-2 col-sm-10">
-      <%= link_to "Back", oauth_applications_path, class: 'btn btn-secondary' %>
-    </div>
-  </div>
-<% end %>
+</div>

--- a/app/views/doorkeeper/applications/show.html.erb
+++ b/app/views/doorkeeper/applications/show.html.erb
@@ -43,7 +43,7 @@
               <code class="bg-light"><%= uri %></code>
             </td>
             <td>
-              <% if @application.user_id == current_user.id %>
+              <% if application_owned_by_current_user?(@application) %>
                 <%= link_to t('doorkeeper.applications.buttons.authorize'), oauth_authorization_path(client_id: @application.uid, redirect_uri: uri, response_type: 'code', scope: @application.scopes), class: 'btn btn-success', target: '_blank' %>
               <% end %>
             </td>
@@ -55,7 +55,7 @@
     <% end %>
   </div>
 
-  <% if @application.user_id == current_user.id %>
+  <% if application_owned_by_current_user?(@application) %>
     <div class="col-md-4">
       <h3><%= t('.actions') %></h3>
 

--- a/app/views/doorkeeper/applications/show.html.erb
+++ b/app/views/doorkeeper/applications/show.html.erb
@@ -43,7 +43,9 @@
               <code class="bg-light"><%= uri %></code>
             </td>
             <td>
-              <%= link_to t('doorkeeper.applications.buttons.authorize'), oauth_authorization_path(client_id: @application.uid, redirect_uri: uri, response_type: 'code', scope: @application.scopes), class: 'btn btn-success', target: '_blank' %>
+              <% if @application.user_id == current_user.id %>
+                <%= link_to t('doorkeeper.applications.buttons.authorize'), oauth_authorization_path(client_id: @application.uid, redirect_uri: uri, response_type: 'code', scope: @application.scopes), class: 'btn btn-success', target: '_blank' %>
+              <% end %>
             </td>
           </tr>
         <% end %>
@@ -53,19 +55,21 @@
     <% end %>
   </div>
 
-  <div class="col-md-4">
-    <h3><%= t('.actions') %></h3>
+  <% if @application.user_id == current_user.id %>
+    <div class="col-md-4">
+      <h3><%= t('.actions') %></h3>
 
-    <p><%= link_to t('doorkeeper.applications.buttons.edit'), edit_oauth_application_path(@application), class: 'btn btn-primary' %></p>
+      <p><%= link_to t('doorkeeper.applications.buttons.edit'), edit_oauth_application_path(@application), class: 'btn btn-primary' %></p>
 
-    <p>
-      <%= button_to t('doorkeeper.applications.buttons.regenerate_secret'),
-          regenerate_oauth_secret_path(@application),
-          method: :post,
-          class: 'btn btn-warning',
-          data: { confirm: t('doorkeeper.applications.buttons.regenerate_secret_confirm') } %>
-    </p>
+      <p>
+        <%= button_to t('doorkeeper.applications.buttons.regenerate_secret'),
+            regenerate_oauth_secret_path(@application),
+            method: :post,
+            class: 'btn btn-warning',
+            data: { confirm: t('doorkeeper.applications.buttons.regenerate_secret_confirm') } %>
+      </p>
 
-    <p><%= render 'delete_form', application: @application, submit_btn_css: 'btn btn-danger' %></p>
-  </div>
+      <p><%= render 'delete_form', application: @application, submit_btn_css: 'btn btn-danger' %></p>
+    </div>
+  <% end %>
 </div>

--- a/app/views/layouts/_signin_signout.html.erb
+++ b/app/views/layouts/_signin_signout.html.erb
@@ -1,3 +1,12 @@
+<% if current_user&.can_manage_oauth_apps? %>
+  <li class="<%= ' active' if active_page?(oauth_applications_path) %>">
+    <%= link_to oauth_applications_path do %>
+      <i class="fas fa-screwdriver-wrench" aria-hidden="true">&nbsp;</i>
+      <%= _('Developer Tools') %>
+    <% end %>
+  </li>
+<% end %>
+
 <!-- language dropdown -->
 <% if Language.many? %>
   <li class="dropdown" id="change-language">

--- a/app/views/users/_admin_grant_permissions.html.erb
+++ b/app/views/users/_admin_grant_permissions.html.erb
@@ -62,7 +62,15 @@
               <% end %>
             <% end %>
           <% end %>
-        </ul>
+
+        <!-- Developer / OAuth Apps Section -->
+        <% perm = Perm.find_by(name: 'manage_oauth_apps') %>
+        <%= label_tag :developer_privileges %>
+        <li class="list-group-item" style="border: none"
+            title="<%= _('Allows the user to create and manage OAuth applications for third-party integrations') %>">
+            <%= check_box_tag "perm_ids[]", perm.id, user.perms.include?(perm), class: 'developer_privileges' %>
+            <%= _('Manage OAuth apps') %>
+        </li>
       </div>
       <div class="modal-footer">
         <%= submit_tag _('Save'), class: "btn btn-primary" %>

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -8,16 +8,19 @@ Doorkeeper.configure do
   resource_owner_authenticator do
     if request.path == native_oauth_authorization_path
       # Deactivate native_oauth_authorization_path (intended for mobile devices)
-      redirect_to root_path, alert: "You are not authorized to perform this action."
+      redirect_to root_path, alert: _('You are not authorized to perform this action.')
     else
       # https://doorkeeper.gitbook.io/guides/ruby-on-rails/configuration
       current_user || warden.authenticate!(scope: :user)
     end
   end
 
-  # ensure only super-admins can manage oauth applications
+  # ensure only users with required perms can manage oauth applications
   admin_authenticator do |_routes|
-    redirect_to root_path, alert: "You are not authorized to perform this action." unless current_user&.can_super_admin?
+    unless current_user&.can_manage_oauth_apps?
+      redirect_to root_path,
+                  alert: _('You are not authorized to perform this action.')
+    end
   end
 
   # grant flows enabled

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -33,6 +33,7 @@ Doorkeeper.configure do
 
   # scopes enabled
   default_scopes :read
+  optional_scopes :write
 
   # ensure client apps cannot ask for scopes outwith those specified here
   enforce_configured_scopes

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -28,6 +28,8 @@ en:
         submit: 'Submit'
         cancel: 'Cancel'
         authorize: 'Authorize'
+        regenerate_secret: 'Regenerate Secret'
+        regenerate_secret_confirm: 'Are you sure? This will invalidate the current secret.'
       form:
         error: 'Whoops! Check your form for possible errors'
       help:
@@ -134,7 +136,9 @@ en:
     flash:
       applications:
         create:
-          notice: 'Application created.'
+          notice: |
+            Application created.<br>
+            Please copy the application secret now and store it somewhere safely. It will disappear after you leave or refresh this page.
         destroy:
           notice: 'Application deleted.'
         update:

--- a/config/locales/translation.en-CA.yml
+++ b/config/locales/translation.en-CA.yml
@@ -369,6 +369,9 @@ en-CA:
         submit: Submit
         cancel: Cancel
         authorize: Authorize
+        regenerate_secret: Regenerate Secret
+        regenerate_secret_confirm: Are you sure? This will invalidate the current
+          secret.
       form:
         error: Whoops! Check your form for possible errors
       help:
@@ -479,7 +482,9 @@ en-CA:
     flash:
       applications:
         create:
-          notice: Application created.
+          notice: |-
+            Application created.<br>
+            Please copy the application secret now and store it somewhere safely. It will disappear after you leave or refresh this page.
         destroy:
           notice: Application deleted.
         update:

--- a/config/locales/translation.fr-CA.yml
+++ b/config/locales/translation.fr-CA.yml
@@ -391,6 +391,8 @@ fr-CA:
         submit: Envoyer
         cancel: Annuler
         authorize: Autoriser
+        regenerate_secret: Régénérer le secret
+        regenerate_secret_confirm: Êtes-vous sûr ? Cela invalidera le secret actuel.
       form:
         error: Oups! Vérifier votre formulaire pour des erreurs possibles
       help:
@@ -509,7 +511,9 @@ fr-CA:
     flash:
       applications:
         create:
-          notice: Application créée.
+          notice: |-
+            Application créée.<br>
+            Veuillez copier le code secret de l'application et le conserver en lieu sûr. Il disparaîtra lorsque vous quitterez ou actualiserez cette page.
         destroy:
           notice: Application supprimée.
         update:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,9 @@ Rails.application.routes.draw do
   use_doorkeeper do
     controllers applications: 'oauth_applications'
   end
+  post 'oauth/applications/:id/regenerate_secret',
+       to: 'oauth_applications#regenerate_secret',
+       as: :regenerate_oauth_secret
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   devise_for(:users, controllers: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,9 @@
 
 # rubocop:disable Metrics/BlockLength
 Rails.application.routes.draw do
-  use_doorkeeper
+  use_doorkeeper do
+    controllers applications: 'oauth_applications'
+  end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   devise_for(:users, controllers: {

--- a/db/migrate/20260330204346_add_user_to_oauth_applications.rb
+++ b/db/migrate/20260330204346_add_user_to_oauth_applications.rb
@@ -1,0 +1,15 @@
+class AddUserToOauthApplications < ActiveRecord::Migration[6.1]
+
+  def up
+    # Initially allow null to backfill existing oauth apps
+    add_reference :oauth_applications, :user, foreign_key: true, index: true, null: true
+
+    user = User.find_by!(email: 'dittest@ualberta.ca')
+
+    change_column_null :oauth_applications, :user_id, false, user.id
+  end
+
+  def down
+    remove_reference :oauth_applications, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_02_19_200258) do
+ActiveRecord::Schema.define(version: 2026_03_30_204346) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -354,7 +354,9 @@ ActiveRecord::Schema.define(version: 2026_02_19_200258) do
     t.boolean "confidential", default: true, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id", null: false
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
+    t.index ["user_id"], name: "index_oauth_applications_on_user_id"
   end
 
   create_table "option_warnings", id: :serial, force: :cascade do |t|
@@ -925,6 +927,7 @@ ActiveRecord::Schema.define(version: 2026_02_19_200258) do
   add_foreign_key "oauth_access_grants", "users", column: "resource_owner_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "users", column: "resource_owner_id"
+  add_foreign_key "oauth_applications", "users"
   add_foreign_key "org_token_permissions", "orgs"
   add_foreign_key "org_token_permissions", "token_permission_types"
   add_foreign_key "orgs", "languages"

--- a/lib/tasks/dmp_assistant_upgrade.rake
+++ b/lib/tasks/dmp_assistant_upgrade.rake
@@ -46,9 +46,7 @@ namespace :dmp_assistant_upgrade do
   # Sets `confirmed_at` to `Time.now.utc` for all superusers
   def confirm_superusers
     confirmed_at = Time.now.utc
-    count = User.joins(:perms).where(perms: { id: super_admin_perm_ids })
-                .distinct
-                .update_all(confirmed_at: confirmed_at)
+    count = User.super_admins.update_all(confirmed_at: confirmed_at)
     p "Updated confirmed_at = #{confirmed_at} for #{count} superuser(s)"
   end
 

--- a/lib/tasks/perms.rake
+++ b/lib/tasks/perms.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+namespace :perms do
+  desc 'Add perm for managing OAuth apps'
+  task add_oauth_apps_perm: :environment do
+    perm = Perm.find_or_create_by(name: 'manage_oauth_apps')
+
+    # Grant the new permission to all super admins
+    User.super_admins.each do |user|
+      user.perms << perm unless user.perms.include?(perm)
+    end
+  end
+end

--- a/spec/controllers/oauth_applications_controller_spec.rb
+++ b/spec/controllers/oauth_applications_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe OauthApplicationsController, type: :controller do
   end
 
   describe '#application_params' do
-    it 'merges user_id and default scopes into the parent params' do
+    it 'merges user_id into the parent params' do
       Doorkeeper::ApplicationsController.any_instance
                                         # Ensure parent controller has application_params implemented
                                         .expects(:application_params)

--- a/spec/controllers/oauth_applications_controller_spec.rb
+++ b/spec/controllers/oauth_applications_controller_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe OauthApplicationsController, type: :controller do
+  let!(:manage_oauth_apps_perm) { create(:perm, :manage_oauth_apps) }
+  let(:user) { create(:user) }
+
+  before do
+    user.perms << manage_oauth_apps_perm
+    sign_in(user)
+  end
+
+  describe '#application_params' do
+    it 'merges user_id and default scopes into the parent params' do
+      Doorkeeper::ApplicationsController.any_instance
+                                        # Ensure parent controller has application_params implemented
+                                        .expects(:application_params)
+                                        .returns({ name: 'Test OAuth App' })
+
+      # Call the (private) method on our own controller
+      result = controller.send(:application_params)
+
+      expect(result[:name]).to eq('Test OAuth App')
+      # Ensure our controller adds user.id
+      expect(result[:user_id]).to eq(user.id)
+    end
+  end
+end

--- a/spec/factories/oauth_applications.rb
+++ b/spec/factories/oauth_applications.rb
@@ -21,5 +21,6 @@ FactoryBot.define do
     secret { SecureRandom.uuid }
     redirect_uri { "https://#{Faker::Internet.unique.domain_name}/callback" }
     scopes { 'read' }
+    user_id { create(:user).id }
   end
 end

--- a/spec/factories/perms.rb
+++ b/spec/factories/perms.rb
@@ -58,5 +58,10 @@ FactoryBot.define do
       name { 'review_org_plans' }
       initialize_with { Perm.find_or_create_by(name: name) }
     end
+
+    trait :manage_oauth_apps do
+      name { 'manage_oauth_apps' }
+      initialize_with { Perm.find_or_create_by(name: name) }
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -77,7 +77,7 @@ FactoryBot.define do
       after(:create) do |user, _evaluator|
         %w[change_org_affiliation add_organisations
            grant_permissions use_api change_org_details grant_api_to_orgs
-           modify_templates modify_guidance].each do |perm_name|
+           modify_templates modify_guidance manage_oauth_apps].each do |perm_name|
           user.perms << Perm.find_or_create_by(name: perm_name)
         end
       end

--- a/spec/requests/oauth_applications_spec.rb
+++ b/spec/requests/oauth_applications_spec.rb
@@ -77,6 +77,24 @@ RSpec.describe 'OauthApplications', type: :request do
     end
   end
 
+  shared_examples 'owner-only oauth application controls on index' do |super_admin:|
+    it 'renders edit and delete controls only for owned applications' do
+      get oauth_applications_path
+
+      html = Nokogiri::HTML(response.body)
+
+      expect(html.at_css("#application_#{owned_application.id} a.btn-link")).to_not be_nil
+      expect(html.at_css("#application_#{owned_application.id} " \
+                         "form[action='#{oauth_application_path(owned_application)}']")).to_not be_nil
+
+      if super_admin
+        expect(html.at_css("#application_#{non_owned_application.id} a.btn-link")).to be_nil
+      else
+        expect(html.at_css("#application_#{non_owned_application.id}")).to be_nil
+      end
+    end
+  end
+
   describe 'GET /oauth/applications' do
     context 'when signed in without manage_oauth_apps permission' do
       let(:request_path) { oauth_applications_path }
@@ -85,8 +103,8 @@ RSpec.describe 'OauthApplications', type: :request do
     end
 
     context 'when signed in as a super user (with manage_oauth_apps permission)' do
-      let!(:application_one) { create(:oauth_application, user_id: create(:user).id, name: 'OAuth App 1') }
-      let!(:application_two) { create(:oauth_application, user_id: create(:user).id, name: 'OAuth App 2') }
+      let!(:owned_application) { create(:oauth_application, user_id: super_admin.id, name: 'Owned App') }
+      let!(:non_owned_application) { create(:oauth_application, user_id: create(:user).id, name: 'Other User App') }
 
       before do
         sign_in(super_admin)
@@ -98,15 +116,16 @@ RSpec.describe 'OauthApplications', type: :request do
         expect(response).to have_http_status(:ok)
         html = Nokogiri::HTML(response.body)
 
-        expect(html.at_css("#application_#{application_one.id}")).to_not be_nil
-        expect(html.at_css("#application_#{application_two.id}")).to_not be_nil
+        expect(html.at_css("#application_#{owned_application.id}")).to_not be_nil
+        expect(html.at_css("#application_#{non_owned_application.id}")).to_not be_nil
       end
+
+      include_examples 'owner-only oauth application controls on index', super_admin: true
     end
 
     context 'when signed in as non-super user with manage_oauth_apps permission' do
-      let(:other_user) { create(:user) }
       let!(:owned_application) { create(:oauth_application, user_id: authorized_user.id, name: 'Owned App') }
-      let!(:other_user_application) { create(:oauth_application, user_id: other_user.id, name: 'Other User App') }
+      let!(:non_owned_application) { create(:oauth_application, user_id: create(:user).id, name: 'Other User App') }
 
       before do
         sign_in(authorized_user)
@@ -119,8 +138,10 @@ RSpec.describe 'OauthApplications', type: :request do
         html = Nokogiri::HTML(response.body)
 
         expect(html.at_css("#application_#{owned_application.id}")).to_not be_nil
-        expect(html.at_css("#application_#{other_user_application.id}")).to be_nil
+        expect(html.at_css("#application_#{non_owned_application.id}")).to be_nil
       end
+
+      include_examples 'owner-only oauth application controls on index', super_admin: false
     end
   end
 
@@ -185,6 +206,7 @@ RSpec.describe 'OauthApplications', type: :request do
 
     context 'when signed in as a non-super user with manage_oauth_apps permission' do
       let(:other_authorized_user) { create(:user) }
+      let(:viewed_application) { create(:oauth_application, user_id: authorized_user.id) }
 
       before do
         sign_in_with_manage_oauth_apps(other_authorized_user)
@@ -207,6 +229,32 @@ RSpec.describe 'OauthApplications', type: :request do
         expect(response).to redirect_to(root_path)
         follow_redirect!
         expect(flash[:alert]).to include('not authorized')
+      end
+
+      it 'renders owner-only actions and authorize controls' do
+        get oauth_application_path(viewed_application)
+
+        html = Nokogiri::HTML(response.body)
+
+        expect(html.at_css('div.col-md-4')).to_not be_nil
+        expect(html.at_css('a.btn-success')).to_not be_nil
+      end
+    end
+
+    context 'when signed in as a super admin viewing another user\'s application' do
+      let(:viewed_application) { create(:oauth_application, user_id: application_owner.id) }
+
+      before do
+        sign_in(super_admin)
+      end
+
+      it 'does not render owner-only actions and authorize controls' do
+        get oauth_application_path(viewed_application)
+
+        html = Nokogiri::HTML(response.body)
+
+        expect(html.at_css('div.col-md-4')).to be_nil
+        expect(html.at_css('a.btn-success')).to be_nil
       end
     end
   end

--- a/spec/requests/oauth_applications_spec.rb
+++ b/spec/requests/oauth_applications_spec.rb
@@ -1,0 +1,257 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'OauthApplications', type: :request do
+  let!(:manage_oauth_apps_perm) { create(:perm, :manage_oauth_apps) }
+  let(:authorized_user) { create(:user) }
+  let(:unauthorized_user) { create(:user) }
+  let(:super_admin) { create(:user, :super_admin) }
+
+  def sign_in_with_manage_oauth_apps(user)
+    user.perms << manage_oauth_apps_perm
+    sign_in(user)
+  end
+
+  before do
+    sign_in_with_manage_oauth_apps(authorized_user)
+  end
+
+  shared_examples 'denies access without manage_oauth_apps permission' do
+    before do
+      sign_in(unauthorized_user)
+      get request_path
+    end
+
+    it 'redirects to root with an authorization alert' do
+      expect(response).to redirect_to(root_path)
+      follow_redirect!
+      expect(flash[:alert]).to include('not authorized')
+    end
+  end
+
+  shared_examples 'owner-only oauth application update' do
+    it 'allows updating own application' do
+      owned_application = create(:oauth_application, user_id: current_user.id, name: 'Owned App')
+
+      patch oauth_application_path(owned_application), params: { doorkeeper_application: { name: 'Updated Name' } }
+
+      expect(response).to redirect_to(oauth_application_path(owned_application))
+      expect(owned_application.reload.name).to eq('Updated Name')
+    end
+
+    it 'denies updating another user application' do
+      other_user_application = create(:oauth_application, user_id: create(:user).id, name: 'Other User App')
+
+      patch oauth_application_path(other_user_application),
+            params: { doorkeeper_application: { name: 'Updated Name' } }
+
+      expect(response).to redirect_to(root_path)
+      expect(other_user_application.reload.name).to eq('Other User App')
+      follow_redirect!
+      expect(flash[:alert]).to include('not authorized')
+    end
+  end
+
+  shared_examples 'owner-only oauth application destroy' do
+    it 'allows destroying own application' do
+      owned_application = create(:oauth_application, user_id: current_user.id)
+
+      expect do
+        delete oauth_application_path(owned_application)
+      end.to change(Doorkeeper::Application, :count).by(-1)
+
+      expect(response).to redirect_to(oauth_applications_path)
+    end
+
+    it 'denies destroying another user application' do
+      other_user_application = create(:oauth_application, user_id: create(:user).id)
+
+      expect do
+        delete oauth_application_path(other_user_application)
+      end.not_to change(Doorkeeper::Application, :count)
+
+      expect(response).to redirect_to(root_path)
+      follow_redirect!
+      expect(flash[:alert]).to include('not authorized')
+    end
+  end
+
+  describe 'GET /oauth/applications' do
+    context 'when signed in without manage_oauth_apps permission' do
+      let(:request_path) { oauth_applications_path }
+
+      include_examples 'denies access without manage_oauth_apps permission'
+    end
+
+    context 'when signed in as a super user (with manage_oauth_apps permission)' do
+      let!(:application_one) { create(:oauth_application, user_id: create(:user).id, name: 'OAuth App 1') }
+      let!(:application_two) { create(:oauth_application, user_id: create(:user).id, name: 'OAuth App 2') }
+
+      before do
+        sign_in(super_admin)
+      end
+
+      it 'shows all oauth applications' do
+        get oauth_applications_path
+
+        expect(response).to have_http_status(:ok)
+        html = Nokogiri::HTML(response.body)
+
+        expect(html.at_css("#application_#{application_one.id}")).to_not be_nil
+        expect(html.at_css("#application_#{application_two.id}")).to_not be_nil
+      end
+    end
+
+    context 'when signed in as non-super user with manage_oauth_apps permission' do
+      let(:other_user) { create(:user) }
+      let!(:owned_application) { create(:oauth_application, user_id: authorized_user.id, name: 'Owned App') }
+      let!(:other_user_application) { create(:oauth_application, user_id: other_user.id, name: 'Other User App') }
+
+      before do
+        sign_in(authorized_user)
+      end
+
+      it 'shows only oauth applications for the current user' do
+        get oauth_applications_path
+
+        expect(response).to have_http_status(:ok)
+        html = Nokogiri::HTML(response.body)
+
+        expect(html.at_css("#application_#{owned_application.id}")).to_not be_nil
+        expect(html.at_css("#application_#{other_user_application.id}")).to be_nil
+      end
+    end
+  end
+
+  describe 'GET /oauth/applications/new' do
+    context 'when signed in with manage_oauth_apps permission' do
+      before do
+        sign_in(authorized_user)
+      end
+
+      it 'renders the expected form fields and default scopes' do
+        get new_oauth_application_path
+
+        expect(response).to have_http_status(:ok)
+        html = Nokogiri::HTML(response.body)
+
+        name_input = html.at_css('#doorkeeper_application_name')
+        expect(name_input['name']).to eq('doorkeeper_application[name]')
+        expect(name_input['required']).to eq('required')
+
+        scopes_input = html.at_css('#doorkeeper_application_scopes')
+        expect(scopes_input['name']).to eq('doorkeeper_application[scopes]')
+
+        redirect_uri_input = html.at_css('#doorkeeper_application_redirect_uri')
+        expect(redirect_uri_input['name']).to eq('doorkeeper_application[redirect_uri]')
+
+        submit_button = html.at_css("input[type='submit'].btn.btn-primary")
+        expect(submit_button['value']).to eq('Submit')
+
+        cancel_link = html.at_css("a.btn.btn-secondary[href='#{oauth_applications_path}']")
+        expect(cancel_link.text).to eq('Cancel')
+      end
+    end
+
+    context 'when signed in without manage_oauth_apps permission' do
+      let(:request_path) { new_oauth_application_path }
+
+      include_examples 'denies access without manage_oauth_apps permission'
+    end
+  end
+
+  describe 'GET /oauth/applications/:id' do
+    let(:application_owner) { create(:user) }
+    let(:application) { create(:oauth_application, user_id: application_owner.id) }
+
+    context 'when signed in as super user with manage_oauth_apps permission' do
+      before do
+        sign_in(super_admin)
+      end
+
+      it 'allows access' do
+        get oauth_application_path(application)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when signed in as a normal user without manage_oauth_apps permission' do
+      let(:request_path) { oauth_application_path(application) }
+
+      include_examples 'denies access without manage_oauth_apps permission'
+    end
+
+    context 'when signed in as a non-super user with manage_oauth_apps permission' do
+      let(:other_authorized_user) { create(:user) }
+
+      before do
+        sign_in_with_manage_oauth_apps(other_authorized_user)
+        sign_in(authorized_user)
+      end
+
+      it 'allows access when the application belongs to the current user' do
+        owned_application = create(:oauth_application, user_id: authorized_user.id)
+
+        get oauth_application_path(owned_application)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'denies access when the application belongs to another user' do
+        other_user_application = create(:oauth_application, user_id: other_authorized_user.id)
+
+        get oauth_application_path(other_user_application)
+
+        expect(response).to redirect_to(root_path)
+        follow_redirect!
+        expect(flash[:alert]).to include('not authorized')
+      end
+    end
+  end
+
+  describe 'PATCH /oauth/applications/:id' do
+    context 'when signed in as super user' do
+      let(:current_user) { super_admin }
+
+      before do
+        sign_in(super_admin)
+      end
+
+      include_examples 'owner-only oauth application update'
+    end
+
+    context 'when signed in as a non-super user with manage_oauth_apps permission' do
+      let(:current_user) { authorized_user }
+
+      before do
+        sign_in(authorized_user)
+      end
+
+      include_examples 'owner-only oauth application update'
+    end
+  end
+
+  describe 'DELETE /oauth/applications/:id' do
+    context 'when signed in as super user' do
+      let(:current_user) { super_admin }
+
+      before do
+        sign_in(super_admin)
+      end
+
+      include_examples 'owner-only oauth application destroy'
+    end
+
+    context 'when signed in as a non-super user with manage_oauth_apps permission' do
+      let(:current_user) { authorized_user }
+
+      before do
+        sign_in(authorized_user)
+      end
+
+      include_examples 'owner-only oauth application destroy'
+    end
+  end
+end

--- a/spec/requests/oauth_applications_spec.rb
+++ b/spec/requests/oauth_applications_spec.rb
@@ -17,10 +17,10 @@ RSpec.describe 'OauthApplications', type: :request do
     sign_in_with_manage_oauth_apps(authorized_user)
   end
 
-  shared_examples 'denies access without manage_oauth_apps permission' do
+  shared_examples 'denies access without manage_oauth_apps permission' do |http_method = :get|
     before do
       sign_in(unauthorized_user)
-      get request_path
+      public_send(http_method, request_path)
     end
 
     it 'redirects to root with an authorization alert' do
@@ -252,6 +252,39 @@ RSpec.describe 'OauthApplications', type: :request do
       end
 
       include_examples 'owner-only oauth application destroy'
+    end
+  end
+
+  describe 'POST /oauth/applications/:id/regenerate_secret' do
+    let!(:user) { create(:user) }
+    let!(:application) { create(:oauth_application, user_id: user.id, name: 'OAuth App') }
+
+    before do
+      sign_in_with_manage_oauth_apps(user)
+    end
+
+    it 'regenerates the secret and redirects with a flash message' do
+      old_secret = application.secret
+      post regenerate_oauth_secret_path(application)
+      expect(response).to redirect_to(oauth_application_path(application))
+      follow_redirect!
+      expect(response.body).to include('Application secret has been regenerated')
+      application.reload
+      expect(application.secret).not_to eq(old_secret)
+    end
+
+    context 'when user is not authorized' do
+      let(:request_path) { regenerate_oauth_secret_path(application) }
+      include_examples 'denies access without manage_oauth_apps permission', :post
+    end
+
+    it 'does not allow a user with manage_oauth_apps to regenerate secret for an app they do not own' do
+      other_user = create(:user)
+      sign_in_with_manage_oauth_apps(other_user)
+      post regenerate_oauth_secret_path(application)
+      expect(response).to redirect_to(root_path)
+      follow_redirect!
+      expect(flash[:alert]).to eq('You are not authorized to perform this action.')
     end
   end
 end


### PR DESCRIPTION
# Summary
This PR introduces end-to-end OAuth application management for users, while enforcing required permissions to do so, as well as ownership-based access for sensitive actions. The work delivers the following:
- Permission-based access (`Perm.manage_oauth_app`) to Doorkeeper app management (**NOT** super-admin only)
- Ownership enforcement for update/destroy and UI action visibility (`current_user.id == application.user_id`)
- Secret regeneration from the OAuth application UI
- Test coverage for authorization and owner-only UI gating
- Supporting schema (creation of `oauth_applications.user_id` column), factories, and permission task updates

# Changes
## Authorization and ownership model
- Added `manage_oauth_apps` permission and `can_manage_oauth_apps?` User helper.
- Added `User.super_admins` scope for query-level super-admin selection.
- Added `user_id` foreign key on `oauth_applications` to support ownership.
- Implemented custom `OauthApplicationsController` extending `Doorkeeper` controller behavior:
- Super admins can view all apps.
- Non-super users with `manage_oauth_apps` can only see their own apps.
- Update/destroy (and related privileged actions) are owner-only.
## Doorkeeper integration and UX
- Updated Doorkeeper routes/config to use the custom `OauthApplicationsController` and delegated admin authentication.
- Added `manage_oauth_apps` option in admin permission UI.
- Added "Developer Tools" navigation link for users with `manage_oauth_apps` perm.
- Restored Doorkeeper `show` page toward upstream/default structure.
- Added `optional :write` scope support and improved scope selection in the OAuth app form.
- Added OAuth secret regeneration action and UI flow with one-time plaintext flash display and error handling.
- Added related i18n text and route support.
## UI safety and polish
- Gated owner-only action controls on index/show pages to prevent non-owners (specifically super admins) from seeing edit/delete/authorize actions.
- Refactored ownership checks to a shared `helper_method` for readability and reduced duplication.
- Included small accessibility/style polish for OAuth applications action controls.
## Tests
- Added request specs for OAuth applications access and behavior.
- Added focused controller spec coverage for application_params.
- Expanded request coverage for owner-only UI gating on index/show.
- Updated factories/traits to support `manage_oauth_apps` and `oauth_application` ownership.
