### PR TITLE
 disable translation of all non-default_funder (i.e. Alliance) templates

### DIFF
--- a/app/controllers/org_admin/phases_controller.rb
+++ b/app/controllers/org_admin/phases_controller.rb
@@ -9,7 +9,7 @@ module OrgAdmin
 
     # GET /org_admin/templates/:template_id/phases/:id
     # rubocop:disable Metrics/AbcSize
-    def show
+    def show # rubocop:disable Metrics/MethodLength
       phase = Phase.includes(:template, :sections).order(:number).find(params[:id])
       authorize phase
       unless phase.template.latest?
@@ -17,13 +17,23 @@ module OrgAdmin
         flash[:notice] = _('You are viewing a historical version of this template. You will not be able to make changes.')
         # rubocop:enable Layout/LineLength
       end
+      sections_includes = [
+        :template,
+        {
+          questions: [
+            :template,
+            { question_options: :template }
+          ]
+        }
+      ]
+
       sections = if phase.template.customization_of? && phase.template.latest?
                    # The user is working with the latest version so only use the modifiable sections
-                   phase.template_sections.order(:number)
+                   phase.template_sections.includes(sections_includes).order(:number)
                  else
                    # This is not the latest version sso just get all the sections. Everything
                    # will be readonly
-                   phase.sections.order(:number)
+                   phase.sections.includes(sections_includes).order(:number)
                  end
       render('container',
              locals: {
@@ -57,8 +67,18 @@ module OrgAdmin
                  template: phase.template,
                  phase: phase,
                  prefix_section: phase.prefix_section,
-                 sections: phase.sections.order(:number)
-                                         .select(:id, :title, :modifiable, :phase_id),
+                 sections: phase.sections
+                                .includes(
+                                  :template,
+                                  {
+                                    questions: [
+                                      :template,
+                                      { question_options: :template }
+                                    ]
+                                  }
+                                )
+                                .order(:number)
+                                .select(:id, :title, :modifiable, :phase_id),
                  suffix_sections: phase.suffix_sections.order(:number),
                  current_section: Section.find_by(id: params[:section], phase_id: phase.id)
                })
@@ -69,7 +89,20 @@ module OrgAdmin
     # preview a phase
     # GET /org_admin/templates/:template_id/phases/:id/preview
     def preview
-      @phase = Phase.includes(:template).find(params[:id])
+      @phase = Phase.includes(
+        :template,
+        {
+          sections: [
+            :template,
+            {
+              questions: [
+                :template,
+                { question_options: :template }
+              ]
+            }
+          ]
+        }
+      ).find(params[:id])
       authorize @phase
       @template = @phase.template
       @guidance_presenter = GuidancePresenter.new(Plan.new(template: @phase.template))

--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -106,11 +106,9 @@ module OrgAdmin
       authorize template
       # Load the info needed for the overview section if the authorization check passes!
       phases = template.phases
-                       .includes(sections: { questions: :question_options })
+                       .with_template_includes
                        .order('phases.number', 'sections.number', 'questions.number',
                               'question_options.number')
-                       .select('phases.title', 'phases.description', 'phases.modifiable',
-                               'sections.title', 'questions.text', 'question_options.text')
       unless template.latest?
         # rubocop:disable Layout/LineLength
         flash[:notice] = _('You are viewing a historical version of this template. You will not be able to make changes.')
@@ -125,22 +123,16 @@ module OrgAdmin
     end
 
     # GET /org_admin/templates/:id/edit
-    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def edit
       template = Template.includes(:org, :phases).find(params[:id])
       authorize template
       # Load the info needed for the overview section if the authorization check passes!
-      phases = template.phases.includes(sections: { questions: :question_options })
+      phases = template.phases
+                       .with_template_includes
                        .order('phases.number',
                               'sections.number',
                               'questions.number',
                               'question_options.number')
