### PR TITLE
refactor(api-v1): Extract plan `create` logic into `CreateFromDmpService`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ### Changed
 
- - chore(doorkeeper): delete unneeded doorkeeper views
+ - chore(doorkeeper): delete unneeded doorkeeper views [#1319](https://github.com/portagenetwork/roadmap/pull/1319)
+
+ - refactor(api-v1): Extract plan `create` logic into `CreateFromDmpService` [#1328](https://github.com/portagenetwork/roadmap/pull/1328)
 
 ### Dependency Updates
 

--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -20,57 +20,17 @@ module Api
       end
 
       # POST /api/v1/plans
-      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       def create
-        dmp = @json.with_indifferent_access.fetch(:items, []).first.fetch(:dmp, {})
+        result = Api::Plans::CreateFromDmpService.new(json: @json, client: client).call
 
-        # Do a pass through the raw JSON and check to make sure all required fields
-        # were present. If not, return the specific errors
-        errs = Api::V1::JsonValidationService.validation_errors(json: dmp)
-        render_error(errors: errs, status: :bad_request) and return if errs.any?
-
-        # Convert the JSON into a Plan and it's associations
-        plan = Api::V1::Deserialization::Plan.deserialize(json: dmp)
-        if plan.present?
-          save_err = _('Unable to create your DMP')
-          exists_err = _('Plan already exists. Send an update instead.')
-          no_org_err = _("Could not determine ownership of the DMP. Please add an
-                          :affiliation to the :contact")
-
-          # Try to determine the Plan's owner
-          owner = determine_owner(client: client, plan: plan)
-          plan.org = owner.org if owner.present? && plan.org.blank?
-          render_error(errors: no_org_err, status: :bad_request) and return unless plan.org.present?
-
-          # Validate the plan and it's associations and return errors with context
-          # e.g. 'Contact affiliation name can't be blank' instead of 'name can't be blank'
-          errs = Api::V1::ContextualErrorService.process_plan_errors(plan: plan)
-
-          # The resulting plan (our its associations were invalid)
-          render_error(errors: errs, status: :bad_request) and return if errs.any?
-          # Skip if this is an existing DMP
-          render_error(errors: exists_err, status: :bad_request) and return unless plan.new_record?
-
-          # If we cannot save for some reason then return an error
-          plan = Api::V1::PersistenceService.safe_save(plan: plan)
-          render_error(errors: save_err, status: :internal_server_error) and return if plan.new_record?
-
-          # Invite the Owner if they are a Contributor then attach the Owner to the Plan
-          owner = invite_contributor(contributor: owner) if owner.is_a?(Contributor)
-          plan.add_user!(owner.id, :creator)
-
+        if result[:plan].present?
           # Kaminari Pagination requires an ActiveRecord result set :/
-          @items = paginate_response(results: Plan.where(id: plan.id))
+          @items = paginate_response(results: Plan.where(id: result[:plan].id))
           render '/api/v1/plans/index', status: :created
         else
-          render_error(errors: [_('Invalid JSON!')], status: :bad_request)
+          render_error(errors: result[:errors], status: result[:status])
         end
-      rescue JSON::ParserError
-        render_error(errors: [_('Invalid JSON')], status: :bad_request)
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
-      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
       # GET /api/v1/plans
       def index
@@ -102,53 +62,6 @@ module Api
         scheme = IdentifierScheme.by_name(json[:dmp_id][:type]).first
         Identifier.where(value: json[:dmp_id][:identifier], identifier_scheme: scheme).any?
       end
-
-      # Get the Plan's owner
-      def determine_owner(client:, plan:)
-        contact = plan.contributors.find(&:data_curation?)
-        # Use the contact if it was sent in and has an affiliation defined
-        return contact if contact.present? && contact.org.present?
-
-        # If the contact has no affiliation defined, see if they are already a User
-        user = lookup_user(contributor: contact)
-        return user if user.present?
-
-        # Otherwise just return the client
-        client
-      end
-
-      def lookup_user(contributor:)
-        return nil unless contributor.present?
-
-        identifiers = contributor.identifiers.map do |id|
-          { name: id.identifier_scheme&.name, value: id.value }
-        end
-        user = User.from_identifiers(array: identifiers) if identifiers.any?
-        user = User.find_by(email: contributor.email) unless user.present?
-        user
-      end
-
-      # rubocop:disable Metrics/AbcSize
-      def invite_contributor(contributor:)
-        return nil unless contributor.present?
-
-        # If the user was not found, invite them and attach any know identifiers
-        names = contributor.name&.split || ['']
-        firstname = names.length > 1 ? names.first : nil
-        surname = names.length > 1 ? names.last : names.first
-        user = User.invite!({ email: contributor.email,
-                              firstname: firstname,
-                              surname: surname,
-                              org: contributor.org }, client)
-
-        contributor.identifiers.each do |id|
-          user.identifiers << Identifier.new(
-            identifier_scheme: id.identifier_scheme, value: id.value
-          )
-        end
-        user
-      end
-      # rubocop:enable Metrics/AbcSize
     end
   end
 end

--- a/app/services/api/plans/create_from_dmp_service.rb
+++ b/app/services/api/plans/create_from_dmp_service.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+module Api
+  module Plans
+    class CreateFromDmpService
+      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+      def initialize(json:, client:)
+        @json = json
+        @client = client
+      end
+
+      def call
+        dmp = @json.with_indifferent_access.fetch(:items, []).first.fetch(:dmp, {})
+
+        # Do a pass through the raw JSON and check to make sure all required fields
+        # were present. If not, return the specific errors
+        errs = Api::V1::JsonValidationService.validation_errors(json: dmp)
+        render_error(errors: errs, status: :bad_request) and return if errs.any?
+
+        # Convert the JSON into a Plan and it's associations
+        plan = Api::V1::Deserialization::Plan.deserialize(json: dmp)
+        if plan.present?
+          save_err = _('Unable to create your DMP')
+          exists_err = _('Plan already exists. Send an update instead.')
+          no_org_err = _("Could not determine ownership of the DMP. Please add an
+                          :affiliation to the :contact")
+
+          # Try to determine the Plan's owner
+          owner = determine_owner(client: client, plan: plan)
+          plan.org = owner.org if owner.present? && plan.org.blank?
+          render_error(errors: no_org_err, status: :bad_request) and return unless plan.org.present?
+
+          # Validate the plan and it's associations and return errors with context
+          # e.g. 'Contact affiliation name can't be blank' instead of 'name can't be blank'
+          errs = Api::V1::ContextualErrorService.process_plan_errors(plan: plan)
+
+          # The resulting plan (our its associations were invalid)
+          render_error(errors: errs, status: :bad_request) and return if errs.any?
+          # Skip if this is an existing DMP
+          render_error(errors: exists_err, status: :bad_request) and return unless plan.new_record?
+
+          # If we cannot save for some reason then return an error
+          plan = Api::V1::PersistenceService.safe_save(plan: plan)
+          render_error(errors: save_err, status: :internal_server_error) and return if plan.new_record?
+
+          # Invite the Owner if they are a Contributor then attach the Owner to the Plan
+          owner = invite_contributor(contributor: owner) if owner.is_a?(Contributor)
+          plan.add_user!(owner.id, :creator)
+
+          # Kaminari Pagination requires an ActiveRecord result set :/
+          @items = paginate_response(results: Plan.where(id: plan.id))
+          render '/api/v1/plans/index', status: :created
+        else
+          render_error(errors: [_('Invalid JSON!')], status: :bad_request)
+        end
+      rescue JSON::ParserError
+        render_error(errors: [_('Invalid JSON')], status: :bad_request)
+      end
+
+      private
+
+      # Get the Plan's owner
+      def determine_owner(client:, plan:)
+        contact = plan.contributors.find(&:data_curation?)
+        # Use the contact if it was sent in and has an affiliation defined
+        return contact if contact.present? && contact.org.present?
+
+        # If the contact has no affiliation defined, see if they are already a User
+        user = lookup_user(contributor: contact)
+        return user if user.present?
+
+        # Otherwise just return the client
+        client
+      end
+
+      def lookup_user(contributor:)
+        return nil unless contributor.present?
+
+        identifiers = contributor.identifiers.map do |id|
+          { name: id.identifier_scheme&.name, value: id.value }
+        end
+        user = User.from_identifiers(array: identifiers) if identifiers.any?
+        user = User.find_by(email: contributor.email) unless user.present?
+        user
+      end
+
+      # rubocop:disable Metrics/AbcSize
+      def invite_contributor(contributor:)
+        return nil unless contributor.present?
+
+        # If the user was not found, invite them and attach any know identifiers
+        names = contributor.name&.split || ['']
+        firstname = names.length > 1 ? names.first : nil
+        surname = names.length > 1 ? names.last : names.first
+        user = User.invite!({ email: contributor.email,
+                              firstname: firstname,
+                              surname: surname,
+                              org: contributor.org }, client)
+
+        contributor.identifiers.each do |id|
+          user.identifiers << Identifier.new(
+            identifier_scheme: id.identifier_scheme, value: id.value
+          )
+        end
+        user
+      end
+      # rubocop:enable Metrics/AbcSize
+
+      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    end
+  end
+end

--- a/app/services/api/plans/create_from_dmp_service.rb
+++ b/app/services/api/plans/create_from_dmp_service.rb
@@ -2,21 +2,23 @@
 
 module Api
   module Plans
+    # Service for creating a Plan from a DMP JSON payload (API v1 format).
+    # Extracted to support reuse by future API versions.
     class CreateFromDmpService
-      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-
       def initialize(json:, client:)
         @json = json
         @client = client
       end
 
+      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       def call
         dmp = @json.with_indifferent_access.fetch(:items, []).first.fetch(:dmp, {})
 
         # Do a pass through the raw JSON and check to make sure all required fields
         # were present. If not, return the specific errors
         errs = Api::V1::JsonValidationService.validation_errors(json: dmp)
-        render_error(errors: errs, status: :bad_request) and return if errs.any?
+        return { errors: errs, status: :bad_request } if errs.any?
 
         # Convert the JSON into a Plan and it's associations
         plan = Api::V1::Deserialization::Plan.deserialize(json: dmp)
@@ -27,41 +29,41 @@ module Api
                           :affiliation to the :contact")
 
           # Try to determine the Plan's owner
-          owner = determine_owner(client: client, plan: plan)
+          owner = determine_owner(plan: plan)
           plan.org = owner.org if owner.present? && plan.org.blank?
-          render_error(errors: no_org_err, status: :bad_request) and return unless plan.org.present?
+          return { errors: no_org_err, status: :bad_request } unless plan.org.present?
 
           # Validate the plan and it's associations and return errors with context
           # e.g. 'Contact affiliation name can't be blank' instead of 'name can't be blank'
           errs = Api::V1::ContextualErrorService.process_plan_errors(plan: plan)
 
           # The resulting plan (our its associations were invalid)
-          render_error(errors: errs, status: :bad_request) and return if errs.any?
+          return { errors: errs, status: :bad_request } if errs.any?
           # Skip if this is an existing DMP
-          render_error(errors: exists_err, status: :bad_request) and return unless plan.new_record?
+          return { errors: exists_err, status: :bad_request } unless plan.new_record?
 
           # If we cannot save for some reason then return an error
           plan = Api::V1::PersistenceService.safe_save(plan: plan)
-          render_error(errors: save_err, status: :internal_server_error) and return if plan.new_record?
+          return { errors: save_err, status: :internal_server_error } if plan.new_record?
 
           # Invite the Owner if they are a Contributor then attach the Owner to the Plan
           owner = invite_contributor(contributor: owner) if owner.is_a?(Contributor)
           plan.add_user!(owner.id, :creator)
 
-          # Kaminari Pagination requires an ActiveRecord result set :/
-          @items = paginate_response(results: Plan.where(id: plan.id))
-          render '/api/v1/plans/index', status: :created
+          { plan: plan }
         else
-          render_error(errors: [_('Invalid JSON!')], status: :bad_request)
+          { errors: [_('Invalid JSON!')], status: :bad_request }
         end
       rescue JSON::ParserError
-        render_error(errors: [_('Invalid JSON')], status: :bad_request)
+        { errors: [_('Invalid JSON')], status: :bad_request }
       end
+      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
       private
 
       # Get the Plan's owner
-      def determine_owner(client:, plan:)
+      def determine_owner(plan:)
         contact = plan.contributors.find(&:data_curation?)
         # Use the contact if it was sent in and has an affiliation defined
         return contact if contact.present? && contact.org.present?
@@ -71,7 +73,7 @@ module Api
         return user if user.present?
 
         # Otherwise just return the client
-        client
+        @client
       end
 
       def lookup_user(contributor:)
@@ -96,7 +98,7 @@ module Api
         user = User.invite!({ email: contributor.email,
                               firstname: firstname,
                               surname: surname,
-                              org: contributor.org }, client)
+                              org: contributor.org }, @client)
 
         contributor.identifiers.each do |id|
           user.identifiers << Identifier.new(
@@ -106,8 +108,6 @@ module Api
         user
       end
       # rubocop:enable Metrics/AbcSize
-
-      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     end
   end
 end


### PR DESCRIPTION
# Description

Extracts the DMP creation business logic from `Api::V1::PlansController#create` 
into a new `Api::Plans::CreateFromDmpService`, in preparation for adding a v2 
plans create endpoint that can reuse the same logic.

# Changes proposed in this PR:

## `app/services/api/plans/create_from_dmp_service.rb` (new)
A service for creating a Plan from a DMP JSON payload (API v1 format), extracted
to support reuse by future API versions.
- Returns `{ plan: }` on success or `{ errors:, status: }` on failure.

## `app/controllers/api/v1/plans_controller.rb`
- Replaces the `create` method implementation with a call to the service
- Removes duplicate helper methods (`determine_owner`, `lookup_user`, 
  `invite_contributor`) now owned by the service
- No intended behavioural changes

# Note:

Existing `spec/requests/api/v1/plans_controller_spec.rb` passes without 
modification, supporting no behavioural changes.
