### PR TITLE
feat(Identifier): add `orcid_format` validator and specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+ - feat(Identifier): add orcid_format validator and specs [#1370](https://github.com/portagenetwork/roadmap/pull/1370)
+
 ### Dependency Updates
 
  - chore(deps): bump surnet/alpine-wkhtmltopdf from 3.23.2-0.12.6-small to 3.23.4-0.12.6-small [#1363](https://github.com/portagenetwork/roadmap/pull/1363)

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -46,13 +46,18 @@ class ContributorsController < ApplicationController
       @contributor = Contributor.new(args)
       stash_orcid
 
-      if @contributor.save
-        # Now that the model has been ssaved, go ahead and save the identifiers
-        save_orcid
+      begin
+        ActiveRecord::Base.transaction do
+          @contributor.save!
+          # Now that the model has been saved, go ahead and save the identifiers
+          save_orcid!
+        end
 
         redirect_to plan_contributors_path(@plan),
                     notice: success_message(@contributor, _('added'))
-      else
+      rescue ActiveRecord::RecordInvalid => e
+        @contributor.errors.add(:base, e.record.errors.full_messages.to_sentence) if e.record.is_a?(Identifier)
+
         flash[:alert] = failure_message(@contributor, _('add'))
         render :new
       end
@@ -189,11 +194,11 @@ class ContributorsController < ApplicationController
     @contributor.identifiers = []
   end
 
-  def save_orcid
+  def save_orcid!
     return true unless @cached_orcid.present?
 
     @cached_orcid.identifiable = @contributor
-    @cached_orcid.save
+    @cached_orcid.save!
     @contributor.reload
   end
 end

--- a/app/models/identifier.rb
+++ b/app/models/identifier.rb
@@ -22,6 +22,9 @@
 
 # Object that represents an identifier for an object
 class Identifier < ApplicationRecord
+  ORCID_REGEX = /\A\d{4}-\d{4}-\d{4}-\d{3}[\dX]\z/
+  ORCID_HOST = 'orcid.org/'
+
   # ================
   # = Associations =
   # ================
@@ -41,6 +44,8 @@ class Identifier < ApplicationRecord
   validate :value_uniqueness_with_scheme, if: :schemed?
 
   validate :value_uniqueness_without_scheme, unless: :schemed?
+
+  validate :orcid_format, if: -> { identifier_scheme&.name == 'orcid' }
 
   # ===============
   # = Scopes =
@@ -142,5 +147,18 @@ class Identifier < ApplicationRecord
                                        identifiable: identifiable).any?
       errors.add(:identifier_scheme, _('already assigned a value'))
     end
+  end
+
+  def orcid_format
+    return if value.blank?
+
+    return if normalized_orcid_value.match?(ORCID_REGEX)
+
+    errors.add(:value, 'Invalid ORCID format. Expected format: 0000-0000-0000-0000')
+  end
+
+  def normalized_orcid_value
+    raw = value.to_s.strip
+    raw.split(ORCID_HOST).last
   end
 end

--- a/spec/controllers/contributors_controller_spec.rb
+++ b/spec/controllers/contributors_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe ContributorsController, type: :controller do
   before(:each) do
-    @scheme = create(:identifier_scheme, name: 'orcid')
+    @scheme = create(:identifier_scheme, :orcid)
     @org = create(:org, managed: true)
     @plan = create(:plan, :creator, org: @org)
     @user = @plan.owner
@@ -22,7 +22,7 @@ RSpec.describe ContributorsController, type: :controller do
         }.to_json,
         identifiers_attributes: { '0': {
           identifier_scheme_id: @scheme.id,
-          value: SecureRandom.uuid
+          value: '0000-0000-0000-000X'
         } }
       }
     }

--- a/spec/factories/identifier_schemes.rb
+++ b/spec/factories/identifier_schemes.rb
@@ -33,6 +33,11 @@ FactoryBot.define do
       end
     end
 
+    trait :orcid do
+      name { 'orcid' }
+      identifier_prefix { 'https://orcid.org/' }
+    end
+
     trait :openid_connect do
       name { 'openid_connect' }
       description { 'CILogon' }

--- a/spec/factories/identifiers.rb
+++ b/spec/factories/identifiers.rb
@@ -37,5 +37,11 @@ FactoryBot.define do
     trait :for_user do
       association :identifiable, factory: :user
     end
+
+    trait :orcid do
+      association :identifier_scheme, factory: %i[identifier_scheme orcid]
+      association :identifiable, factory: :user
+      value { '0000-0000-0000-000X' }
+    end
   end
 end

