### PR TITLE
Validate ORCID Format for Contributors

### DIFF
--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -29,7 +29,7 @@ class ContributorsController < ApplicationController
     authorize @plan
   end
 
-  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize
   # POST /plans/:plan_id/contributors
   def create
     authorize @plan, :edit?
@@ -40,34 +40,26 @@ class ContributorsController < ApplicationController
     if args.blank?
       @contributor = Contributor.new(args)
       @contributor.errors.add(:affiliation, 'invalid')
-      flash[:alert] = failure_message(@contributor, _('add'))
-      render :new
-    else
-      args[:plan_id] = @plan.id
-      @contributor = Contributor.new(args)
-
-      process_orcid(hash: args, contributor: @contributor)
-
-      if @contributor.errors.any?
-        flash[:alert] = failure_message(@contributor, _('add'))
-        return render :new
-      end
-
-      stash_orcid
-
-      if @contributor.save
-        # Now that the model has been saved, go ahead and save the identifiers
-        save_orcid
-
-        redirect_to plan_contributors_path(@plan),
-                    notice: success_message(@contributor, _('added'))
-      else
-        flash[:alert] = failure_message(@contributor, _('add'))
-        render :new
-      end
+      return render_create_failure
     end
+
+    args[:plan_id] = @plan.id
+    @contributor = Contributor.new(args)
+
+    process_orcid(hash: args, contributor: @contributor)
+
+    return render_create_failure if @contributor.errors.any?
+
+    stash_orcid
+
+    return render_create_failure unless @contributor.save
+
+    save_orcid
+
+    redirect_to plan_contributors_path(@plan),
+                notice: success_message(@contributor, _('added'))
   end
-  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+  # rubocop:enable Metrics/AbcSize
 
   # PUT /plans/:plan_id/contributors/:id
   def update # rubocop:disable Metrics/AbcSize
@@ -162,6 +154,11 @@ class ContributorsController < ApplicationController
     else
       contributor.errors.add(:base, 'Invalid ORCID format. Expected format: 0000-0000-0000-0000')
     end
+  end
+
+  def render_create_failure
+    flash[:alert] = failure_message(@contributor, _('add'))
+    render :new
   end
 
   # =============

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -36,20 +36,27 @@ class ContributorsController < ApplicationController
 
     args = translate_roles(hash: contributor_params)
     args = process_org(hash: args)
+
     if args.blank?
       @contributor = Contributor.new(args)
       @contributor.errors.add(:affiliation, 'invalid')
       flash[:alert] = failure_message(@contributor, _('add'))
       render :new
     else
-      args = process_orcid_for_create(hash: args)
       args[:plan_id] = @plan.id
-
       @contributor = Contributor.new(args)
+
+      process_orcid(hash: args, contributor: @contributor)
+
+      if @contributor.errors.any?
+        flash[:alert] = failure_message(@contributor, _('add'))
+        return render :new
+      end
+
       stash_orcid
 
       if @contributor.save
-        # Now that the model has been ssaved, go ahead and save the identifiers
+        # Now that the model has been saved, go ahead and save the identifiers
         save_orcid
 
         redirect_to plan_contributors_path(@plan),

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -66,7 +66,7 @@ class ContributorsController < ApplicationController
     authorize @plan
     args = translate_roles(hash: contributor_params)
     args = process_org(hash: args)
-    args = process_orcid(hash: args, contributor: @contributor)
+    process_orcid(hash: args, contributor: @contributor)
 
     if @contributor.errors.blank? && @contributor.update(args)
       return redirect_to edit_plan_contributor_path(@plan, @contributor),
@@ -130,19 +130,18 @@ class ContributorsController < ApplicationController
 
   # When creating, just remove the ORCID if it was left blank
   def process_orcid(hash:, contributor:)
-    return hash unless hash[:identifiers_attributes].present?
+    return unless hash[:identifiers_attributes].present?
 
     id_hash = hash[:identifiers_attributes][:'0']
 
     if id_hash[:value].present?
       validate_and_clean_orcid(id_hash, contributor)
-      return hash
+      return
     end
 
     contributor.identifier_for_scheme(scheme: 'orcid')&.destroy if contributor.persisted?
 
     hash.delete(:identifiers_attributes)