-                       .select('phases.title',
-                               'phases.description',
-                               'phases.modifiable',
-                               'sections.title',
-                               'questions.text',
-                               'question_options.text')
       if template.latest?
         render 'container', locals: {
           partial_path: 'edit',
@@ -152,7 +144,6 @@ module OrgAdmin
         redirect_to org_admin_template_path(id: template.id)
       end
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
     # GET /org_admin/templates/new
     def new
@@ -319,15 +310,22 @@ module OrgAdmin
       # now with prefetching (if guidance is added, prefetch annottaions/guidance)
       @template = Template.includes(
         :org,
-        phases: {
-          sections: {
-            questions: %i[
-              question_options
-              question_format
-              annotations
+        phases: [
+          :template,
+          {
+            sections: [
+              :template,
+              {
+                questions: [
+                  :template,
+                  :question_format,
+                  :annotations,
+                  { question_options: :template }
+                ]
+              }
             ]
           }
-        }
+        ]
       ).find(@template.id)
 
       @formatting = Settings::Template::DEFAULT_SETTINGS[:formatting]

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -209,17 +209,20 @@ class PlansController < ApplicationController
   # GET /plans/:plan_id/phases/:id/edit
   # rubocop:disable Metrics/AbcSize
   def edit
-    plan = Plan.includes(
-      { template: {
-        phases: {
-          sections: {
-            questions: %i[question_format annotations]
-          }
-        }
-      } },
-      { answers: :notes }
-    )
-               .find(params[:id])
+    plan = Plan.with_detailed_template
+               .includes(
+                 {
+                   template: {
+                     phases: {
+                       sections: {
+                         questions: %i[question_format annotations]
+                       }
+                     }
+                   }
+                 },
+                 { answers: :notes }
+               ).find(params[:id])
+
     authorize plan
     phase_id = params[:phase_id].to_i
     phase = plan.template.phases.find { |p| p.id == phase_id }
@@ -437,7 +440,8 @@ class PlansController < ApplicationController
 
   # GET /plans/:id/overview
   def overview
-    plan = Plan.includes(template: [:org, { phases: { sections: :questions } }])
+    plan = Plan.with_detailed_template
+               .includes(template: :org)
                .find(params[:id])
 
     authorize plan

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -69,8 +69,7 @@ class Annotation < ApplicationRecord
 
   # text is translated through the translation gem
   def text
-    text = read_attribute(:text)
-    _(text) unless text.blank?
+    TemplateTranslationService.translate(self, :text)
   end
 
   # The text from the annotation

--- a/app/models/phase.rb
+++ b/app/models/phase.rb
@@ -149,12 +149,10 @@ class Phase < ApplicationRecord
 
   # title and description are translated through the translation gem
   def title
-    title = read_attribute(:title)
-    _(title) unless title.blank?
+    TemplateTranslationService.translate(self, :title)
   end
 
   def description
-    description = read_attribute(:description)
-    _(description) unless description.blank?
+    TemplateTranslationService.translate(self, :description)
   end
 end

--- a/app/models/phase.rb
+++ b/app/models/phase.rb
@@ -96,6 +96,23 @@ class Phase < ApplicationRecord
     Phase.where(template_id: template_id).select(:id, :title)
   }
 
+  scope :with_template_includes, lambda {
+    includes(
+      :template,
+      {
+        sections: [
+          :template,
+          {
+            questions: [
+              :template,
+              { question_options: :template }
+            ]
+          }
+        ]
+      }
+    )
+  }
+
   def deep_copy(**options)
     copy = dup
     copy.modifiable = options.fetch(:modifiable, modifiable)

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -203,6 +203,29 @@ class Plan < ApplicationRecord
       .distinct
   }
 
+  # Retrieves template with pre-fetched sections and questions
+  # to avoid eager loading when translating
+  scope :with_detailed_template, lambda {
+    includes(
+      template: {
+        phases: [
+          :template,
+          {
+            sections: [
+              :template,
+              {
+                questions: [
+                  :template,
+                  { question_options: :template }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    )
+  }
+
   ##
   # Settings for the template
   has_settings :export, class_name: 'Settings::Template' do |s|

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -116,13 +116,11 @@ class Question < ApplicationRecord
 
   # text and default_value are translated through the translation gem
   def text
-    text = read_attribute(:text)
-    _(text) unless text.blank?
+    TemplateTranslationService.translate(self, :text)
   end
 
   def default_value
-    default_value = read_attribute(:default_value)
-    _(default_value) unless default_value.blank?
+    TemplateTranslationService.translate(self, :default_value)
   end
 
   # rubocop:disable Metrics/AbcSize

--- a/app/models/question_option.rb
+++ b/app/models/question_option.rb
@@ -78,8 +78,7 @@ class QuestionOption < ApplicationRecord
 
   # text is translated through the translation gem
   def text
-    text = read_attribute(:text)
-    _(text) unless text.blank?
+    TemplateTranslationService.translate(self, :text)
   end
 
   def deep_copy(**options)

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -99,13 +99,11 @@ class Section < ApplicationRecord
 
   # title and description are translated through the translation gem
   def title
-    title = read_attribute(:title)
-    _(title) unless title.blank?
+    TemplateTranslationService.translate(self, :title)
   end
 
   def description
-    description = read_attribute(:description)
-    _(description) unless description.blank?
+    TemplateTranslationService.translate(self, :description)
   end
 
   # The title of the Section

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -287,13 +287,11 @@ class Template < ApplicationRecord
 
   # title and description are translated through the translation gem
   def title
-    title = read_attribute(:title)
-    _(title) unless title.blank?
+    TemplateTranslationService.translate(self, :title)
   end
 
   def description
-    description = read_attribute(:description)
-    _(description) unless description.blank?
+    TemplateTranslationService.translate(self, :description)
   end
 
   # Creates a copy of the current template

--- a/app/services/template_translation_service.rb
+++ b/app/services/template_translation_service.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Service to handle conditional translation of template content
+# based on whether or not it belongs to the default funder organization.
+class TemplateTranslationService
+  class << self
+    # Translates a given attribute for a record if it belongs to the default funder
+    # @param record [ActiveRecord::Base] The model instance (Template, Phase, Section, etc.)
+    # @param attribute [Symbol, String] The database column name to translate
+    # @return [String, nil] The translated or raw string content
+    def translate(record, attribute)
+      return nil if record.blank?
+
+      value = record.read_attribute(attribute)
+      return value if value.blank?
+
+      if default_funder_template?(record)
+        # Return translation if it's the default funder
+        _(value)
+      else
+        # Return the exact database value for customized templates
+        value
+      end
+    end
+
+    private
+
+    # Traverses up associations to find the parent template and check its org
+    def default_funder_template?(record)
+      template = fetch_template_from_record(record)
+
+      return false if template.blank?
+
+      # Check if template belongs to default funder
+      template.org_id == Rails.application.config.default_funder_id
+    rescue StandardError => e
+      Rails.logger.error "Template translation error: #{e.message}"
+    end
+
+    def fetch_template_from_record(record) # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
+      case record.class.name
+      when 'Template'       then record
+      when 'Phase'          then record.template
+      when 'Section'        then record.phase&.template
+      when 'Question'       then record.section&.phase&.template
+      when 'Annotation', 'QuestionOption' then record.question&.section&.phase&.template
+      end
+    end
+  end
+end

--- a/app/services/template_translation_service.rb
+++ b/app/services/template_translation_service.rb
@@ -27,24 +27,13 @@ class TemplateTranslationService
 
     # Traverses up associations to find the parent template and check its org
     def default_funder_template?(record)
-      template = fetch_template_from_record(record)
-
+      template = record.is_a?(Template) ? record : record.template
       return false if template.blank?
 
-      # Check if template belongs to default funder
       template.org_id == Rails.application.config.default_funder_id
     rescue StandardError => e
       Rails.logger.error "Template translation error: #{e.message}"
-    end
-
-    def fetch_template_from_record(record) # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
-      case record.class.name
-      when 'Template'       then record
-      when 'Phase'          then record.template
-      when 'Section'        then record.phase&.template
-      when 'Question'       then record.section&.phase&.template
-      when 'Annotation', 'QuestionOption' then record.question&.section&.phase&.template
-      end
+      false
     end
   end
 end

--- a/spec/services/template_translation_service_spec.rb
+++ b/spec/services/template_translation_service_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TemplateTranslationService do
+  before do
+    @funding_org = create(:org, :funder)
+    @original_default_funder_id = Rails.application.config.default_funder_id
+    Rails.application.config.default_funder_id = @funding_org.id
+
+    @default_template = create(:template, :default, :published, org: @funding_org)
+    @custom_template  = create(:template, :published, org: create(:org))
+
+    # Safely intercept  translations
+    def TemplateTranslationService._(val)
+      "translated_#{val}"
+    end
+  end
+
+  after do
+    Rails.application.config.default_funder_id = @original_default_funder_id
+  end
+
+  describe '.translate' do
+    it 'returns nil if the passed record is blank' do
+      expect(described_class.translate(nil, :title)).to be_nil
+    end
+
+    it 'returns the raw value if the attribute content is blank' do
+      @default_template.title = ''
+      expect(described_class.translate(@default_template, :title)).to eq('')
+    end
+
+    context 'when the record belongs to the default funder' do
+      it 'translates the attribute for a Template record' do
+        @default_template.title = 'Default Title'
+
+        expect(described_class.translate(@default_template, :title)).to eq('translated_Default Title')
+      end
+
+      it 'translates the attribute for an associated child record (e.g., Phase)' do
+        phase = create(:phase, template: @default_template, title: 'Default Phase')
+
+        expect(described_class.translate(phase, :title)).to eq('translated_Default Phase')
+      end
+    end
+
+    context 'when the record belongs to a customized template' do
+      it 'returns the exact database string untouched' do
+        @custom_template.title = 'Custom Org Title'
+
+        expect(described_class.translate(@custom_template, :title)).to eq('Custom Org Title')
+      end
+    end
+  end
+
+  describe 'private methods' do
+    describe '#default_funder_template?' do
+      it 'returns false when passed a record lacking a template' do
+        orphan_phase = build(:phase, template: nil)
+
+        expect(described_class.send(:default_funder_template?, orphan_phase)).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1373 .

Changes proposed in this PR:
- Create `template_translation_service` to translate all values in a template accordingly. If the value belongs to a template from a default funder, it is returned as a translated value, otherwise it is returned as is with no translation.
