### PR TITLE
fix(v0/v1/v2-api): Remove access to API for deactivated users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
  - Allow pre-filling Research Outputs with DOI [#1374](https://github.com/portagenetwork/roadmap/pull/1374)
 
+### Fixed
+
+ - fix(v0/v1/v2-api): Remove access to API for deactivated users [#1400](https://github.com/portagenetwork/roadmap/pull/1400)
+
 ### Dependency Updates
 
  - chore(deps): bump surnet/alpine-wkhtmltopdf from 3.23.2-0.12.6-small to 3.23.4-0.12.6-small [#1363](https://github.com/portagenetwork/roadmap/pull/1363)

--- a/app/controllers/api/v0/base_controller.rb
+++ b/app/controllers/api/v0/base_controller.rb
@@ -119,8 +119,7 @@ module Api
           else
             @token = token
             @user = User.find_by(api_token: token)
-            # if no user found, return false, otherwise true
-            !@user.nil? && @user.can_use_api?
+            @user.present? && @user.active? && @user.can_use_api?
           end
         end
       end

--- a/app/controllers/api/v2/base_api_controller.rb
+++ b/app/controllers/api/v2/base_api_controller.rb
@@ -10,6 +10,8 @@ module Api
       before_action :doorkeeper_authorize!, except: %i[heartbeat]
       # get details of server (e.g. DMPonline) and client app
       before_action :base_response_content
+      # check if the user account associated with the token is active
+      before_action :authorize_resource_owner, except: %i[heartbeat]
 
       before_action :log_access
 
@@ -57,6 +59,13 @@ module Api
         return unless doorkeeper_token&.resource_owner_id
 
         @resource_owner = User.find(doorkeeper_token.resource_owner_id)
+      end
+
+      # Reject request if the resource owner account is deactivated
+      def authorize_resource_owner
+        return if @resource_owner.active?
+
+        render_error(errors: _('User account has been deactivated.'), status: :unauthorized)
       end
 
       def log_access

--- a/app/controllers/api/v2/base_api_controller.rb
+++ b/app/controllers/api/v2/base_api_controller.rb
@@ -8,10 +8,10 @@ module Api
 
       # call doorkeeper to authorize the request
       before_action :doorkeeper_authorize!, except: %i[heartbeat]
+      # Authorize resource owner, check if the user account associated with the token is active
+      before_action :authorize_resource_owner, except: %i[heartbeat]
       # get details of server (e.g. DMPonline) and client app
       before_action :base_response_content
-      # check if the user account associated with the token is active
-      before_action :authorize_resource_owner, except: %i[heartbeat]
 
       before_action :log_access
 
@@ -52,20 +52,20 @@ module Api
       # define instance variable json and associated getter and setter methods
       attr_accessor :json
 
+      def authorize_resource_owner
+        return unless doorkeeper_token&.resource_owner_id.present?
+
+        @resource_owner = User.find_by(id: doorkeeper_token.resource_owner_id)
+
+        return if @resource_owner.present? && @resource_owner.active?
+
+        render_error(errors: _('User account has been deactivated.'), status: :unauthorized)
+      end
+
       def base_response_content
         @application = ApplicationService.application_name
         @client = doorkeeper_token&.application
         @caller = @client&.name || request.remote_ip
-        return unless doorkeeper_token&.resource_owner_id
-
-        @resource_owner = User.find(doorkeeper_token.resource_owner_id)
-      end
-
-      # Reject request if the resource owner account is deactivated
-      def authorize_resource_owner
-        return if @resource_owner.active?
-
-        render_error(errors: _('User account has been deactivated.'), status: :unauthorized)
       end
 
       def log_access

--- a/app/services/api/v1/auth/jwt/authorization_service.rb
+++ b/app/services/api/v1/auth/jwt/authorization_service.rb
@@ -35,7 +35,7 @@ module Api
 
             # Valid if User is active, has permission to use the API and
             # the :client_secret matches the token
-            usr = User.where(email: token[:client_id], active: true, api_token: @client_secret).first
+            usr = User.where(email: token[:client_id], active: true).first
             @api_client = usr.present? && usr.can_use_api? ? usr : nil
           end
           # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity

--- a/app/services/api/v1/auth/jwt/authorization_service.rb
+++ b/app/services/api/v1/auth/jwt/authorization_service.rb
@@ -19,9 +19,9 @@ module Api
 
           private
 
-          # Lookup the Client bassed on the client_id embedded in the JWT
+          # Lookup the Client based on the client_id embedded in the JWT
           # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
-          def client
+          def client # rubocop:disable Metrics/PerceivedComplexity
             return @api_client if @api_client.present?
 
             token = decoded_auth_token
@@ -33,7 +33,10 @@ module Api
             @api_client = ApiClient.where(client_id: token[:client_id]).first
             return @api_client if @api_client.present?
 
-            @api_client = User.where(email: token[:client_id]).first
+            # Valid if User is active, has permission to use the API and
+            # the :client_secret matches the token
+            usr = User.where(email: token[:client_id], active: true, api_token: @client_secret).first
+            @api_client = usr.present? && usr.can_use_api? ? usr : nil
           end
           # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
 

--- a/spec/requests/api/v2/base_controller_spec.rb
+++ b/spec/requests/api/v2/base_controller_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V2::BaseApiController do
+  include ApiHelper
+
+  describe 'GET /api/v2/me' do
+    context 'OAuth (authorization_code grant type) — on behalf of a user' do
+      before do
+        @user = create(:user)
+        @client = create(:oauth_application)
+        token = mock_authorization_code_token(oauth_application: @client, user: @user).plaintext_token
+
+        @headers = {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          Authorization: "Bearer #{token}"
+        }
+      end
+
+      it 'returns 200 OK and user details when user is active' do
+        get(api_v2_me_path, headers: @headers)
+
+        expect(response).to have_http_status(:ok)
+
+        json = JSON.parse(response.body)
+        expect(json['email']).to eq(@user.email)
+        expect(json['firstname']).to eq(@user.firstname)
+        expect(json['surname']).to eq(@user.surname)
+        expect(json['organisation']).to eq(@user.org.name)
+      end
+
+      it 'returns 401 Unauthorized when user account is deactivated' do
+        @user.update(active: false)
+
+        get(api_v2_me_path, headers: @headers)
+
+        expect(response).to have_http_status(:unauthorized)
+
+        json = JSON.parse(response.body)
+        expect(json['errors']).to include('User account has been deactivated.')
+      end
+
+      it 'returns 401 Unauthorized when user account is deleted' do
+        @user.destroy
+
+        get(api_v2_me_path, headers: @headers)
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when no authorization token is provided' do
+      it 'returns 401 Unauthorized' do
+        get(api_v2_me_path, headers: { Accept: 'application/json' })
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Changes proposed in this PR:
- Add authorization checks to v0, v1, and v2 of the DMP Roadmap API to prevent deactivated users from accessing and querying the APIs.
- Create `base_controller_spec` for V2 `base_api_controller`.