--- a/spec/models/exported_plan_spec.rb
+++ b/spec/models/exported_plan_spec.rb
@@ -20,8 +20,7 @@ RSpec.describe Org, type: :model do
         expect(@exported.orcid).to eql('')
       end
       it 'returns the ORCID identifier' do
-        scheme = build(:identifier_scheme, name: 'orcid')
-        identifier = build(:identifier, :for_user, identifier_scheme: scheme)
+        identifier = build(:identifier, :orcid)
         @exported.owner.identifiers << identifier
         expect(@exported.orcid).to eql(identifier.value)
       end

--- a/spec/models/identifier_spec.rb
+++ b/spec/models/identifier_spec.rb
@@ -65,6 +65,58 @@ RSpec.describe Identifier, type: :model do
         expect(id.valid?).to eql(true)
       end
     end
+    describe '#orcid_format' do
+      let(:scheme) do
+        create(
+          :identifier_scheme,
+          name: 'orcid',
+          identifier_prefix: 'https://orcid.org'
+        )
+      end
+
+      it 'accepts a valid ORCID without a prefix' do
+        id = build(
+          :identifier,
+          identifier_scheme: scheme,
+          value: '0000-0002-1825-0097'
+        )
+
+        expect(id.valid?).to eql(true)
+      end
+
+      it 'accepts a valid ORCID with a prefix' do
+        id = build(
+          :identifier,
+          identifier_scheme: scheme,
+          value: 'https://orcid.org/0000-0002-1825-0097'
+        )
+
+        expect(id.valid?).to eql(true)
+      end
+
+      it 'rejects an invalid ORCID' do
+        id = build(
+          :identifier,
+          identifier_scheme: scheme,
+          value: 'not-an-orcid'
+        )
+
+        expect(id.valid?).to eql(false)
+        expect(id.errors[:value]).to include(
+          'Invalid ORCID format. Expected format: 0000-0000-0000-0000'
+        )
+      end
+
+      it 'does not validate non-ORCID schemes' do
+        id = build(
+          :identifier,
+          identifier_scheme: create(:identifier_scheme, name: 'ror'),
+          value: 'not-an-orcid'
+        )
+
+        expect(id.valid?).to eql(true)
+      end
+    end
   end
 
   context 'associations' do
@@ -219,6 +271,24 @@ RSpec.describe Identifier, type: :model do
       id = build(:identifier, value: val, identifier_scheme: @scheme)
       expected = @scheme.identifier_prefix
       expect(id.value.starts_with?(expected)).to eql(true)
+    end
+  end
+
+  describe '#normalized_orcid_value' do
+    it 'strips the ORCID host from the value' do
+      scheme = create(
+        :identifier_scheme,
+        name: 'orcid',
+        identifier_prefix: 'https://orcid.org'
+      )
+
+      id = build(
+        :identifier,
+        identifier_scheme: scheme,
+        value: 'https://orcid.org/0000-0002-1825-0097'
+      )
+
+      expect(id.send(:normalized_orcid_value)).to eql('0000-0002-1825-0097')
     end
   end
 end

--- a/spec/models/identifier_spec.rb
+++ b/spec/models/identifier_spec.rb
@@ -67,11 +67,7 @@ RSpec.describe Identifier, type: :model do
     end
     describe '#orcid_format' do
       let(:scheme) do
-        create(
-          :identifier_scheme,
-          name: 'orcid',
-          identifier_prefix: 'https://orcid.org'
-        )
+        create(:identifier_scheme, :orcid)
       end
 
       it 'accepts a valid ORCID without a prefix' do
@@ -276,11 +272,7 @@ RSpec.describe Identifier, type: :model do
 
   describe '#normalized_orcid_value' do
     it 'strips the ORCID host from the value' do
