### PR TITLE
chore(annotate): regen schema info for models & factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+ - chore(annotate): regen schema info for models & factories [#1340](https://github.com/portagenetwork/roadmap/pull/1340)
+
 ## [4.1.1+portage-4.8.0]
 
 ### Added

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -6,7 +6,7 @@
 #
 #  id             :integer          not null, primary key
 #  text           :text
-#  type           :integer          default(0), not null
+#  type           :integer          default("example_answer"), not null
 #  created_at     :datetime
 #  updated_at     :datetime
 #  org_id         :integer

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -15,9 +15,7 @@
 #
 # Indexes
 #
-#  fk_rails_3d5ed4418f           (question_id)
 #  fk_rails_584be190c2           (user_id)
-#  fk_rails_84a6005a3e           (plan_id)
 #  index_answers_on_plan_id      (plan_id)
 #  index_answers_on_question_id  (question_id)
 #

--- a/app/models/api_client.rb
+++ b/app/models/api_client.rb
@@ -4,25 +4,23 @@
 #
 # Table name: api_clients
 #
-#  id             :integer          not null, primary key
-#  name           :string,          not null
-#  homepage       :string
-#  contact_name   :string
-#  contact_email  :string,          not null
-#  client_id      :string,          not null
-#  client_secret  :string,          not null
-#  last_access    :datetime
-#  created_at     :datetime
-#  updated_at     :datetime
-#  org_id         :integer
+#  id            :integer          not null, primary key
+#  client_secret :string           not null
+#  contact_email :string           not null
+#  contact_name  :string
+#  description   :string
+#  homepage      :string
+#  last_access   :datetime
+#  name          :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  client_id     :string           not null
+#  org_id        :integer
 #
 # Indexes
 #
-#  index_api_clients_on_name     (name)
+#  index_api_clients_on_name  (name)
 #
-# Foreign Keys
-#
-#  fk_rails_...  (org_id => orgs.id)
 
 # Object that represents an external system
 class ApiClient < ApplicationRecord

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -4,15 +4,15 @@
 #
 # Table name: conditions
 #
-#  id                 :integer          not null, primary key
-#  question_id        :integer
-#  number             :integer
-#  action_type        :integer
-#  option_list        :text
-#  remove_data        :text
-#  webhook_data       :text
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
+#  id           :integer          not null, primary key
+#  action_type  :integer
+#  number       :integer
+#  option_list  :text
+#  remove_data  :text
+#  webhook_data :text
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  question_id  :integer
 #
 # Indexes
 #
@@ -20,8 +20,7 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (question_id => question.id)
-#
+#  fk_rails_...  (question_id => questions.id)
 #
 
 # Object that represents a condition of a conditional question

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -4,27 +4,23 @@
 #
 # Table name: contributors
 #
-#  id           :integer          not null, primary key
-#  firstname    :string
-#  surname      :string
-#  email        :string
-#  phone        :string
-#  roles        :integer
-#  org_id       :integer
-#  plan_id      :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  id         :integer          not null, primary key
+#  email      :string
+#  name       :string
+#  phone      :string
+#  roles      :integer          not null
+#  created_at :datetime
+#  updated_at :datetime
+#  org_id     :integer
+#  plan_id    :integer          not null
 #
 # Indexes
 #
-#  index_contributors_on_id      (id)
-#  index_contributors_on_email   (email)
-#  index_contributors_on_org_id  (org_id)
+#  index_contributors_on_email    (email)
+#  index_contributors_on_org_id   (org_id)
+#  index_contributors_on_plan_id  (plan_id)
+#  index_contributors_on_roles    (roles)
 #
-# Foreign Keys
-#
-#  fk_rails_...  (org_id => orgs.id)
-#  fk_rails_...  (plan_id => plans.id)
 
 # Object that represents a contributor to a plan
 class Contributor < ApplicationRecord

--- a/app/models/guidance_group.rb
+++ b/app/models/guidance_group.rb
@@ -9,7 +9,7 @@
 #
 #  id              :integer          not null, primary key
 #  name            :string
-#  optional_subset :boolean          default(FALSE), not null
+#  optional_subset :boolean          default(TRUE), not null
 #  published       :boolean          default(FALSE), not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/app/models/identifier.rb
+++ b/app/models/identifier.rb
@@ -11,11 +11,13 @@
 #  created_at           :datetime
 #  updated_at           :datetime
 #  identifiable_id      :integer
-#  identifier_scheme_id :integer          not null
+#  identifier_scheme_id :integer
 #
 # Indexes
 #
 #  index_identifiers_on_identifiable_type_and_identifiable_id  (identifiable_type,identifiable_id)
+#  index_identifiers_on_identifier_scheme_id_and_value         (identifier_scheme_id,value)
+#  index_identifiers_on_scheme_and_type_and_id                 (identifier_scheme_id,identifiable_id,identifiable_type)
 #
 
 # Object that represents an identifier for an object

--- a/app/models/identifier_scheme.rb
+++ b/app/models/identifier_scheme.rb
@@ -4,15 +4,15 @@
 #
 # Table name: identifier_schemes
 #
-#  id               :integer          not null, primary key
-#  active           :boolean
-#  description      :string
-#  context          :integer
-#  logo_url         :text
-#  name             :string
-#  user_landing_url :string
-#  created_at       :datetime
-#  updated_at       :datetime
+#  id                :integer          not null, primary key
+#  active            :boolean
+#  context           :integer
+#  description       :string
+#  identifier_prefix :text
+#  logo_url          :text
+#  name              :string
+#  created_at        :datetime
+#  updated_at        :datetime
 #
 
 # Object that represents a type of identifiaction (e.g. ORCID, ROR, etc.)

--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -4,7 +4,7 @@
 #
 # Table name: licenses
 #
-#  id           :bigint           not null, primary key
+#  id           :bigint(8)        not null, primary key
 #  deprecated   :boolean          default(FALSE)
 #  identifier   :string           not null
 #  name         :string           not null

--- a/app/models/metadata_standard.rb
+++ b/app/models/metadata_standard.rb
@@ -4,15 +4,15 @@
 #
 # Table name: metadata_standards
 #
-#  id                  :bigint           not null, primary key
-#  description         :text
-#  locations           :json
-#  related_entities    :json
-#  title               :string
-#  uri                 :string
-#  created_at          :datetime         not null
-#  updated_at          :datetime         not null
-#  rdamsc_id           :string
+#  id               :bigint(8)        not null, primary key
+#  description      :text
+#  locations        :json
+#  related_entities :json
+#  title            :string
+#  uri              :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  rdamsc_id        :string
 #
 class MetadataStandard < ApplicationRecord
   # =============

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -7,12 +7,12 @@
 #  id                :integer          not null, primary key
 #  body              :text
 #  dismissable       :boolean
+#  enabled           :boolean          default(TRUE)
 #  expires_at        :date
 #  level             :integer
 #  notification_type :integer
 #  starts_at         :date
 #  title             :string
-#  enabled            :boolean
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -4,31 +4,38 @@
 #
 # Table name: orgs
 #
-#  id                     :integer          not null, primary key
-#  abbreviation           :string
-#  contact_email          :string
-#  contact_name           :string
-#  feedback_msg           :text
-#  feedback_enabled       :boolean          default(FALSE)
-#  is_other :boolean default(FALSE), not null
-#  links                  :text
-#  logo_name              :string
-#  logo_uid               :string
-#  managed                :boolean          default(FALSE), not null
-#  name                   :string
-#  org_type               :integer          default(0), not null
-#  sort_name              :string
-#  target_url             :string
-#  created_at             :datetime         not null
-#  updated_at             :datetime         not null
-#  language_id            :integer
-#  region_id              :integer
-#  managed                :boolean          default(false), not null
-#  helpdesk_email         :string
+#  id                      :integer          not null, primary key
+#  abbreviation            :string
+#  banner_name             :string
+#  banner_uid              :string
+#  contact_email           :string
+#  contact_name            :string
+#  display_in_registration :boolean
+#  feedback_enabled        :boolean          default(FALSE)
+#  feedback_msg            :text
+#  helpdesk_email          :string
+#  is_other                :boolean          default(FALSE), not null
+#  links                   :text
+#  logo_name               :string
+#  logo_uid                :string
+#  managed                 :boolean          default(FALSE), not null
+#  name                    :string
+#  org_type                :integer          default(0), not null
+#  target_url              :string
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  language_id             :integer
+#  region_id               :integer
+#
+# Indexes
+#
+#  fk_rails_5640112cab  (language_id)
+#  fk_rails_5a6adf6bab  (region_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (language_id => languages.id)
+#  fk_rails_...  (region_id => regions.id)
 #
 
 # Object that represents an Organization/Institution/Funder

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -7,37 +7,39 @@
 #
 # Table name: plans
 #
-#  id                                :integer          not null, primary key
-#  complete                          :boolean          default(FALSE)
-#  description                       :text
-#  feedback_requested                :boolean          default(FALSE)
-#  identifier                        :string
-#  title                             :string
-#  visibility                        :integer          default(3), not null
-#  created_at                        :datetime
-#  updated_at                        :datetime
-#  template_id                       :integer
-#  org_id                            :integer
-#  funder_id                         :integer
-#  grant_id                          :integer
-#  research_domain_id                :bigint
-#  funding_status                    :integer
-#  ethical_issues                    :boolean
-#  ethical_issues_description        :text
-#  ethical_issues_report             :string
+#  id                         :integer          not null, primary key
+#  complete                   :boolean          default(FALSE)
+#  description                :text
+#  end_date                   :datetime
+#  ethical_issues             :boolean
+#  ethical_issues_description :text
+#  ethical_issues_report      :string
+#  feedback_requested         :boolean          default(FALSE)
+#  funding_status             :integer
+#  identifier                 :string
+#  start_date                 :datetime
+#  title                      :string
+#  visibility                 :integer          default("privately_visible"), not null
+#  created_at                 :datetime
+#  updated_at                 :datetime
+#  funder_id                  :integer
+#  grant_id                   :integer
+#  org_id                     :integer
+#  research_domain_id         :bigint(8)
+#  template_id                :integer
 #
 # Indexes
 #
-#  index_plans_on_template_id   (template_id)
-#  index_plans_on_funder_id     (funder_id)
-#  index_plans_on_grant_id      (grant_id)
-#  index_plans_on_api_client_id (api_client_id)
+#  index_plans_on_funder_id           (funder_id)
+#  index_plans_on_grant_id            (grant_id)
+#  index_plans_on_org_id              (org_id)
+#  index_plans_on_research_domain_id  (research_domain_id)
+#  index_plans_on_template_id         (template_id)
 #
 # Foreign Keys
 #
-#  fk_rails_...  (template_id => templates.id)
 #  fk_rails_...  (org_id => orgs.id)
-#  fk_rails_...  (research_domain_id => research_domains.id)
+#  fk_rails_...  (template_id => templates.id)
 #
 
 # Object that represents an DMP

--- a/app/models/question_format.rb
+++ b/app/models/question_format.rb
@@ -6,7 +6,7 @@
 #
 #  id           :integer          not null, primary key
 #  description  :text
-#  formattype   :integer          default(0)
+#  formattype   :integer          default("textarea")
 #  option_based :boolean          default(FALSE)
 #  title        :string
 #  created_at   :datetime         not null

--- a/app/models/question_option.rb
+++ b/app/models/question_option.rb
@@ -4,17 +4,19 @@
 #
 # Table name: question_options
 #
-#  id          :integer          not null, primary key
-#  is_default  :boolean
-#  number      :integer
-#  text        :string
-#  created_at  :datetime
-#  updated_at  :datetime
-#  question_id :integer
+#  id             :integer          not null, primary key
+#  is_default     :boolean
+#  number         :integer
+#  text           :string
+#  created_at     :datetime
+#  updated_at     :datetime
+#  question_id    :integer
+#  versionable_id :string(36)
 #
 # Indexes
 #
-#  index_question_options_on_question_id  (question_id)
+#  index_question_options_on_question_id     (question_id)
+#  index_question_options_on_versionable_id  (versionable_id)
 #
 # Foreign Keys
 #

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -4,12 +4,11 @@
 #
 # Table name: regions
 #
-#  id           :integer          not null, primary key
-#  abbreviation :string
-#  description  :string
-#  name         :string           not null
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
+#  id              :integer          not null, primary key
+#  abbreviation    :string
+#  description     :string
+#  name            :string
+#  super_region_id :integer
 #
 
 # Object that represents a regional area

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -4,23 +4,22 @@
 #
 # Table name: repositories
 #
-#  id          :bigint           not null, primary key
+#  id          :bigint(8)        not null, primary key
 #  contact     :string
 #  description :text             not null
+#  homepage    :string
 #  info        :json
 #  name        :string           not null
-#  homepage    :string
+#  uri         :string           not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  uri         :string           not null
 #
 # Indexes
 #
-#  index_repositories_on_name     (name)
-#  index_repositories_on_homepage (homepage)
-#  index_repositories_on_uri      (uri)
+#  index_repositories_on_homepage  (homepage)
+#  index_repositories_on_name      (name)
+#  index_repositories_on_uri       (uri)
 #
-# Object that represents a research output repository (e.g. GitHub or Zenodo)
 class Repository < ApplicationRecord
   # =============
   # = Constants =

--- a/app/models/research_domain.rb
+++ b/app/models/research_domain.rb
@@ -4,12 +4,12 @@
 #
 # Table name: research_domains
 #
-#  id         :bigint        not null, primary key
-#  identifier :string        not null
-#  label      :string        not null
-#  created_at :datetime      not null
-#  updated_at :datetime      not null
-#  parent_id  :bigint
+#  id         :bigint(8)        not null, primary key
+#  identifier :string           not null
+#  label      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  parent_id  :bigint(8)
 #
 # Indexes
 #

--- a/app/models/research_output.rb
+++ b/app/models/research_output.rb
@@ -4,10 +4,10 @@
 #
 # Table name: research_outputs
 #
-#  id                      :bigint           not null, primary key
+#  id                      :bigint(8)        not null, primary key
 #  abbreviation            :string
 #  access                  :integer          default("open"), not null
-#  byte_size               :bigint
+#  byte_size               :bigint(8)
 #  description             :text
 #  display_order           :integer
 #  is_default              :boolean
@@ -19,16 +19,17 @@
 #  title                   :string           not null
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  license_id              :bigint
+#  license_id              :bigint(8)
 #  plan_id                 :integer
 #
 # Indexes
 #
+#  index_research_outputs_on_license_id   (license_id)
 #  index_research_outputs_on_output_type  (output_type)
+#  index_research_outputs_on_plan_id      (plan_id)
 #
 # Foreign Keys
 #
-#  fk_rails_...  (plan_id => plans.id)
 #  fk_rails_...  (license_id => licenses.id)
 #
 

--- a/app/models/tracker.rb
+++ b/app/models/tracker.rb
@@ -1,6 +1,23 @@
 # frozen_string_literal: true
 
-# Object that represents a Google Analytics tracker code
+# == Schema Information
+#
+# Table name: trackers
+#
+#  id         :integer          not null, primary key
+#  code       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  org_id     :integer
+#
+# Indexes
+#
+#  index_trackers_on_org_id  (org_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (org_id => orgs.id)
+#
 class Tracker < ApplicationRecord
   belongs_to :org
   validates :code, format: { with: /\A\z|\AUA-[0-9]+-[0-9]+\z/,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,17 +13,19 @@
 #  confirmed_at           :datetime
 #  current_sign_in_at     :datetime
 #  current_sign_in_ip     :string
+#  dmponline3             :boolean
 #  email                  :string(80)       default(""), not null
-#  encrypted_password     :string
+#  encrypted_password     :string           default("")
 #  firstname              :string
 #  invitation_accepted_at :datetime
 #  invitation_created_at  :datetime
 #  invitation_sent_at     :datetime
 #  invitation_token       :string
 #  invited_by_type        :string
+#  last_api_access        :datetime
 #  last_sign_in_at        :datetime
 #  last_sign_in_ip        :string
-#  other_organisation :string
+#  other_organisation     :string
 #  recovery_email         :string
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
@@ -41,7 +43,7 @@
 #
 #  fk_rails_45f4f12508    (language_id)
 #  fk_rails_f29bf9cdf2    (department_id)
-#  index_users_on_email   (email)
+#  index_users_on_email   (email) UNIQUE
 #  index_users_on_org_id  (org_id)
 #
 # Foreign Keys

--- a/spec/factories/annotations.rb
+++ b/spec/factories/annotations.rb
@@ -6,7 +6,7 @@
 #
 #  id             :integer          not null, primary key
 #  text           :text
-#  type           :integer          default(0), not null
+#  type           :integer          default("example_answer"), not null
 #  created_at     :datetime
 #  updated_at     :datetime
 #  org_id         :integer

--- a/spec/factories/answers.rb
+++ b/spec/factories/answers.rb
@@ -15,9 +15,7 @@
 #
 # Indexes
 #
-#  fk_rails_3d5ed4418f           (question_id)
 #  fk_rails_584be190c2           (user_id)
-#  fk_rails_84a6005a3e           (plan_id)
 #  index_answers_on_plan_id      (plan_id)
 #  index_answers_on_question_id  (question_id)
 #

--- a/spec/factories/api_clients.rb
+++ b/spec/factories/api_clients.rb
@@ -4,25 +4,23 @@
 #
 # Table name: api_clients
 #
-#  id             :integer          not null, primary key
-#  name           :string,          not null
-#  homepage       :string
-#  contact_name   :string
-#  contact_email  :string,          not null
-#  client_id      :string,          not null
-#  client_secret  :string,          not null
-#  last_access    :datetime
-#  created_at     :datetime
-#  updated_at     :datetime
-#  org_id         :integer
+#  id            :integer          not null, primary key
+#  client_secret :string           not null
+#  contact_email :string           not null
+#  contact_name  :string
+#  description   :string
+#  homepage      :string
+#  last_access   :datetime
+#  name          :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  client_id     :string           not null
+#  org_id        :integer
 #
 # Indexes
 #
-#  index_api_clients_on_name     (name)
+#  index_api_clients_on_name  (name)
 #
-# Foreign Keys
-#
-#  fk_rails_...  (org_id => orgs.id)
 
 FactoryBot.define do
   factory :api_client do

--- a/spec/factories/conditions.rb
+++ b/spec/factories/conditions.rb
@@ -4,15 +4,15 @@
 #
 # Table name: conditions
 #
-#  id                 :integer          not null, primary key
-#  question_id        :integer
-#  number             :integer
-#  action_type        :integer
-#  option_list        :text
-#  remove_data        :text
-#  webhook_data       :text
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
+#  id           :integer          not null, primary key
+#  action_type  :integer
+#  number       :integer
+#  option_list  :text
+#  remove_data  :text
+#  webhook_data :text
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  question_id  :integer
 #
 # Indexes
 #
@@ -20,8 +20,7 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (question_id => question.id)
-#
+#  fk_rails_...  (question_id => questions.id)
 #
 
 FactoryBot.define do

--- a/spec/factories/contributors.rb
+++ b/spec/factories/contributors.rb
@@ -4,26 +4,23 @@
 #
 # Table name: contributors
 #
-#  id           :integer          not null, primary key
-#  name         :string
-#  email        :string
-#  phone        :string
-#  roles        :integer
-#  org_id       :integer
-#  plan_id      :integer
-#  created_at   :datetime
-#  updated_at   :datetime
+#  id         :integer          not null, primary key
+#  email      :string
+#  name       :string
+#  phone      :string
+#  roles      :integer          not null
+#  created_at :datetime
+#  updated_at :datetime
+#  org_id     :integer
+#  plan_id    :integer          not null
 #
 # Indexes
 #
-#  index_contributors_on_id      (id)
-#  index_contributors_on_email   (email)
-#  index_contributors_on_org_id  (org_id)
+#  index_contributors_on_email    (email)
+#  index_contributors_on_org_id   (org_id)
+#  index_contributors_on_plan_id  (plan_id)
+#  index_contributors_on_roles    (roles)
 #
-# Foreign Keys
-#
-#  fk_rails_...  (org_id => orgs.id)
-#  fk_rails_...  (plan_id => plans.id)
 
 FactoryBot.define do
   factory :contributor do

--- a/spec/factories/guidance_groups.rb
+++ b/spec/factories/guidance_groups.rb
@@ -6,7 +6,7 @@
 #
 #  id              :integer          not null, primary key
 #  name            :string
-#  optional_subset :boolean          default(FALSE), not null
+#  optional_subset :boolean          default(TRUE), not null
 #  published       :boolean          default(FALSE), not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/spec/factories/identifier_schemes.rb
+++ b/spec/factories/identifier_schemes.rb
@@ -6,11 +6,11 @@
 #
 #  id                :integer          not null, primary key
 #  active            :boolean
-#  description       :string
 #  context           :integer
+#  description       :string
+#  identifier_prefix :text
 #  logo_url          :text
 #  name              :string
-#  identifier_prefix :string
 #  created_at        :datetime
 #  updated_at        :datetime
 #

--- a/spec/factories/identifiers.rb
+++ b/spec/factories/identifiers.rb
@@ -11,11 +11,13 @@
 #  created_at           :datetime
 #  updated_at           :datetime
 #  identifiable_id      :integer
-#  identifier_scheme_id :integer          not null
+#  identifier_scheme_id :integer
 #
 # Indexes
 #
 #  index_identifiers_on_identifiable_type_and_identifiable_id  (identifiable_type,identifiable_id)
+#  index_identifiers_on_identifier_scheme_id_and_value         (identifier_scheme_id,value)
+#  index_identifiers_on_scheme_and_type_and_id                 (identifier_scheme_id,identifiable_id,identifiable_type)
 #
 
 FactoryBot.define do

--- a/spec/factories/licenses.rb
+++ b/spec/factories/licenses.rb
@@ -4,7 +4,7 @@
 #
 # Table name: licenses
 #
-#  id           :bigint           not null, primary key
+#  id           :bigint(8)        not null, primary key
 #  deprecated   :boolean          default(FALSE)
 #  identifier   :string           not null
 #  name         :string           not null

--- a/spec/factories/metadata_standards.rb
+++ b/spec/factories/metadata_standards.rb
@@ -4,15 +4,15 @@
 #
 # Table name: metadata_standards
 #
-#  id                  :bigint           not null, primary key
-#  description         :text
-#  locations           :json
-#  related_entities    :json
-#  title               :string
-#  uri                 :string
-#  created_at          :datetime         not null
-#  updated_at          :datetime         not null
-#  rdamsc_id           :string
+#  id               :bigint(8)        not null, primary key
+#  description      :text
+#  locations        :json
+#  related_entities :json
+#  title            :string
+#  uri              :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  rdamsc_id        :string
 #
 FactoryBot.define do
   factory :metadata_standard do

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -7,12 +7,12 @@
 #  id                :integer          not null, primary key
 #  body              :text
 #  dismissable       :boolean
+#  enabled           :boolean          default(TRUE)
 #  expires_at        :date
 #  level             :integer
 #  notification_type :integer
 #  starts_at         :date
 #  title             :string
-#  enable            :boolean
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #

--- a/spec/factories/orgs.rb
+++ b/spec/factories/orgs.rb
@@ -4,31 +4,38 @@
 #
 # Table name: orgs
 #
-#  id                     :integer          not null, primary key
-#  abbreviation           :string
-#  contact_email          :string
-#  contact_name           :string
-#  feedback_msg           :text
-#  feedback_enabled       :boolean          default(FALSE)
-#  is_other               :boolean          default(FALSE), not null
-#  links                  :text
-#  logo_name              :string
-#  logo_uid               :string
-#  managed                :boolean          default(FALSE), not null
-#  name                   :string
-#  org_type               :integer          default(0), not null
-#  target_url             :string
-#  created_at             :datetime         not null
-#  updated_at             :datetime         not null
-#  language_id            :integer
+#  id                      :integer          not null, primary key
+#  abbreviation            :string
+#  banner_name             :string
+#  banner_uid              :string
+#  contact_email           :string
+#  contact_name            :string
+#  display_in_registration :boolean
+#  feedback_enabled        :boolean          default(FALSE)
+#  feedback_msg            :text
+#  helpdesk_email          :string
+#  is_other                :boolean          default(FALSE), not null
+#  links                   :text
+#  logo_name               :string
+#  logo_uid                :string
+#  managed                 :boolean          default(FALSE), not null
+#  name                    :string
+#  org_type                :integer          default(0), not null
+#  target_url              :string
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  language_id             :integer
+#  region_id               :integer
 #
 # Indexes
 #
 #  fk_rails_5640112cab  (language_id)
+#  fk_rails_5a6adf6bab  (region_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (language_id => languages.id)
+#  fk_rails_...  (region_id => regions.id)
 #
 
 FactoryBot.define do

--- a/spec/factories/plans.rb
+++ b/spec/factories/plans.rb
@@ -4,39 +4,39 @@
 #
 # Table name: plans
 #
-#  id                                :integer          not null, primary key
-#  complete                          :boolean          default(FALSE)
-#  description                       :text
-#  ethical_issues                    :boolean
-#  ethical_issues_description        :text
-#  ethical_issues_report             :string
-#  feedback_requested                :boolean          default(FALSE)
-#  funding_status                    :integer
-#  identifier                        :string
-#  title                             :string
-#  visibility                        :integer          default(3), not null
-#  created_at                        :datetime
-#  updated_at                        :datetime
-#  template_id                       :integer
-#  org_id                            :integer
-#  funder_id                         :integer
-#  grant_id                          :integer
-#  api_client_id                     :integer
-#  research_domain_id                :bigint
+#  id                         :integer          not null, primary key
+#  complete                   :boolean          default(FALSE)
+#  description                :text
+#  end_date                   :datetime
+#  ethical_issues             :boolean
+#  ethical_issues_description :text
+#  ethical_issues_report      :string
+#  feedback_requested         :boolean          default(FALSE)
+#  funding_status             :integer
+#  identifier                 :string
+#  start_date                 :datetime
+#  title                      :string
+#  visibility                 :integer          default("privately_visible"), not null
+#  created_at                 :datetime
+#  updated_at                 :datetime
+#  funder_id                  :integer
+#  grant_id                   :integer
+#  org_id                     :integer
+#  research_domain_id         :bigint(8)
+#  template_id                :integer
 #
 # Indexes
 #
-#  index_plans_on_template_id   (template_id)
-#  index_plans_on_funder_id     (funder_id)
-#  index_plans_on_grant_id      (grant_id)
-#  index_plans_on_api_client_id (api_client_id)
+#  index_plans_on_funder_id           (funder_id)
+#  index_plans_on_grant_id            (grant_id)
+#  index_plans_on_org_id              (org_id)
+#  index_plans_on_research_domain_id  (research_domain_id)
+#  index_plans_on_template_id         (template_id)
 #
 # Foreign Keys
 #
-#  fk_rails_...  (template_id => templates.id)
 #  fk_rails_...  (org_id => orgs.id)
-#  fk_rails_...  (api_client_id => api_clients.id)
-#  fk_rails_...  (research_domain_id => research_domains.id)
+#  fk_rails_...  (template_id => templates.id)
 #
 
 FactoryBot.define do

--- a/spec/factories/question_formats.rb
+++ b/spec/factories/question_formats.rb
@@ -6,7 +6,7 @@
 #
 #  id           :integer          not null, primary key
 #  description  :text
-#  formattype   :integer          default(0)
+#  formattype   :integer          default("textarea")
 #  option_based :boolean          default(FALSE)
 #  title        :string
 #  created_at   :datetime         not null

--- a/spec/factories/question_options.rb
+++ b/spec/factories/question_options.rb
@@ -4,17 +4,19 @@
 #
 # Table name: question_options
 #
-#  id          :integer          not null, primary key
-#  is_default  :boolean
-#  number      :integer
-#  text        :string
-#  created_at  :datetime
-#  updated_at  :datetime
-#  question_id :integer
+#  id             :integer          not null, primary key
+#  is_default     :boolean
+#  number         :integer
+#  text           :string
+#  created_at     :datetime
+#  updated_at     :datetime
+#  question_id    :integer
+#  versionable_id :string(36)
 #
 # Indexes
 #
-#  index_question_options_on_question_id  (question_id)
+#  index_question_options_on_question_id     (question_id)
+#  index_question_options_on_versionable_id  (versionable_id)
 #
 # Foreign Keys
 #

--- a/spec/factories/regions.rb
+++ b/spec/factories/regions.rb
@@ -4,12 +4,11 @@
 #
 # Table name: regions
 #
-#  id           :integer          not null, primary key
-#  abbreviation :string
-#  description  :string
-#  name         :string           not null
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
+#  id              :integer          not null, primary key
+#  abbreviation    :string
+#  description     :string
+#  name            :string
+#  super_region_id :integer
 #
 
 FactoryBot.define do

--- a/spec/factories/repositories.rb
+++ b/spec/factories/repositories.rb
@@ -4,21 +4,21 @@
 #
 # Table name: repositories
 #
-#  id          :bigint           not null, primary key
+#  id          :bigint(8)        not null, primary key
 #  contact     :string
 #  description :text             not null
+#  homepage    :string
 #  info        :json
 #  name        :string           not null
-#  homepage    :string
+#  uri         :string           not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  uri         :string           not null
 #
 # Indexes
 #
-#  index_repositories_on_name  (name)
-#  index_repositories_on_url   (homepage)
-#  index_repositories_on_url   (uri)
+#  index_repositories_on_homepage  (homepage)
+#  index_repositories_on_name      (name)
+#  index_repositories_on_uri       (uri)
 #
 FactoryBot.define do
   factory :repository do

--- a/spec/factories/research_domains.rb
+++ b/spec/factories/research_domains.rb
@@ -5,15 +5,15 @@
 # Table name: research_domains
 #
 #  id         :bigint(8)        not null, primary key
-#  identifier :string(255)      not null
-#  label      :string(255)      not null
+#  identifier :string           not null
+#  label      :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  parent_id  :bigint(8)
 #
 # Indexes
 #
-#  index_research_domain_on_parent_id  (parent_id)
+#  index_research_domains_on_parent_id  (parent_id)
 #
 # Foreign Keys
 #

--- a/spec/factories/research_outputs.rb
+++ b/spec/factories/research_outputs.rb
@@ -5,18 +5,18 @@
 # Table name: research_outputs
 #
 #  id                      :bigint(8)        not null, primary key
-#  abbreviation            :string(255)
+#  abbreviation            :string
 #  access                  :integer          default("open"), not null
 #  byte_size               :bigint(8)
-#  description             :text(65535)
+#  description             :text
 #  display_order           :integer
 #  is_default              :boolean
 #  output_type             :integer          default("dataset"), not null
-#  output_type_description :string(255)
+#  output_type_description :string
 #  personal_data           :boolean
 #  release_date            :datetime
 #  sensitive_data          :boolean
-#  title                   :string(255)      not null
+#  title                   :string           not null
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #  license_id              :bigint(8)
@@ -27,6 +27,10 @@
 #  index_research_outputs_on_license_id   (license_id)
 #  index_research_outputs_on_output_type  (output_type)
 #  index_research_outputs_on_plan_id      (plan_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (license_id => licenses.id)
 #
 FactoryBot.define do
   factory :research_output do

--- a/spec/factories/trackers.rb
+++ b/spec/factories/trackers.rb
@@ -1,5 +1,23 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: trackers
+#
+#  id         :integer          not null, primary key
+#  code       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  org_id     :integer
+#
+# Indexes
+#
+#  index_trackers_on_org_id  (org_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (org_id => orgs.id)
+#
 FactoryBot.define do
   factory :tracker do
     org { nil }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -13,14 +13,16 @@
 #  confirmed_at           :datetime
 #  current_sign_in_at     :datetime
 #  current_sign_in_ip     :string
+#  dmponline3             :boolean
 #  email                  :string(80)       default(""), not null
-#  encrypted_password     :string
+#  encrypted_password     :string           default("")
 #  firstname              :string
 #  invitation_accepted_at :datetime
 #  invitation_created_at  :datetime
 #  invitation_sent_at     :datetime
 #  invitation_token       :string
 #  invited_by_type        :string
+#  last_api_access        :datetime
 #  last_sign_in_at        :datetime
 #  last_sign_in_ip        :string
 #  other_organisation     :string
@@ -41,7 +43,7 @@
 #
 #  fk_rails_45f4f12508    (language_id)
 #  fk_rails_f29bf9cdf2    (department_id)
-#  index_users_on_email   (email)
+#  index_users_on_email   (email) UNIQUE
 #  index_users_on_org_id  (org_id)
 #
 # Foreign Keys


### PR DESCRIPTION
# Changes proposed in this PR:
Regenerate schema annotations via `bundle exec rake annotate_models`.

- updates auto-generated `== Schema Information` comments across models and factories
- aligns column metadata (types/defaults/nullability), indexes, and foreign key notes with current DB schema
- no runtime logic changes; documentation-only sync
