### PR TITLE
perf(org/admin/users/admin_index): optimise list rendering

### DIFF
--- a/app/controllers/paginable/users_controller.rb
+++ b/app/controllers/paginable/users_controller.rb
@@ -17,7 +17,7 @@ module Paginable
       scope = if current_user.can_super_admin?
                 User.includes(:department, :org, :perms, :roles, identifiers: :identifier_scheme)
               else
-                current_user.org.users.includes(:department, :org, :perms, :roles, identifiers: :identifier_scheme)
+                current_user.org.users.includes(:department, :perms, :roles, identifiers: :identifier_scheme)
               end
 
       scope = scope.joins(:perms).distinct if @filter_admin

--- a/app/controllers/paginable/users_controller.rb
+++ b/app/controllers/paginable/users_controller.rb
@@ -15,9 +15,9 @@ module Paginable
       @filter_admin = params[:filter_admin] == '1'
 
       scope = if current_user.can_super_admin?
-                User.includes(:department, :org, :perms, :roles, :identifiers)
+                User.includes(:department, :org, :perms, :roles, identifiers: :identifier_scheme)
               else
-                current_user.org.users.includes(:department, :org, :perms, :roles, :identifiers)
+                current_user.org.users.includes(:department, :org, :perms, :roles, identifiers: :identifier_scheme)
               end
 
       scope = scope.joins(:perms).distinct if @filter_admin

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,7 +24,7 @@ class UsersController < ApplicationController
                    User.includes(:department, :org, :perms, :roles, identifiers: :identifier_scheme).page(1)
                  else
                    current_user.org.users
-                               .includes(:department, :org, :perms, :roles, identifiers: :identifier_scheme)
+                               .includes(:department, :perms, :roles, identifiers: :identifier_scheme)
                                .page(1)
                  end
       end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,10 +21,10 @@ class UsersController < ApplicationController
         @filter_admin = false
 
         @users = if current_user.can_super_admin?
-                   User.includes(:department, :org, :perms, :roles, :identifiers).page(1)
+                   User.includes(:department, :org, :perms, :roles, identifiers: :identifier_scheme).page(1)
                  else
                    current_user.org.users
-                               .includes(:department, :org, :perms, :roles, :identifiers)
+                               .includes(:department, :org, :perms, :roles, identifiers: :identifier_scheme)
                                .page(1)
                  end
       end

--- a/app/models/perm.rb
+++ b/app/models/perm.rb
@@ -81,4 +81,14 @@ class Perm < ApplicationRecord
   def self.manage_oauth_apps
     lazy_load('manage_oauth_apps')
   end
+
+  def self.super_admin_names
+    %w[add_organisations grant_api_to_orgs change_org_affiliation]
+  end
+
+  def self.org_admin_names(include_super_admin_names: true)
+    names = %w[grant_permissions modify_templates modify_guidance change_org_details]
+    names += super_admin_perm_names if include_super_admin_names
+    names
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -146,11 +146,7 @@ class User < ApplicationRecord
   scope :super_admins, lambda {
     joins(:perms)
       # Reuses the `can_super_admin?` definition
-      .where(perms: { name: %w[
-               add_organisations
-               grant_api_to_orgs
-               change_org_affiliation
-             ] })
+      .where(perms: { name: Perm.super_admin_names })
       .distinct
   }
 
@@ -159,10 +155,7 @@ class User < ApplicationRecord
     joins(:perms).where('users.org_id = ? AND perms.name IN (?) AND ' \
                         'users.active = ?',
                         org_id,
-                        %w[grant_permissions
-                           modify_templates
-                           modify_guidance
-                           change_org_details],
+                        Perm.org_admin_names(include_super_admin_names: false),
                         true)
   }
 

--- a/app/views/paginable/users/_index.html.erb
+++ b/app/views/paginable/users/_index.html.erb
@@ -99,9 +99,8 @@
                     <% end %>
                   </td>
                   <td class="text-center">