-    hash
   end
 
   def validate_and_clean_orcid(id_hash, contributor)

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -5,6 +5,8 @@ class ContributorsController < ApplicationController
   include OrgSelectable
   helper PaginableHelper
 
+  ORCID_REGEX = /\A\d{4}-\d{4}-\d{4}-\d{3}[\dX]\z/
+
   before_action :fetch_plan
   before_action :fetch_contributor, only: %i[edit update destroy]
   after_action :verify_authorized
@@ -138,17 +140,15 @@ class ContributorsController < ApplicationController
     hash
   end
 
-  # When updating, destroy the ORCID if it was blanked out on form
-  def process_orcid_for_update(hash:)
-    return hash unless hash[:identifiers_attributes].present?
+  def validate_and_clean_orcid(id_hash, contributor)
+    raw_value = id_hash[:value].to_s.strip
+    raw_value = raw_value.split('orcid.org/').last if raw_value.include?('orcid.org/')
 
-    id_hash = hash[:identifiers_attributes][:'0']
-    return hash unless id_hash[:value].blank?
-
-    existing = @contributor.identifier_for_scheme(scheme: 'orcid')
-    existing.destroy if existing.present?
-    hash.delete(:identifiers_attributes)
-    hash
+    if raw_value.match?(ORCID_REGEX)
+      id_hash[:value] = raw_value
+    else
+      contributor.errors.add(:base, 'Invalid ORCID format. Expected format: 0000-0000-0000-0000')
+    end
   end
 
   # =============

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -70,21 +70,21 @@ class ContributorsController < ApplicationController
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   # PUT /plans/:plan_id/contributors/:id
-  def update
+  def update # rubocop:disable Metrics/AbcSize
     authorize @plan
     args = translate_roles(hash: contributor_params)
     args = process_org(hash: args)
-    args = process_orcid_for_update(hash: args)
+    args = process_orcid(hash: args, contributor: @contributor)
 
-    if @contributor.update(args)
-      redirect_to edit_plan_contributor_path(@plan, @contributor),
-                  notice: success_message(@contributor, _('saved'))
-    else
-      flash.now[:alert] = failure_message(@contributor, _('save'))
-      render :edit
+    if @contributor.errors.blank? && @contributor.update(args)
+      return redirect_to edit_plan_contributor_path(@plan, @contributor),
+                         notice: success_message(@contributor, _('saved'))
     end
+
+    @contributor.assign_attributes(args)
+    flash.now[:alert] = failure_message(@contributor, _('save'))
+    render :edit
   end
-  # rubocop:enable
 
   # DELETE /plans/:plan_id/contributors/:id
   def destroy

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -130,11 +130,17 @@ class ContributorsController < ApplicationController
   end
 
   # When creating, just remove the ORCID if it was left blank
-  def process_orcid_for_create(hash:)
+  def process_orcid(hash:, contributor:)
     return hash unless hash[:identifiers_attributes].present?
 
     id_hash = hash[:identifiers_attributes][:'0']
-    return hash unless id_hash[:value].blank?
+
+    if id_hash[:value].present?
+      validate_and_clean_orcid(id_hash, contributor)
+      return hash
+    end
+
+    contributor.identifier_for_scheme(scheme: 'orcid')&.destroy if contributor.persisted?
 
     hash.delete(:identifiers_attributes)
     hash

--- a/spec/controllers/contributors_controller_spec.rb
+++ b/spec/controllers/contributors_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ContributorsController, type: :controller do
         }.to_json,
         identifiers_attributes: { '0': {
           identifier_scheme_id: @scheme.id,
-          value: SecureRandom.uuid
+          value: '0000-0002-1825-0097'
         } }
       }
     }


### PR DESCRIPTION
Changes proposed in this PR:
-  Validate ORCID formats when creating and updating a contributor in a plan, ensuring that it matches the XXXX-XXXX-XXXX-XXXX format.
- Refactor the `create` and `update` functions in `contributors_controller` to be more readable.
- Combined `process_orcid_for_create` and `process_orcid_for_update` functions into one `process_orcid` function.
