### PR TITLE
fix(charts): add `startupProbe`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+ - fix(charts): add `startupProbe` [#1388](https://github.com/portagenetwork/roadmap/pull/1388)
+
 ### Dependency Updates
 
  - chore(deps): bump @babel/core from 7.21.4 to 7.29.6 [#1376](https://github.com/portagenetwork/roadmap/pull/1376)

--- a/charts/dmp-roadmap/README.md
+++ b/charts/dmp-roadmap/README.md
@@ -385,12 +385,12 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 | app.image.repository | string | global.image.repository | Repository to use for the DMP Roadmap app |
 | app.image.tag | string | global.image.tag or chart appVersion | Tag to use for the DMP Roadmap app |
 | app.imagePullSecrets | list | global.imagePullSecrets | Secrets with credentials to pull images from a private registry |
-| app.livenessProbe | object | `{"failureThreshold":6,"httpGet":{"path":"/api/v1/heartbeat","port":"http"},"initialDelaySeconds":120,"periodSeconds":20,"successThreshold":1,"timeoutSeconds":10}` | Liveness probe configuration for the app |
+| app.livenessProbe | object | `{"failureThreshold":6,"httpGet":{"path":"/api/v1/heartbeat","port":"http"},"periodSeconds":20,"successThreshold":1,"timeoutSeconds":10}` | Liveness probe configuration for the app |
 | app.nodeSelector | object | `{}` | Node selector for the app deployment |
 | app.podAnnotations | object | `{}` | Pod annotations for the app deployment |
 | app.podLabels | object | `{}` | Pod labels for the app deployment |
 | app.podSecurityContext | object | `{"fsGroup":3000}` | Pod security context for the app deployment |
-| app.readinessProbe | object | `{"failureThreshold":6,"httpGet":{"path":"/api/v1/heartbeat","port":"http"},"initialDelaySeconds":60,"periodSeconds":20,"successThreshold":1,"timeoutSeconds":10}` | Readiness probe configuration for the app |
+| app.readinessProbe | object | `{"failureThreshold":6,"httpGet":{"path":"/api/v1/heartbeat","port":"http"},"periodSeconds":20,"successThreshold":1,"timeoutSeconds":10}` | Readiness probe configuration for the app |
 | app.replicas | int | `1` | Number of app replicas |
 | app.resources | object | `{"limits":{"cpu":"500m","memory":"1Gi"},"requests":{"cpu":"200m","memory":"512Mi"}}` | Resource requests and limits for the app |
 | app.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":1000,"seccompProfile":{"type":"RuntimeDefault"}}` | Container security context for the app deployment |

--- a/charts/dmp-roadmap/README.md
+++ b/charts/dmp-roadmap/README.md
@@ -401,6 +401,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 | app.serviceAccount.automount | bool | `true` | Automatically mount a ServiceAccount's API credentials? |
 | app.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | app.serviceAccount.name | string | If not set and create is true, a name is generated using the fullname template | The name of the service account to use. |
+| app.startupProbe | object | `{"failureThreshold":48,"httpGet":{"path":"/api/v1/heartbeat","port":"http"},"periodSeconds":10,"successThreshold":1,"timeoutSeconds":10}` | Startup probe configuration for the app |
 | app.tolerations | list | `[]` | Tolerations for the app deployment |
 | app.volumeMounts | list | `[]` | Additional volume mounts for the app deployment |
 | app.volumes | list | `[]` | Additional volumes for the app deployment |

--- a/charts/dmp-roadmap/templates/app/deployment.yaml
+++ b/charts/dmp-roadmap/templates/app/deployment.yaml
@@ -69,7 +69,6 @@ spec:
             httpGet:
               path: /api/v1/heartbeat
               port: {{ .Values.app.service.targetPort }}
-            initialDelaySeconds: {{ .Values.app.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.app.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.app.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.app.livenessProbe.failureThreshold }}
@@ -78,7 +77,6 @@ spec:
             httpGet:
               path: /api/v1/heartbeat
               port: {{ .Values.app.service.targetPort }}
-            initialDelaySeconds: {{ .Values.app.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.app.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.app.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.app.readinessProbe.failureThreshold }}

--- a/charts/dmp-roadmap/templates/app/deployment.yaml
+++ b/charts/dmp-roadmap/templates/app/deployment.yaml
@@ -57,6 +57,14 @@ spec:
             - name: http
               containerPort: {{ .Values.app.service.targetPort }}
               protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /api/v1/heartbeat
+              port: {{ .Values.app.service.targetPort }}
+            periodSeconds: {{ .Values.app.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.app.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.app.startupProbe.failureThreshold }}
+            successThreshold: {{ .Values.app.startupProbe.successThreshold }}
           livenessProbe:
             httpGet:
               path: /api/v1/heartbeat

--- a/charts/dmp-roadmap/values.schema.json
+++ b/charts/dmp-roadmap/values.schema.json
@@ -520,6 +520,68 @@
           "title": "serviceAccount",
           "type": "object"
         },
+        "startupProbe": {
+          "additionalProperties": false,
+          "description": "Startup probe configuration for the app",
+          "properties": {
+            "failureThreshold": {
+              "default": 48,
+              "required": [],
+              "title": "failureThreshold",
+              "type": "integer"
+            },
+            "httpGet": {
+              "additionalProperties": false,
+              "properties": {
+                "path": {
+                  "default": "/api/v1/heartbeat",
+                  "required": [],
+                  "title": "path",
+                  "type": "string"
+                },
+                "port": {
+                  "default": "http",
+                  "required": [],
+                  "title": "port",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "path",
+                "port"
+              ],
+              "title": "httpGet",
+              "type": "object"
+            },
+            "periodSeconds": {
+              "default": 10,
+              "required": [],
+              "title": "periodSeconds",
+              "type": "integer"
+            },
+            "successThreshold": {
+              "default": 1,
+              "required": [],
+              "title": "successThreshold",
+              "type": "integer"
+            },
+            "timeoutSeconds": {
+              "default": 10,
+              "required": [],
+              "title": "timeoutSeconds",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "httpGet",
+            "periodSeconds",
+            "timeoutSeconds",
+            "failureThreshold",
+            "successThreshold"
+          ],
+          "title": "startupProbe",
+          "type": "object"
+        },
         "tolerations": {
           "description": "Tolerations for the app deployment",
           "items": {
@@ -549,6 +611,7 @@
         }
       },
       "required": [
+        "startupProbe",
         "livenessProbe",
         "readinessProbe",
         "autoscaling",

--- a/charts/dmp-roadmap/values.schema.json
+++ b/charts/dmp-roadmap/values.schema.json
@@ -149,12 +149,6 @@
               "title": "httpGet",
               "type": "object"
             },
-            "initialDelaySeconds": {
-              "default": 120,
-              "required": [],
-              "title": "initialDelaySeconds",
-              "type": "integer"
-            },
             "periodSeconds": {
               "default": 20,
               "required": [],
@@ -176,7 +170,6 @@
           },
           "required": [
             "httpGet",
-            "initialDelaySeconds",
             "periodSeconds",
             "timeoutSeconds",
             "failureThreshold",
@@ -256,12 +249,6 @@
               "title": "httpGet",
               "type": "object"
             },
-            "initialDelaySeconds": {
-              "default": 60,
-              "required": [],
-              "title": "initialDelaySeconds",
-              "type": "integer"
-            },
             "periodSeconds": {
               "default": 20,
               "required": [],
@@ -283,7 +270,6 @@
           },
           "required": [
             "httpGet",
-            "initialDelaySeconds",
             "periodSeconds",
             "timeoutSeconds",
             "failureThreshold",

--- a/charts/dmp-roadmap/values.yaml
+++ b/charts/dmp-roadmap/values.yaml
@@ -313,6 +313,17 @@ app:
     limits:
       cpu: 500m
       memory: 1Gi
+  
+  # -- Startup probe configuration for the app
+  # @section -- Application Configuration
+  startupProbe:
+    httpGet:
+      path: /api/v1/heartbeat
+      port: http
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 48
+    successThreshold: 1
 
   # -- Liveness probe configuration for the app
   # @section -- Application Configuration

--- a/charts/dmp-roadmap/values.yaml
+++ b/charts/dmp-roadmap/values.yaml
@@ -331,7 +331,6 @@ app:
     httpGet:
       path: /api/v1/heartbeat
       port: http
-    initialDelaySeconds: 120
     periodSeconds: 20
     timeoutSeconds: 10
     failureThreshold: 6
@@ -343,7 +342,6 @@ app:
     httpGet:
       path: /api/v1/heartbeat
       port: http
-    initialDelaySeconds: 60
     periodSeconds: 20
     timeoutSeconds: 10
     failureThreshold: 6


### PR DESCRIPTION
# Changes proposed in this PR:

### Add a startup probe so Kubernetes waits for Rails initialization to complete before applying normal health checks.
- The startup probe allows up to 8 minutes for the application to finish initialization before Kubernetes restarts the container.
- Without this, the app can fail to initialize because the liveness probe begins checking before the Rails server has started listening. Long-running startup tasks such as `translation:sync` can exceed the liveness probe's failure threshold, causing Kubernetes to restart the container before initialization completes.

### Remove the initial delays from the liveness and readiness probes.

- With a startup probe configured, Kubernetes waits for the application to complete initialization before running the liveness and readiness probes. The additional initialDelaySeconds values are therefore redundant and can be removed.

### Update `README.md` and `values.schema.json` via `pre-commit run --all-files`