-                    <% presenter = IdentifierPresenter.new(identifiable: user) %>
-                    <% presenter.identifiers.each do |identifier| %>
-                      <p><%= identifier.identifier_scheme.name %></p>
+                    <% user.identifiers.each do |identifier| %>
+                      <p><%= identifier.identifier_scheme&.name %></p>
                     <% end %>
                   </td>
                 </tr>

--- a/app/views/paginable/users/_index.html.erb
+++ b/app/views/paginable/users/_index.html.erb
@@ -1,5 +1,7 @@
 <% is_super_admin = current_user.can_super_admin? %>
 <% is_org_admin = current_user.can_org_admin? %>
+<% super_admin_perm_names = %w[add_organisations grant_api_to_orgs change_org_affiliation] %>
+<% org_admin_perm_names = %w[grant_permissions modify_templates modify_guidance change_org_details] %>
 <% if @clicked_through %>
   <p><%= _(<<-TEXT
     The data on the usage dashboard is historical in nature. This means that the number of records below may not
@@ -72,12 +74,18 @@
                   </td>
                   <%# The content of this column get updated through AJAX whenever the permission for an user are updated %>
                   <td class="text-center" data-descriptor="current_privileges">
+                    <% user_perm_names = user.perms.map(&:name) %>
+                    <% is_user_super_admin = (super_admin_perm_names & user_perm_names).any? %>
                     <span class="privilege-description">
-                      <%= render partial: 'users/current_privileges', locals: { user: user } %>
+                      <% if is_user_super_admin %>
+                        <%= _('Super Admin') %>
+                      <% elsif (org_admin_perm_names & user_perm_names).any?  %>
+                        <%= _('Organisational Admin') %>
+                      <% end %>
                     </span>
                     <br>
                     <%# Do not allow a user to change their own permissions or a super admin's permissions if they are not a super admin %>
-                    <% unless current_user == user || !is_super_admin && user.can_super_admin? %>
+                    <% unless current_user == user || (!is_super_admin && is_user_super_admin) %>
                       <%= link_to( _('Edit'), admin_grant_permissions_user_path(user)) %>
                     <% end %>
                   </td>

--- a/app/views/paginable/users/_index.html.erb
+++ b/app/views/paginable/users/_index.html.erb
@@ -1,7 +1,5 @@
 <% is_super_admin = current_user.can_super_admin? %>
 <% is_org_admin = current_user.can_org_admin? %>
-<% super_admin_perm_names = %w[add_organisations grant_api_to_orgs change_org_affiliation] %>
-<% org_admin_perm_names = %w[grant_permissions modify_templates modify_guidance change_org_details] %>
 <% if @clicked_through %>
   <p><%= _(<<-TEXT
     The data on the usage dashboard is historical in nature. This means that the number of records below may not
@@ -75,11 +73,11 @@
                   <%# The content of this column get updated through AJAX whenever the permission for an user are updated %>
                   <td class="text-center" data-descriptor="current_privileges">
                     <% user_perm_names = user.perms.map(&:name) %>
-                    <% is_user_super_admin = (super_admin_perm_names & user_perm_names).any? %>
+                    <% is_user_super_admin = (Perm.super_admin_names & user_perm_names).any? %>
                     <span class="privilege-description">
                       <% if is_user_super_admin %>
                         <%= _('Super Admin') %>
-                      <% elsif (org_admin_perm_names & user_perm_names).any?  %>
+                      <% elsif (Perm.org_admin_names(include_super_admin_names: false) & user_perm_names).any?  %>
                         <%= _('Organisational Admin') %>
                       <% end %>
                     </span>


### PR DESCRIPTION
# Changes proposed in this PR:
- Eager load identifiers and their schemes in both `users_controller.rb` and `paginable/users_controller.rb`, and remove redundant `:org` eager loading to eliminate N+1 queries and unnecessary data fetching.
- Refactor users list view to iterate directly over `user.identifiers` and display `identifier_scheme` names, removing `IdentifierPresenter` and its `load_schemes` method, which previously caused additional N+1 queries for identifier schemes.
- Update permission checks to compare users’ prefetched permissions against the names in `Perm` methods, removing reliance on the `Perm.lazy_load` caching pattern.
- Centralize and DRY up super/org admin permission logic via the `Perm` model for consistent, efficient checks.