-      scheme = create(
-        :identifier_scheme,
-        name: 'orcid',
-        identifier_prefix: 'https://orcid.org'
-      )
+      scheme = create(:identifier_scheme, :orcid)
 
       id = build(
         :identifier,

--- a/spec/presenters/api/v1/contributor_presenter_spec.rb
+++ b/spec/presenters/api/v1/contributor_presenter_spec.rb
@@ -27,8 +27,7 @@ RSpec.describe Api::V1::ContributorPresenter do
       expect(rslt).to eql(nil)
     end
     it 'returns the ORCID' do
-      scheme = create(:identifier_scheme, name: 'orcid')
-      orcid = create(:identifier, identifier_scheme: scheme, identifiable: @contributor)
+      orcid = create(:identifier, :orcid, identifiable: @contributor)
       @contributor.reload
       rslt = described_class.contributor_id(identifiers: @contributor.identifiers)
       expect(rslt).to eql(orcid)

--- a/spec/support/mocks/api_json_samples.rb
+++ b/spec/support/mocks/api_json_samples.rb
@@ -14,7 +14,7 @@ module Mocks
     def mock_identifier_schemes
       create(:identifier_scheme, name: 'ror')
       create(:identifier_scheme, name: 'fundref')
-      create(:identifier_scheme, name: 'orcid')
+      create(:identifier_scheme, :orcid)
       create(:identifier_scheme, name: 'grant')
     end
 
@@ -78,7 +78,7 @@ module Mocks
       contact = {
         name: Faker::TvShows::Simpsons.character,
         email: Faker::Internet.email,
-        id: SecureRandom.uuid
+        id: '0000-0000-0000-000X'
       }
       {
         total_items: 1,
@@ -126,7 +126,7 @@ module Mocks
                 },
                 contributor_id: {
                   type: 'orcid',
-                  identifier: SecureRandom.uuid
+                  identifier: '0000-0000-0000-0000'
                 }
               }, {
                 role: [

--- a/spec/support/mocks/api_v2_json_samples.rb
+++ b/spec/support/mocks/api_v2_json_samples.rb
@@ -14,7 +14,7 @@ module Mocks
     def mock_identifier_schemes
       create(:identifier_scheme, name: 'ror')
       create(:identifier_scheme, name: 'fundref')
-      create(:identifier_scheme, name: 'orcid')
+      create(:identifier_scheme, :orcid)
       create(:identifier_scheme, name: 'grant')
     end
 
@@ -83,7 +83,7 @@ module Mocks
           Faker::TvShows::Simpsons.character.split.last
         ].join(' '),
         email: Faker::Internet.email,
-        id: SecureRandom.uuid
+        id: '0000-0000-0000-000X'
       }
 
       {
@@ -134,7 +134,7 @@ module Mocks
             },
             contributor_id: {
               type: 'orcid',
-              identifier: SecureRandom.uuid
+              identifier: '0000-0000-0000-0000'
             }
           }, {
             role: [

--- a/spec/views/api/v1/contributors/_show.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/contributors/_show.json.jbuilder_spec.rb
@@ -5,11 +5,9 @@ require 'rails_helper'
 describe 'api/v1/contributors/_show.json.jbuilder' do
   before(:each) do
     @plan = create(:plan)
-    scheme = create(:identifier_scheme, name: 'orcid')
     @contact = create(:contributor, org: create(:org), plan: @plan, roles_count: 0,
                                     data_curation: true)
-    @ident = create(:identifier, identifiable: @contact, value: Faker::Lorem.word,
-                                 identifier_scheme: scheme)
+    @ident = create(:identifier, :orcid, identifiable: @contact)
     @contact.reload
   end
 

--- a/spec/views/api/v2/contributors/_show.json.jbuilder_spec.rb
+++ b/spec/views/api/v2/contributors/_show.json.jbuilder_spec.rb
@@ -5,11 +5,9 @@ require 'rails_helper'
 describe 'api/v2/contributors/_show.json.jbuilder' do
   before do
     @plan = create(:plan)
-    scheme = create(:identifier_scheme, name: 'orcid')
     @contact = create(:contributor, org: create(:org), plan: @plan, roles_count: 0,
                                     data_curation: true)
-    @ident = create(:identifier, identifiable: @contact, value: Faker::Lorem.word,
-                                 identifier_scheme: scheme)
+    @ident = create(:identifier, :orcid, identifiable: @contact)
     @contact.reload
   end
 


### PR DESCRIPTION
## Changes proposed in this PR:
Add ORCID-specific format validator to `Identifier` model.

- Introduces a custom validator (`orcid_format`) that ensures ORCID-associated identifiers conform to the expected format (0000-0000-0000-0000).
- Add `normalized_orcid_value` helper to extract ORCID identifier from URLs
- Extend model specs to cover:
  - valid ORCID values (raw and URL-form)
  - invalid ORCID values
  - non-ORCID schemes bypassing validation

- Adress tests that were breaking due to the added `orcid_format` validator
  - Introduce ORCID traits for `identifier_schemes` and `identifiers` to standardize test setup for ORCID-related records.
  - Update existing tests to use the new `:orcid` traits instead of ad-hoc values. Replace `SecureRandom.uuid`-generated identifiers with hard-coded ORCID-formatted strings that satisfy the `orcid_format` validation.

## NOTES:
- Valid ORCID examples include '0000-0000-0000-0000' and `[https://orcid.org/0000-0000-0000-0000`](https://orcid.org/0000-0000-0000-0000%60)
- Normalization is used only for validation purposes and does not alter persisted value behavior
- Existing identifier prefix logic remains unchanged.