### PR TITLE
chore(doorkeeper): set `base_controller 'ApplicationController'`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
  - refactor(api-v1 specs): create spec file for `Api::Plans::CreateFromDmpService` & move `Api::V1::PlansController` specs [#1329](https://github.com/portagenetwork/roadmap/pull/1329)
 
+ - chore(doorkeeper): set `base_controller 'ApplicationController'` [#1332](https://github.com/portagenetwork/roadmap/pull/1332)
+
 ### Dependency Updates
 
  - chore(deps): bump eslint from 8.38.0 to 9.26.0 [#1270](https://github.com/portagenetwork/roadmap/pull/1270)

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -4,6 +4,9 @@ Doorkeeper.configure do
   # set the object-relational-model (ORM)
   orm :active_record
 
+  # https://doorkeeper.gitbook.io/guides/configuration/other-configurations
+  base_controller 'ApplicationController'
+
   # ensure resource owner is authenticated
   resource_owner_authenticator do
     if request.path == native_oauth_authorization_path


### PR DESCRIPTION
# Changes proposed in this PR:

Configure Doorkeeper to use `ApplicationController` as its base controller.

- By default, Doorkeeper controllers inherit directly from `ActionController::Base`.
- Setting `base_controller 'ApplicationController'` allows Doorkeeper routes to inherit app-specific behavior such as locale handling, branded view paths, and shared controller filters/rescues.
- This removes the need to duplicate locale and view-path setup in OAuth-specific controllers.
