### PR TITLE
refactor(api/v2/plans): extract extension JSON into separate partial and add test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
  - chore(annotate): regen schema info for models & factories [#1340](https://github.com/portagenetwork/roadmap/pull/1340)
 
+ - refactor(api/v2/plans): extract extension JSON into separate partial and add test coverage [#1343](https://github.com/portagenetwork/roadmap/pull/1343)
+
 ## [4.1.1+portage-4.8.0]
 
 ### Added

--- a/app/views/api/v2/plans/_extension.json.jbuilder
+++ b/app/views/api/v2/plans/_extension.json.jbuilder
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# locals: plan, presenter
+
+json.extension [plan.template] do |template|
+  json.set! :dmproadmap do
+    json.template do
+      json.id template.id
+      json.title strip_tags(template.title)
+    end
+  end
+
+  if @complete
+    json.complete_plan do
+      q_and_a = presenter.complete_plan_data
+      next if q_and_a.blank?
+
+      json.array! q_and_a do |item|
+        json.question_id item[:id]
+        json.title item[:title]
+        json.section strip_tags(item[:section])
+        json.question sanitize(item[:question])
+        json.answer sanitize(item[:answer])
+      end
+    end
+  end
+end

--- a/app/views/api/v2/plans/_show.json.jbuilder
+++ b/app/views/api/v2/plans/_show.json.jbuilder
@@ -61,27 +61,5 @@ unless @minimal
     json.partial! "api/v2/datasets/show", output: output
   end
 
-  json.extension [plan.template] do |template|
-    json.set! :dmproadmap do
-      json.template do
-        json.id template.id
-        json.title strip_tags(template.title)
-      end
-    end
-
-    if @complete
-      json.complete_plan do
-        q_and_a = presenter.complete_plan_data
-        next if q_and_a.blank?
-
-        json.array! q_and_a do |item|
-          json.question_id item[:id]
-          json.title item[:title]
-          json.section strip_tags(item[:section])
-          json.question sanitize(item[:question])
-          json.answer sanitize(item[:answer])
-        end
-      end
-    end
-  end
+  json.partial! 'api/v2/plans/extension', plan: plan, presenter: presenter unless @rda_only
 end

--- a/spec/views/api/v2/plans/_extension.json.jbuilder_spec.rb
+++ b/spec/views/api/v2/plans/_extension.json.jbuilder_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'api/v2/plans/_extension.json.jbuilder' do
+  before do
+    @plan = create(:plan, :creator)
+    @plan.template.update!(title: 'Template title')
+    @presenter = Api::V2::PlanPresenter.new(plan: @plan)
+  end
+
+  describe 'extension payload' do
+    before do
+      render partial: 'api/v2/plans/extension',
+             locals: { plan: @plan, presenter: @presenter }
+      @json = JSON.parse(rendered).with_indifferent_access
+      @extension = @json[:extension].first.with_indifferent_access
+    end
+
+    it 'includes one extension entry' do
+      expect(@json[:extension].length).to eql(1)
+    end
+
+    it 'includes the dmproadmap template id' do
+      expect(@extension[:dmproadmap][:template][:id]).to eql(@plan.template.id)
+    end
+
+    it 'includes template title' do
+      expect(@extension[:dmproadmap][:template][:title]).to eql('Template title')
+    end
+
+    it 'does not include complete_plan by default' do
+      expect(@extension[:complete_plan]).to be_nil
+    end
+  end
+
+  describe 'when @complete is true' do
+    before do
+      assign(:complete, true)
+    end
+
+    it 'includes complete_plan when presenter has data' do
+      @presenter.stubs(:complete_plan_data).returns([
+                                                      {
+                                                        id: 123,
+                                                        title: 'Q1',
+                                                        section: 'Section A',
+                                                        question: 'What data?',
+                                                        answer: 'Public repository'
+                                                      }
+                                                    ])
+
+      render partial: 'api/v2/plans/extension',
+             locals: { plan: @plan, presenter: @presenter }
+
+      json = JSON.parse(rendered).with_indifferent_access
+      extension = json[:extension].first.with_indifferent_access
+
+      expect(extension[:complete_plan]).to be_an(Array)
+      expect(extension[:complete_plan].length).to eql(1)
+      expect(extension[:complete_plan].first[:question_id]).to eql(123)
+      expect(extension[:complete_plan].first[:title]).to eql('Q1')
+      expect(extension[:complete_plan].first[:section]).to eql('Section A')
+      expect(extension[:complete_plan].first[:question]).to eql('What data?')
+      expect(extension[:complete_plan].first[:answer]).to eql('Public repository')
+    end
+
+    it 'omits complete_plan when presenter data is blank' do
+      @presenter.stubs(:complete_plan_data).returns([])
+
+      render partial: 'api/v2/plans/extension',
+             locals: { plan: @plan, presenter: @presenter }
+
+      json = JSON.parse(rendered).with_indifferent_access
+      extension = json[:extension].first.with_indifferent_access
+
+      expect(extension[:complete_plan]).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
# Changes proposed in this PR:
Extract the extension-specific JSON from `api/v2/plans/_show.json.jbuilder` into a dedicated `api/v2/plans/_extension.json.jbuilder` partial.
- `@rda_only` is currently always nil, so behaviour prior to this commit remains unchanged.
- improves maintainability for follow up work that separately saves `rda_json` and `extension_json` to `plan_snapshots` table.

Add dedicated view coverage for `api/v2/plans/_extension.json.jbuilder`
- the `extension` payload did not have standalone coverage prior to the partial extraction.
- verify `dmproadmap` template rendering and conditional `complete_plan` output.